### PR TITLE
fix: remove unsed policy and add missing policy

### DIFF
--- a/modules/platform/ec2_deployment/update_ssm_ami_id.tf
+++ b/modules/platform/ec2_deployment/update_ssm_ami_id.tf
@@ -47,18 +47,10 @@ module "update_runner_ami_lambda" {
 data "aws_iam_policy_document" "update_runner_ami_lambda" {
 
   statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-    effect    = "Allow"
-    resources = ["*"]
-  }
-
-  statement {
     effect = "Allow"
     actions = [
       "ssm:GetParameter",
+      "ssm:GetParameters",
       "ssm:PutParameter",
       "ssm:AddTagsToResource"
     ]


### PR DESCRIPTION
## Description

This PR will fix small issue in update-runner-ami lambda policy, by removing a unused policy to allow create logs in CW and missing permission to read SSM parameters

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
