### PR TITLE
docs: add page and script for tenant migration

### DIFF
--- a/docs/configurations/deployments/index.md
+++ b/docs/configurations/deployments/index.md
@@ -1,19 +1,22 @@
 # Forge Deployment Scenarios
 
-- [**First Tenant**](./forge_tenant.md)  
+* [**First Tenant**](./forge_tenant.md)
   *Minimal multi-tenant Forge deployment example. Shows how to provision Forge runners and onboard your first tenant.*
 
-- [**New Tenant Guide**](./new_tenant.md)  
+* [**New Tenant Guide**](./new_tenant.md)
   *Step-by-step checklist for adding a new tenant to an existing Forge deployment, including config files, secrets, and GitHub App setup.*
 
-- [**Forge EKS**](./forge_eks.md)  
+* [**Tenant Migration Guide**](./tenant_migration.md)
+  *Detailed instructions and automation for migrating a tenant safely between EKS clusters using ForgeMT and ARC.*
+
+* [**Forge EKS**](./forge_eks.md)
   *Deploys an EKS cluster with Calico and Karpenter, suitable for running Forge ARC runners and other workloads.*
 
-- [**Forge Integrations**](./forge_integrations.md)  
+* [**Forge Integrations**](./forge_integrations.md)
   *Example for deploying Forge with Splunk, Observability, and other integrations. Includes required modules and configuration tips.*
 
-- [**Splunk Deployment**](./splunk_deployment.md)  
+* [**Splunk Deployment**](./splunk_deployment.md)
   *Complete example for deploying Splunk integrations, including secrets, data manager, and observability modules.*
 
-- [**Extras Deployments**](./forge_extras.md)  
+* [**Extras Deployments**](./forge_extras.md)
   *Deploys supporting infrastructure such as Cloud Custodian, CloudFormation permissions, ECR repositories, Forge subscription, and S3 storage.*

--- a/docs/configurations/deployments/tenant_migration.md
+++ b/docs/configurations/deployments/tenant_migration.md
@@ -1,0 +1,53 @@
+# Migrating a Tenant Between EKS Clusters with ForgeMT + ARC + Terragrunt
+
+## Tenant Migration Steps
+
+1. **Identify Current and Target Clusters**
+
+   * Read the current cluster name from the tenant config file (like `arc_cluster_name: srea-forge-euw1-prod-green`).
+   * Determine the target cluster by switching the suffix from `-green` to `-blue` or vice versa.
+
+2. **Scale Down Runner Sets in the Source Cluster**
+
+   * List all runner sets defined under `arc_runner_specs`.
+   * For each runner set, scale down both minimum and maximum runners to zero on the source cluster to stop all active runner pods.
+
+3. **Disable ARC on the Source Cluster**
+
+   * Update the tenant’s config by setting a migration flag (e.g., `migrate_arc_cluster: true`) which disables ARC resources on the source cluster.
+   * Apply this config change so the Terraform/Terragrunt deployment removes ARC for this tenant in the source cluster.
+
+4. **Enable ARC on the Target Cluster**
+
+   * Change the migration flag back to false (`migrate_arc_cluster: false`).
+   * Update the `arc_cluster_name` to the target cluster (e.g., switching from `srea-forge-euw1-prod-green` to `srea-forge-euw1-prod-blue`).
+   * Deploy ARC resources in the target cluster with these config changes.
+
+5. **Wait for Runner Pods to Stabilize**
+
+   * Verify that runner pods have fully terminated on the source cluster.
+   * Confirm runner pods are healthy and running on the target cluster.
+
+---
+
+## Automation Script for Tenant Migration
+
+To simplify and standardize the migration process, an automation script is available that performs all the steps described above:
+
+* **Detects the current cluster** from the tenant configuration.
+* **Determines the target cluster** by toggling the blue/green suffix.
+* **Scales down runner sets** in the source cluster gracefully.
+* **Updates the migration flag and cluster name** in the tenant config.
+* **Applies Terraform/Terragrunt changes** to disable ARC on the old cluster and enable it on the new one.
+* **Waits for runner pods to terminate** before switching, ensuring a clean handoff.
+* Provides clear logging at each step for easy monitoring.
+
+### Usage Example
+
+Run the script by specifying the tenant’s Terraform directory and Kubernetes context alias:
+
+```
+./scripts/migrate-tenant.sh --tf-dir /full/path/to/tenant_dir --context <kube-context-alias>
+```
+
+The script will handle the rest, reducing human error and speeding up the migration process.

--- a/scripts/migrate-tenant.sh
+++ b/scripts/migrate-tenant.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --tf-dir <terragrunt directory> --context <k8s context alias>"
+    exit 1
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --tf-dir)
+            TF_DIR="$2"
+            shift 2
+            ;;
+        --context)
+            FROM_CTX="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown arg: $1"
+            usage
+            ;;
+        esac
+    done
+
+    [[ -z "${TF_DIR:-}" || -z "${FROM_CTX:-}" ]] && usage
+
+    TENANT=$(basename "$TF_DIR")
+    [[ -z "${TENANT:-}" ]] && {
+        echo "Error: Could not determine tenant from directory '$TF_DIR'"
+        exit 1
+    }
+    CONFIG_FILE="${TF_DIR}/config.yml"
+}
+
+detect_clusters() {
+    CURRENT_CLUSTER=$(yq e '.arc_cluster_name' "$CONFIG_FILE")
+
+    if [[ "$CURRENT_CLUSTER" == *"-green" ]]; then
+        FROM="$CURRENT_CLUSTER"
+        TO="${CURRENT_CLUSTER%-green}-blue"
+    elif [[ "$CURRENT_CLUSTER" == *"-blue" ]]; then
+        FROM="$CURRENT_CLUSTER"
+        TO="${CURRENT_CLUSTER%-blue}-green"
+    else
+        echo "Cannot detect blue/green suffix in arc_cluster_name: $CURRENT_CLUSTER"
+        exit 1
+    fi
+}
+
+scale_down_runners() {
+    echo "🧯 Scaling down runners in namespace: $TENANT"
+    for key in $(yq -r '.arc_runner_specs | keys | .[]' "$CONFIG_FILE"); do
+        echo "Checking runner set: $key"
+        if kubectl --context "$FROM_CTX" get autoscalingrunnersets.actions.github.com -n "$TENANT" "$key" &>/dev/null; then
+            echo "Scaling down runner set: $key"
+            kubectl --context "$FROM_CTX" patch autoscalingrunnersets.actions.github.com -n "$TENANT" "$key" --type merge -p '{"spec":{"minRunners":0,"maxRunners":0}}'
+        else
+            echo "Runner set $key not found, skipping."
+        fi
+    done
+
+    echo "⏳ Waiting for runner pods to terminate..."
+    while kubectl --context "$FROM_CTX" get pods -n "$TENANT" | grep -q runner; do
+        sleep 5
+    done
+}
+
+terragrunt_apply() {
+    local target="$1"
+    echo "🔧 Applying Terragrunt target: $target"
+    terragrunt apply --target "$target" -working-dir "$TF_DIR" -non-interactive -auto-approve
+}
+
+update_config() {
+    local migrate_flag="$1"
+    local cluster_name="$2"
+
+    yq e -i ".migrate_arc_cluster = $migrate_flag" "$CONFIG_FILE"
+    yq e -i ".arc_cluster_name = \"$cluster_name\"" "$CONFIG_FILE"
+}
+
+main() {
+    parse_args "$@"
+    detect_clusters
+
+    echo "🔄 Migrating tenant '$TENANT' from '$FROM' to '$TO'..."
+    echo "📄 Editing config: $CONFIG_FILE"
+    echo "🔍 Using Kubernetes context: $FROM_CTX"
+
+    # Step 1
+    scale_down_runners
+
+    # Step 2
+    echo "🛑 Disabling ARC for tenant on old cluster '$FROM'"
+    update_config true "$FROM"
+    terragrunt_apply 'module.arc_runners'
+
+    # Step 3
+    echo "🚀 Enabling ARC for tenant on new cluster '$TO'"
+    update_config false "$TO"
+    terragrunt_apply 'module.arc_runners'
+
+    echo "✅ Migration complete. Tenant '$TENANT' is now on '$TO'"
+}
+
+main "$@"

--- a/scripts/update-github-app-secrets.sh
+++ b/scripts/update-github-app-secrets.sh
@@ -27,7 +27,7 @@ validate_pem_file() {
 get_secret_name() {
     local terragrunt_dir="$1"
     local type="$2"
-    terragrunt output -json --terragrunt-working-dir "$terragrunt_dir" | jq -r --arg t "$type" '
+    terragrunt output -json --working-dir "$terragrunt_dir" | jq -r --arg t "$type" '
     .tenant.value as $tenant |
     "/cicd/common/\($tenant.name)/\($tenant.vpc_alias)/github_actions_runners_app_" + $t
   '


### PR DESCRIPTION
## Description

This PR introduces a scripted, automated workflow to migrate tenants safely and reliably between blue/green EKS clusters managed by ForgeMT and ARC.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
