### PR TITLE
refactor: replace dockerhub images for public.ecr.aws

### DIFF
--- a/modules/core/arc/scale_set/template_files/dind.yml.tftpl
+++ b/modules/core/arc/scale_set/template_files/dind.yml.tftpl
@@ -37,7 +37,7 @@ template:
 
       - name: init-dind-rootless
         imagePullPolicy: Always
-        image: docker:dind-rootless
+        image: public.ecr.aws/docker/library/docker:dind-rootless
         command:
           - sh
           - -c
@@ -127,7 +127,7 @@ template:
             memory: ${container_requests_memory}
 
       - name: dind
-        image: docker:dind-rootless
+        image: public.ecr.aws/docker/library/docker:dind-rootless
         imagePullPolicy: Always
         args: ["dockerd", "--host=unix:///home/runner/var/run/docker.sock"]
         securityContext:
@@ -157,7 +157,7 @@ template:
             memory: ${container_requests_memory}
 
       - name: runner-logs
-        image: busybox
+        image: public.ecr.aws/docker/library/busybox:stable
         command:
           - sh
           - -c
@@ -184,7 +184,7 @@ template:
             memory: "64Mi"
 
       - name: hook
-        image: busybox
+        image: public.ecr.aws/docker/library/busybox:stable
         command:
           - sh
           - -c

--- a/modules/core/arc/scale_set/template_files/k8s.yml.tftpl
+++ b/modules/core/arc/scale_set/template_files/k8s.yml.tftpl
@@ -69,7 +69,7 @@ template:
             memory: ${container_requests_memory}
 
       - name: runner-logs
-        image: busybox
+        image: public.ecr.aws/docker/library/busybox:stable
         command:
           - sh
           - -c
@@ -96,7 +96,7 @@ template:
             memory: "64Mi"
 
       - name: hook
-        image: busybox
+        image: public.ecr.aws/docker/library/busybox:stable
         command:
           - sh
           - -c

--- a/modules/core/arc/zoombie.tf
+++ b/modules/core/arc/zoombie.tf
@@ -4,6 +4,11 @@ resource "kubernetes_service_account_v1" "zombie_runner_cleanup" {
     name      = "zombie-runner-cleanup"
     namespace = var.controller_config.namespace
   }
+
+  depends_on = [
+    module.controller,
+    module.scale_sets
+  ]
 }
 
 resource "kubernetes_role_v1" "zombie_runner_cleanup" {
@@ -24,6 +29,11 @@ resource "kubernetes_role_v1" "zombie_runner_cleanup" {
     resources  = ["ephemeralrunners"]
     verbs      = ["get", "list", "delete", "watch"]
   }
+
+  depends_on = [
+    module.controller,
+    module.scale_sets
+  ]
 }
 
 resource "kubernetes_role_binding_v1" "zombie_runner_cleanup" {
@@ -44,6 +54,11 @@ resource "kubernetes_role_binding_v1" "zombie_runner_cleanup" {
     kind      = "Role"
     name      = kubernetes_role_v1.zombie_runner_cleanup[0].metadata[0].name
   }
+
+  depends_on = [
+    module.controller,
+    module.scale_sets
+  ]
 }
 
 resource "kubernetes_cron_job_v1" "zombie_runner_cleanup" {
@@ -90,4 +105,9 @@ resource "kubernetes_cron_job_v1" "zombie_runner_cleanup" {
       }
     }
   }
+
+  depends_on = [
+    module.controller,
+    module.scale_sets
+  ]
 }

--- a/modules/infra/eks/nodes.tf
+++ b/modules/infra/eks/nodes.tf
@@ -57,6 +57,5 @@ module "self_managed_node_group" {
 
   depends_on = [
     time_sleep.wait_300_seconds,
-    null_resource.create_calico_installation
   ]
 }


### PR DESCRIPTION
## Description

This PR replaces all DockerHub image references with public.ecr.aws equivalents to improve reliability, comply with organizational policies, and avoid DockerHub rate limits.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
