### PR TITLE
refactor: merge log groups to reduce number of resources

### DIFF
--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -158,31 +158,31 @@ module "runners" {
         block_device_mappings             = val["block_device_mappings"]
         runner_log_files = [
           {
-            "log_group_name" : "syslog",
+            "log_group_name" : "forge-logs",
             "prefix_log_group" : true,
             "file_path" : "/var/log/syslog",
             "log_stream_name" : "{instance_id}/syslog"
           },
           {
-            "log_group_name" : "user-data",
+            "log_group_name" : "forge-logs",
             "prefix_log_group" : true,
             "file_path" : "/var/log/user-data.log",
             "log_stream_name" : "{instance_id}/user-data"
           },
           {
-            "log_group_name" : "runner",
+            "log_group_name" : "forge-logs",
             "prefix_log_group" : true,
             "file_path" : "/opt/actions-runner/_diag/Runner_**.log",
             "log_stream_name" : "{instance_id}/runner"
           },
           {
-            "log_group_name" : "runner-logs",
+            "log_group_name" : "forge-logs",
             "prefix_log_group" : true,
             "file_path" : "/opt/actions-runner/_diag/pages/*.log",
             "log_stream_name" : "{instance_id}/runner-logs"
           },
           {
-            "log_group_name" : "hook",
+            "log_group_name" : "forge-logs",
             "prefix_log_group" : true,
             "file_path" : "/home/ubuntu/hook.log",
             "log_stream_name" : "{instance_id}/hook"


### PR DESCRIPTION
## Description

This PR will reduce the number of cloud watch groups, by merging per runner type

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
