### PR TITLE
feat: allow add tags in forge runners

### DIFF
--- a/modules/platform/ec2_deployment/README.md
+++ b/modules/platform/ec2_deployment/README.md
@@ -24,11 +24,13 @@
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.ec2_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_kms_alias.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_security_group.gh_runner_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.gh_runner_lambda_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ami.runner_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_iam_policy_document.ec2_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_ssm_parameter.ami_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_subnet.runner_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [external_external.download_lambdas](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |

--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -188,12 +188,17 @@ module "runners" {
             "log_stream_name" : "{instance_id}/hook"
           },
         ]
-        ami_owners                          = val["ami_owners"]
-        ami_filter                          = val["ami_filter"]
-        ami_kms_key_arn                     = val["ami_kms_key_arn"]
-        instance_target_capacity_type       = val["instance_target_capacity_type"]
-        enable_job_queued_check             = false
-        runner_iam_role_managed_policy_arns = var.runner_configs.runner_iam_role_managed_policy_arns
+        ami_owners                    = val["ami_owners"]
+        ami_filter                    = val["ami_filter"]
+        ami_kms_key_arn               = val["ami_kms_key_arn"]
+        instance_target_capacity_type = val["instance_target_capacity_type"]
+        enable_job_queued_check       = false
+        runner_iam_role_managed_policy_arns = concat(
+          var.runner_configs.runner_iam_role_managed_policy_arns,
+          [
+            aws_iam_policy.ec2_tags.arn,
+          ]
+        )
         # Yes; we want runners (even pool runners) to self-terminate after a
         # job is complete (and, in the case of pool runners, spawn a new
         # instance to replace it when done).

--- a/modules/platform/ec2_deployment/roles.tf
+++ b/modules/platform/ec2_deployment/roles.tf
@@ -1,0 +1,38 @@
+data "aws_iam_policy_document" "ec2_tags" {
+  statement {
+    actions = [
+      "ec2:CreateTags"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ARN"
+      values   = ["$${ec2:SourceInstanceARN}"]
+    }
+    condition {
+      test     = "ForAllValues:StringLike"
+      variable = "aws:TagKeys"
+      values = [
+        "ghr:repository",
+        "ghr:run_id",
+        "ghr:workflow",
+        "ghr:job",
+        "ghr:commit",
+        "ghr:ref",
+        "ghr:run_attempt",
+        "ghr:run_number",
+        "ghr:actor",
+      ]
+    }
+  }
+}
+
+# Define the actual IAM policy for EC2 tags
+resource "aws_iam_policy" "ec2_tags" {
+  name        = "${var.runner_configs.prefix}-policy-for-ec2-tags"
+  description = "Policy that allows EC2 instances to create tags on themselves."
+  policy      = data.aws_iam_policy_document.ec2_tags.json
+
+  tags     = var.tenant_configs.tags
+  tags_all = var.tenant_configs.tags
+}

--- a/modules/platform/ec2_deployment/template_files/hook_job_started.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started.tftpl
@@ -3,6 +3,19 @@
 LOG_FILE="$HOME/hook.log"
 TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S")
 
+aws ec2 create-tags \
+  --resources "$INSTANCE_ID" \
+  --tags \
+    Key=ghr:repository,Value="$GITHUB_REPOSITORY" \
+    Key=ghr:run_id,Value="$GITHUB_RUN_ID" \
+    Key=ghr:workflow,Value="$GITHUB_WORKFLOW" \
+    Key=ghr:job,Value="$GITHUB_JOB" \
+    Key=ghr:commit,Value="$GITHUB_SHA" \
+    Key=ghr:ref,Value="$GITHUB_REF" \
+    Key=ghr:run_attempt,Value="$GITHUB_RUN_ATTEMPT" \
+    Key=ghr:run_number,Value="$GITHUB_RUN_NUMBER" \
+    Key=ghr:actor,Value="$GITHUB_ACTOR"
+
 {
   echo "{"
   echo "  \"timestamp\": \"$TIMESTAMP\","


### PR DESCRIPTION
## Description

This PR enables GitHub Actions runners to self-update their tags with relevant workflow metadata at runtime.

Environment Variables Used:
- GITHUB_REPOSITORY
- GITHUB_RUN_ID
- GITHUB_WORKFLOW
- GITHUB_JOB
- GITHUB_SHA
- GITHUB_REF
- GITHUB_RUN_ATTEMPT
- GITHUB_RUN_NUMBER
- GITHUB_ACTOR

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
