### PR TITLE
fix: use correct s3 bucket notification for billing lambdas

### DIFF
--- a/modules/integrations/splunk_aws_billing/billing_per_resource.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "cur_per_resource" {
   function_name = "forge-aws-billing-per-resource"
   s3_bucket     = aws_s3_object.cur_per_resource.bucket
   s3_key        = aws_s3_object.cur_per_resource.key
-  handler       = "per_resource.lambda_handler"
+  handler       = "handler_per_resource.lambda_handler"
   architectures = ["x86_64"]
   runtime       = "python3.11"
   role          = aws_iam_role.lambda_exec_role.arn
@@ -38,18 +38,6 @@ resource "aws_lambda_function" "cur_per_resource" {
       SPLUNK_METRICS_URL   = var.splunk_aws_billing_config.splunk_metrics_url
     }
   }
-}
-
-resource "aws_s3_bucket_notification" "cur_per_resource" {
-  bucket = aws_s3_bucket.aws_billing_report.id
-
-  lambda_function {
-    lambda_function_arn = aws_lambda_function.cur_per_resource.arn
-    events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = "cur-per-resource/aws-billing-report/data/"
-  }
-
-  depends_on = [aws_lambda_permission.cur_per_resource]
 }
 
 resource "aws_lambda_permission" "cur_per_resource" {

--- a/modules/integrations/splunk_aws_billing/billing_per_service.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_service.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "cur_per_service" {
   function_name = "forge-aws-billing-per-service"
   s3_bucket     = aws_s3_object.cur_per_service.bucket
   s3_key        = aws_s3_object.cur_per_service.key
-  handler       = "handler.lambda_handler"
+  handler       = "handler_per_service.lambda_handler"
   architectures = ["x86_64"]
   runtime       = "python3.11"
   role          = aws_iam_role.lambda_exec_role.arn
@@ -40,19 +40,7 @@ resource "aws_lambda_function" "cur_per_service" {
   }
 }
 
-resource "aws_s3_bucket_notification" "cur_notification" {
-  bucket = aws_s3_bucket.aws_billing_report.id
-
-  lambda_function {
-    lambda_function_arn = aws_lambda_function.cur_per_service.arn
-    events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = "cur-per-service/aws-billing-report/data/"
-  }
-
-  depends_on = [aws_lambda_permission.allow_s3]
-}
-
-resource "aws_lambda_permission" "allow_s3" {
+resource "aws_lambda_permission" "cur_per_service" {
   statement_id  = "AllowS3Invoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.cur_per_service.function_name

--- a/modules/integrations/splunk_aws_billing/lambda/handler_per_resource.py
+++ b/modules/integrations/splunk_aws_billing/lambda/handler_per_resource.py
@@ -171,7 +171,7 @@ def lambda_handler(event, context):
             dimensions = {
                 'usage_date': usage_date,
                 'service': row['line_item_product_code'],
-                'resource_id': row['resource_id'],
+                'resource_id': row['line_item_resource_id'],
                 'aws_application': row['user_aws_application'],
                 **fields
             }

--- a/modules/integrations/splunk_aws_billing/lambda/handler_per_service.py
+++ b/modules/integrations/splunk_aws_billing/lambda/handler_per_service.py
@@ -148,7 +148,7 @@ def lambda_handler(event, context):
                 pd.to_datetime(usage_date).timetuple())
 
             event_data = {
-                'source': 'aws-cur',
+                'source': 'aws-cur-per-service',
                 'sourcetype': 'forgecicd:aws:billing:cur',
                 'index': SPLUNK_INDEX,
                 'event': {

--- a/modules/integrations/splunk_aws_billing/s3.tf
+++ b/modules/integrations/splunk_aws_billing/s3.tf
@@ -126,3 +126,24 @@ resource "aws_s3_bucket_policy" "cur_bucket_policy" {
   bucket = aws_s3_bucket.aws_billing_report.id
   policy = data.aws_iam_policy_document.cur_bucket_policy.json
 }
+
+resource "aws_s3_bucket_notification" "cur_notification" {
+  bucket = aws_s3_bucket.aws_billing_report.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.cur_per_service.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "cur-per-service/aws-billing-report-per-service/data/"
+  }
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.cur_per_resource.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "cur-per-resource/aws-billing-report-per-resource/data/"
+  }
+
+  depends_on = [
+    aws_lambda_permission.cur_per_service,
+    aws_lambda_permission.cur_per_resource
+  ]
+}


### PR DESCRIPTION
## Description

This PR fixes the s3 bucket notification to call lambdas for aws billing

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
