### PR TITLE
fix: add missing instance_id variable and tag workflow_url

### DIFF
--- a/modules/platform/ec2_deployment/roles.tf
+++ b/modules/platform/ec2_deployment/roles.tf
@@ -21,6 +21,7 @@ data "aws_iam_policy_document" "ec2_tags" {
         "ghr:ref",
         "ghr:run_attempt",
         "ghr:run_number",
+        "ghr:workflow_url",
         "ghr:actor",
       ]
     }

--- a/modules/platform/ec2_deployment/template_files/hook_job_started.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started.tftpl
@@ -3,6 +3,7 @@
 LOG_FILE="$HOME/hook.log"
 TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S")
 
+INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.instanceId')
 aws ec2 create-tags \
   --resources "$INSTANCE_ID" \
   --tags \
@@ -14,6 +15,7 @@ aws ec2 create-tags \
     Key=ghr:ref,Value="$GITHUB_REF" \
     Key=ghr:run_attempt,Value="$GITHUB_RUN_ATTEMPT" \
     Key=ghr:run_number,Value="$GITHUB_RUN_NUMBER" \
+    Key=ghr:workflow_url,Value="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
     Key=ghr:actor,Value="$GITHUB_ACTOR"
 
 {


### PR DESCRIPTION
## Description

This PR fixes the hook_job_started template by adding missing variable and tag

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
