### PR TITLE
fix: use shorter name for aws_cloudwatch_log_delivery_source

### DIFF
--- a/modules/integrations/github_webhook_relay_source/main.tf
+++ b/modules/integrations/github_webhook_relay_source/main.tf
@@ -62,14 +62,14 @@ resource "aws_cloudwatch_event_bus" "source" {
 
 # CloudWatch Log Delivery Sources for INFO, ERROR logs
 resource "aws_cloudwatch_log_delivery_source" "info_logs" {
-  name         = "EventBusSource-${aws_cloudwatch_event_bus.source.name}-INFO_LOGS"
+  name         = "${aws_cloudwatch_event_bus.source.name}-INFO_LOGS"
   log_type     = "INFO_LOGS"
   resource_arn = aws_cloudwatch_event_bus.source.arn
   tags         = var.tags
 }
 
 resource "aws_cloudwatch_log_delivery_source" "error_logs" {
-  name         = "EventBusSource-${aws_cloudwatch_event_bus.source.name}-ERROR_LOGS"
+  name         = "${aws_cloudwatch_event_bus.source.name}-ERROR_LOGS"
   log_type     = "ERROR_LOGS"
   resource_arn = aws_cloudwatch_event_bus.source.arn
   tags         = var.tags


### PR DESCRIPTION
## Description

This PR will fix this error
```
  │   on ../../integrations/github_webhook_relay_source/main.tf line 65, in resource "aws_cloudwatch_log_delivery_source" "info_logs":
  │   65:   name         = "EventBusSource-${aws_cloudwatch_event_bus.source.name}-INFO_LOGS"
  │
  │ Attribute name string length must be between 1 and 60, got: 61
  ╵
```

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
