### PR TITLE
fix: use cronjob to cleanup zoombie runners

### DIFF
--- a/modules/core/arc/README.md
+++ b/modules/core/arc/README.md
@@ -13,6 +13,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.37.1 |
 
 ## Modules
 
@@ -25,6 +26,10 @@
 
 | Name | Type |
 |------|------|
+| [kubernetes_cron_job_v1.zombie_runner_cleanup](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cron_job_v1) | resource |
+| [kubernetes_role_binding_v1.zombie_runner_cleanup](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding_v1) | resource |
+| [kubernetes_role_v1.zombie_runner_cleanup](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_v1) | resource |
+| [kubernetes_service_account_v1.zombie_runner_cleanup](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_subnet.eks_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |

--- a/modules/core/arc/scale_set/README.md
+++ b/modules/core/arc/scale_set/README.md
@@ -32,7 +32,7 @@ No modules.
 | [kubernetes_config_map.hook_pre_post_job](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_role.k8s](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
 | [kubernetes_role_binding.k8s](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
-| [kubernetes_service_account.runner_sa](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
+| [kubernetes_service_account_v1.runner_sa](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/modules/core/arc/scale_set/role.tf
+++ b/modules/core/arc/scale_set/role.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role_policy_attachment" "runner_role_policy_attachment" {
   policy_arn = element(var.runner_iam_role_managed_policy_arns, count.index)
 }
 
-resource "kubernetes_service_account" "runner_sa" {
+resource "kubernetes_service_account_v1" "runner_sa" {
   metadata {
     name      = var.service_account
     namespace = var.namespace

--- a/modules/core/arc/templates/zoombie_runner_cleanup.tpl
+++ b/modules/core/arc/templates/zoombie_runner_cleanup.tpl
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+apk add kubectl yq
+
+echo ""
+echo "Starting cleanup task..."
+
+PODS_FILE="/tmp/pods.txt"
+RUNNERS_FILE="/tmp/runners.txt"
+DIFF_FILE="/tmp/runners_diff.txt"
+NS="${namespace}"
+SELECTOR="app.kubernetes.io/part-of=gha-runner-scale-set"
+
+kubectl -n $NS get pods -l $SELECTOR -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' > $PODS_FILE
+kubectl -n $NS get ephemeralrunners -o yaml | yq '.items[] | select(.status.phase == "Running") | .metadata.name' > $RUNNERS_FILE
+
+## Subtract Pods from running EphemeralRunners to find runners that no longer have a pod
+comm -13 <(sort $PODS_FILE) <(sort $RUNNERS_FILE) > $DIFF_FILE
+
+echo "Runner pods: $(wc -l $PODS_FILE | awk -F' ' '{print $1}')"
+echo "Ephemeral runners: $(wc -l $RUNNERS_FILE | awk -F' ' '{print $1}')"
+echo "Found $(wc -l $DIFF_FILE | awk -F' ' '{print $1}') ephemeral runners without pods"
+
+for runner in $(cat $DIFF_FILE); do
+    kubectl -n $NS delete ephemeralrunner $runner
+done
+rm $PODS_FILE $RUNNERS_FILE $DIFF_FILE
+
+echo "Done."

--- a/modules/core/arc/zoombie.tf
+++ b/modules/core/arc/zoombie.tf
@@ -1,0 +1,89 @@
+resource "kubernetes_service_account_v1" "zombie_runner_cleanup" {
+  metadata {
+    name      = "zombie-runner-cleanup"
+    namespace = var.controller_config.namespace
+  }
+}
+
+resource "kubernetes_role_v1" "zombie_runner_cleanup" {
+  metadata {
+    name      = "zombie-runner-cleanup"
+    namespace = var.controller_config.namespace
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get", "list"]
+  }
+
+  rule {
+    api_groups = ["actions.github.com"]
+    resources  = ["ephemeralrunners"]
+    verbs      = ["get", "list", "delete", "watch"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "zombie_runner_cleanup" {
+  metadata {
+    name      = "zombie-runner-cleanup"
+    namespace = var.controller_config.namespace
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.zombie_runner_cleanup.metadata[0].name
+    namespace = kubernetes_service_account_v1.zombie_runner_cleanup.metadata[0].namespace
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role_v1.zombie_runner_cleanup.metadata[0].name
+  }
+}
+
+resource "kubernetes_cron_job_v1" "zombie_runner_cleanup" {
+  metadata {
+    name      = "zombie-runner-cleanup"
+    namespace = var.controller_config.namespace
+  }
+
+  spec {
+    schedule = "*/10 * * * *"
+
+    job_template {
+      metadata {
+        name = "zombie-runner-cleanup-job"
+      }
+
+      spec {
+        template {
+          metadata {
+            labels = {
+              job = "zombie-runner-cleanup"
+            }
+          }
+
+          spec {
+            service_account_name = kubernetes_service_account_v1.zombie_runner_cleanup.metadata[0].name
+            restart_policy       = "OnFailure"
+
+            container {
+              name  = "zombie-runner-cleanup"
+              image = "alpine:3"
+
+              command = [
+                "/bin/sh",
+                "-c",
+                templatefile("${path.module}/templates/zoombie_runner_cleanup.tpl", {
+                  namespace = var.controller_config.namespace
+                })
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a workaround to clean up zombie runners in ARC, using the solution described in [this comment](https://github.com/actions/actions-runner-controller/issues/4136#issuecomment-2989090497).
And replaced deprecated terraform resource `kubernetes_service_account` for `kubernetes_service_account_v1`

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
