### PR TITLE
fix: use json escape to allow any string in workflow name

### DIFF
--- a/modules/core/arc/README.md
+++ b/modules/core/arc/README.md
@@ -14,7 +14,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.3.5 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.38.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |

--- a/modules/core/arc/scale_set/README.md
+++ b/modules/core/arc/scale_set/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 3.0.2 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.38.0 |
 

--- a/modules/infra/ami_policy/README.md
+++ b/modules/infra/ami_policy/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 
 ## Modules
 

--- a/modules/infra/ami_sharing/README.md
+++ b/modules/infra/ami_sharing/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 
 ## Modules
 

--- a/modules/infra/cloud_custodian/README.md
+++ b/modules/infra/cloud_custodian/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 
 ## Modules
 

--- a/modules/infra/cloud_formation/README.md
+++ b/modules/infra/cloud_formation/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 
 ## Modules
 

--- a/modules/infra/ecr/README.md
+++ b/modules/infra/ecr/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 
 ## Modules
 

--- a/modules/infra/opt_in_regions/README.md
+++ b/modules/infra/opt_in_regions/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 
 ## Modules
 

--- a/modules/infra/service_linked_roles/README.md
+++ b/modules/infra/service_linked_roles/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 
 ## Modules
 

--- a/modules/integrations/splunk_cloud_conf_shared/README.md
+++ b/modules/integrations/splunk_cloud_conf_shared/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 | <a name="provider_splunk"></a> [splunk](#provider\_splunk) | 1.4.31 |
 
 ## Modules

--- a/modules/integrations/splunk_o11y_aws_integration/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_aws_integration_common/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration_common/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 | <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.19.1 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.13.1 |
 

--- a/modules/integrations/splunk_otel_eks/README.md
+++ b/modules/integrations/splunk_otel_eks/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 3.0.2 |
 
 ## Modules

--- a/modules/integrations/teleport/README.md
+++ b/modules/integrations/teleport/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.38.0 |
 
 ## Modules

--- a/modules/integrations/teleport/tenant/README.md
+++ b/modules/integrations/teleport/tenant/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.38.0 |
 
 ## Modules

--- a/modules/platform/ec2_deployment/README.md
+++ b/modules/platform/ec2_deployment/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.3.5 |
 
 ## Modules

--- a/modules/platform/ec2_deployment/template_files/hook_job_started.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started.tftpl
@@ -4,19 +4,33 @@ LOG_FILE="$HOME/hook.log"
 TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S")
 
 INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.instanceId')
-aws ec2 create-tags \
-  --resources "$INSTANCE_ID" \
-  --tags \
-    Key=ghr:repository,Value="$GITHUB_REPOSITORY" \
-    Key=ghr:run_id,Value="$GITHUB_RUN_ID" \
-    Key=ghr:workflow,Value="$GITHUB_WORKFLOW" \
-    Key=ghr:job,Value="$GITHUB_JOB" \
-    Key=ghr:commit,Value="$GITHUB_SHA" \
-    Key=ghr:ref,Value="$GITHUB_REF" \
-    Key=ghr:run_attempt,Value="$GITHUB_RUN_ATTEMPT" \
-    Key=ghr:run_number,Value="$GITHUB_RUN_NUMBER" \
-    Key=ghr:workflow_url,Value="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
-    Key=ghr:actor,Value="$GITHUB_ACTOR"
+aws ec2 create-tags --cli-input-json "$(jq -n \
+  --arg instance "$INSTANCE_ID" \
+  --arg repository "$GITHUB_REPOSITORY" \
+  --arg run_id "$GITHUB_RUN_ID" \
+  --arg workflow "$GITHUB_WORKFLOW" \
+  --arg job "$GITHUB_JOB" \
+  --arg commit "$GITHUB_SHA" \
+  --arg ref "$GITHUB_REF" \
+  --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+  --arg run_number "$GITHUB_RUN_NUMBER" \
+  --arg workflow_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
+  --arg actor "$GITHUB_ACTOR" \
+  '{
+    Resources: [$instance],
+    Tags: [
+      {Key:"ghr:repository", Value:$repository},
+      {Key:"ghr:run_id", Value:$run_id},
+      {Key:"ghr:workflow", Value:$workflow},
+      {Key:"ghr:job", Value:$job},
+      {Key:"ghr:commit", Value:$commit},
+      {Key:"ghr:ref", Value:$ref},
+      {Key:"ghr:run_attempt", Value:$run_attempt},
+      {Key:"ghr:run_number", Value:$run_number},
+      {Key:"ghr:workflow_url", Value:$workflow_url},
+      {Key:"ghr:actor", Value:$actor}
+    ]
+  }')"
 
 {
   echo "{"

--- a/modules/platform/forge_runners/README.md
+++ b/modules/platform/forge_runners/README.md
@@ -17,7 +17,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.1 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.9.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.3.5 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |


### PR DESCRIPTION
## Description

This PR fixes hook job to allow tag ec2 instances with space and special characters in the workflow name

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
