### PR TITLE
docs: replace deprecated terragrunt command for new one

### DIFF
--- a/docs/configurations/deployments/forge_eks.md
+++ b/docs/configurations/deployments/forge_eks.md
@@ -68,8 +68,8 @@ To deploy all modules:
 
 ```sh
 cd examples/deployments/forge-eks/terragrunt/environments/prod/
-terragrunt run-all plan
-terragrunt run-all apply
+terragrunt plan --all
+terragrunt apply --all
 ```
 
 To deploy only the EKS module:

--- a/docs/configurations/deployments/forge_extras.md
+++ b/docs/configurations/deployments/forge_extras.md
@@ -78,8 +78,8 @@ To deploy all modules:
 
 ```sh
 cd examples/deployments/forge-extras/terragrunt/environments/prod/
-terragrunt run-all plan
-terragrunt run-all apply
+terragrunt plan --all
+terragrunt apply --all
 ```
 
 To deploy a specific module (example for Cloud Custodian):

--- a/docs/configurations/deployments/forge_integrations.md
+++ b/docs/configurations/deployments/forge_integrations.md
@@ -35,8 +35,8 @@ To deploy all modules:
 
 ```sh
 cd examples/deployments/forge-integrations/terragrunt/environments/prod/
-terragrunt run-all plan
-terragrunt run-all apply
+terragrunt plan --all
+terragrunt apply --all
 ```
 
 To deploy a specific module:

--- a/docs/configurations/deployments/forge_tenant.md
+++ b/docs/configurations/deployments/forge_tenant.md
@@ -69,8 +69,8 @@ From the environment root directory, deploy all tenants at once:
 
 ```sh
 cd examples/deployments/forge-tenant/terragrunt/environments/prod/
-terragrunt run-all plan
-terragrunt run-all apply
+terragrunt plan --all
+terragrunt apply --all
 ```
 
 Or deploy a single tenant individually by navigating to its folder:

--- a/docs/configurations/deployments/splunk_deployment.md
+++ b/docs/configurations/deployments/splunk_deployment.md
@@ -75,8 +75,8 @@ To deploy all modules:
 
 ```sh
 cd examples/deployments/splunk-deployment/terragrunt/environments/prod/
-terragrunt run-all plan
-terragrunt run-all apply
+terragrunt plan --all
+terragrunt apply --all
 ```
 
 To deploy a specific module (example for Splunk Cloud Data Manager):

--- a/examples/infra-forge/index.md
+++ b/examples/infra-forge/index.md
@@ -29,7 +29,7 @@ terragrunt apply terragrunt/environments/prod/regions/eu-west-1/vpcs/sl/tenants/
 ### Apply All Modules Recursively
 
 ```bash
-terragrunt run-all apply terragrunt/environments/prod/
+terragrunt apply --all terragrunt/environments/prod/
 ```
 
-> **Tip:** Always run `terragrunt run-all plan` first to validate changes before applying.
+> **Tip:** Always run `terragrunt plan --all` first to validate changes before applying.


### PR DESCRIPTION
## Description

This PR will replace references `terragrunt run-all plan/apply` for `terragrunt terragrunt plan/apply --all`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
