### PR TITLE
fix: delete ec2nodeclasses in backgroup to bypass finalizer protection

### DIFF
--- a/modules/core/arc/karpenter.tf
+++ b/modules/core/arc/karpenter.tf
@@ -58,10 +58,10 @@ resource "null_resource" "apply_ec2_node_class" {
     command = <<EOF
 export KUBECONFIG='${local.kubeconfig_path}'
 # Delete existing EC2NodeClass if it exists (needed to update immutable fields)
+kubectl --context ${var.eks_cluster_name}-${var.aws_profile}-${var.aws_region} delete ec2nodeclasses.karpenter.k8s.aws "karpenter-${var.controller_config.namespace}" --ignore-not-found &
 while kubectl --context ${var.eks_cluster_name}-${var.aws_profile}-${var.aws_region} get ec2nodeclasses.karpenter.k8s.aws "karpenter-${var.controller_config.namespace}" >/dev/null 2>&1; do
-  sleep 1
   kubectl --context ${var.eks_cluster_name}-${var.aws_profile}-${var.aws_region} patch ec2nodeclasses.karpenter.k8s.aws "karpenter-${var.controller_config.namespace}" --type=merge -p '{"metadata":{"finalizers":[]}}' || true
-  kubectl --context ${var.eks_cluster_name}-${var.aws_profile}-${var.aws_region} delete ec2nodeclasses.karpenter.k8s.aws "karpenter-${var.controller_config.namespace}" --ignore-not-found || true
+  sleep 1
 done
 
 # Apply the new EC2NodeClass manifest only if not migrating


### PR DESCRIPTION
## Description

This PR fix the logic to update ec2nodeclasses

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
