### PR TITLE
feat: add event bus rule to update ec2 tags with more job info

### DIFF
--- a/modules/platform/ec2_deployment/README.md
+++ b/modules/platform/ec2_deployment/README.md
@@ -20,23 +20,29 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_runners"></a> [runners](#module\_runners) | git::https://github.com/github-aws-runners/terraform-aws-github-runner.git//modules/multi-runner | v6.7.8 |
+| <a name="module_update_ec2_tags"></a> [update\_ec2\_tags](#module\_update\_ec2\_tags) | terraform-aws-modules/lambda/aws | 8.1.0 |
 | <a name="module_update_runner_ami_lambda"></a> [update\_runner\_ami\_lambda](#module\_update\_runner\_ami\_lambda) | terraform-aws-modules/lambda/aws | 8.1.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_event_rule.update_ec2_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.update_runner_ami_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.update_ec2_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.update_runner_ami_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.update_ec2_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.update_runner_ami_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_policy.ec2_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_kms_alias.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_lambda_permission.update_ec2_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.update_runner_ami_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_security_group.gh_runner_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.gh_runner_lambda_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ami.runner_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.ec2_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.update_ec2_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.update_runner_ami_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_ssm_parameter.ami_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_subnet.runner_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |

--- a/modules/platform/ec2_deployment/lambda/update_ec2_tags.py
+++ b/modules/platform/ec2_deployment/lambda/update_ec2_tags.py
@@ -1,0 +1,46 @@
+import json
+import logging
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+ssm = boto3.client('ssm')
+ec2 = boto3.client('ec2')
+
+
+def lambda_handler(event, context):
+    logger.info('Received event: %s', json.dumps(event))
+
+    if event.get('detail-type') != 'workflow_job':
+        logger.info('Ignoring non-workflow_job event: %s',
+                    event.get('detail-type'))
+        return {'statusCode': 200, 'body': json.dumps({'message': 'ignored event'})}
+
+    detail = event.get('detail', {})
+    logger.debug('Event detail payload: %s', json.dumps(detail))
+
+    runner_name = detail.get('workflow_job').get('runner_name')
+    if not runner_name:
+        logger.error('runner_name missing in event detail: %s', detail)
+        return {'statusCode': 400, 'body': json.dumps({'error': 'runner_name missing'})}
+
+    logger.info('Looking up EC2 instances with Name tag: %s', runner_name)
+    resp = ec2.describe_instances(
+        Filters=[{'Name': 'tag:Name', 'Values': [runner_name]}])
+    instance_ids = [
+        inst['InstanceId']
+        for res in resp.get('Reservations', [])
+        for inst in res.get('Instances', [])
+    ]
+    logger.info('Described instances, found IDs: %s', instance_ids)
+    if not instance_ids:
+        logger.info('No instances found with Name tag %s', runner_name)
+        return {'statusCode': 200, 'body': json.dumps({'message': 'no instances found'})}
+
+    logger.info("Tagging instances %s with tag 'found':'1'", instance_ids)
+    ec2.create_tags(Resources=instance_ids, Tags=[
+                    {'Key': 'found', 'Value': '1'}])
+    logger.info('Successfully tagged instances: %s', instance_ids)
+    return {'statusCode': 200, 'body': json.dumps({'tagged_instances': instance_ids})}

--- a/modules/platform/ec2_deployment/lambda/update_ec2_tags.py
+++ b/modules/platform/ec2_deployment/lambda/update_ec2_tags.py
@@ -11,7 +11,7 @@ ec2 = boto3.client('ec2')
 
 
 def lambda_handler(event, context):
-    logger.info('Received event: %s', json.dumps(event))
+    logger.debug('Received event')
 
     if event.get('detail-type') != 'workflow_job':
         logger.info('Ignoring non-workflow_job event: %s',
@@ -19,28 +19,41 @@ def lambda_handler(event, context):
         return {'statusCode': 200, 'body': json.dumps({'message': 'ignored event'})}
 
     detail = event.get('detail', {})
-    logger.debug('Event detail payload: %s', json.dumps(detail))
 
     runner_name = detail.get('workflow_job').get('runner_name')
     if not runner_name:
         logger.error('runner_name missing in event detail: %s', detail)
         return {'statusCode': 400, 'body': json.dumps({'error': 'runner_name missing'})}
 
-    logger.info('Looking up EC2 instances with Name tag: %s', runner_name)
-    resp = ec2.describe_instances(
-        Filters=[{'Name': 'tag:Name', 'Values': [runner_name]}])
-    instance_ids = [
-        inst['InstanceId']
-        for res in resp.get('Reservations', [])
-        for inst in res.get('Instances', [])
-    ]
+    if not (isinstance(runner_name, str) and runner_name.startswith('i-')):
+        logger.info(
+            'Runner name %s is not an EC2 instance ID, ignoring', runner_name)
+        return {'statusCode': 200, 'body': json.dumps({'message': 'ignored non-EC2 runner'})}
+
+    logger.info('Looking up EC2 instance by ID: %s', runner_name)
+    try:
+        resp = ec2.describe_instances(InstanceIds=[runner_name])
+        instance_ids = [inst['InstanceId'] for res in resp.get(
+            'Reservations', []) for inst in res.get('Instances', [])]
+    except ec2.exceptions.ClientError as e:
+        logger.error('Error fetching instance %s: %s', runner_name, e)
+        return {'statusCode': 500, 'body': json.dumps({'error': 'describe_instances failed'})}
+
     logger.info('Described instances, found IDs: %s', instance_ids)
     if not instance_ids:
         logger.info('No instances found with Name tag %s', runner_name)
         return {'statusCode': 200, 'body': json.dumps({'message': 'no instances found'})}
 
-    logger.info("Tagging instances %s with tag 'found':'1'", instance_ids)
+    job_url = detail.get('workflow_job', {}).get('html_url', '')
+    job_id = str(detail.get('workflow_job', {}).get('id', ''))
+    logger.info('GitHub job URL: %s, job ID: %s', job_url, job_id)
+
+    # Tag instances with found flag and GitHub URLs
+    logger.info(
+        'Tagging instances %s with tags job_url, job_id', instance_ids)
     ec2.create_tags(Resources=instance_ids, Tags=[
-                    {'Key': 'found', 'Value': '1'}])
+        {'Key': 'ghr:job_id', 'Value': job_id},
+        {'Key': 'ghr:job_url', 'Value': job_url}
+    ])
     logger.info('Successfully tagged instances: %s', instance_ids)
     return {'statusCode': 200, 'body': json.dumps({'tagged_instances': instance_ids})}

--- a/modules/platform/ec2_deployment/update-ec2-tags.tf
+++ b/modules/platform/ec2_deployment/update-ec2-tags.tf
@@ -28,15 +28,27 @@ module "update_ec2_tags" {
 
 data "aws_iam_policy_document" "update_ec2_tags" {
 
+  # Allow DescribeInstances without condition
+  statement {
+    effect    = "Allow"
+    actions   = ["ec2:DescribeInstances"]
+    resources = ["*"]
+  }
+
+  # Allow tagging operations conditioned on environment tag
   statement {
     effect = "Allow"
     actions = [
-      "ec2:DescribeImages",
-      "ec2:DescribeInstances",
       "ec2:CreateTags",
       "ec2:DeleteTags"
     ]
-    resources = ["*"] # Restrict to tenant Ec2
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/ghr:environment"
+      values   = ["${var.runner_configs.prefix}-*"]
+    }
   }
 }
 

--- a/modules/platform/ec2_deployment/update-ec2-tags.tf
+++ b/modules/platform/ec2_deployment/update-ec2-tags.tf
@@ -1,0 +1,82 @@
+module "update_ec2_tags" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.1.0"
+
+  function_name = "${var.runner_configs.prefix}-update-ec2-tags"
+  handler       = "update_ec2_tags.lambda_handler"
+  runtime       = "python3.12"
+  timeout       = 900
+  architectures = ["x86_64"]
+
+  source_path = [{
+    path = "${path.module}/lambda"
+  }]
+
+  logging_log_group                 = aws_cloudwatch_log_group.update_ec2_tags.name
+  use_existing_cloudwatch_log_group = true
+
+  attach_policy_json = true
+
+  policy_json = data.aws_iam_policy_document.update_ec2_tags.json
+
+  function_tags = var.tenant_configs.tags
+  role_tags     = var.tenant_configs.tags
+  tags          = var.tenant_configs.tags
+
+  depends_on = [aws_cloudwatch_log_group.update_ec2_tags]
+}
+
+data "aws_iam_policy_document" "update_ec2_tags" {
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:CreateTags",
+      "ec2:DeleteTags"
+    ]
+    resources = ["*"] # Restrict to tenant Ec2
+  }
+}
+
+resource "aws_cloudwatch_log_group" "update_ec2_tags" {
+  name              = "/aws/lambda/${var.runner_configs.prefix}-update-ec2-tags"
+  retention_in_days = var.runner_configs.logging_retention_in_days
+  tags              = var.tenant_configs.tags
+  tags_all          = var.tenant_configs.tags
+}
+
+resource "aws_lambda_permission" "update_ec2_tags" {
+  action        = "lambda:InvokeFunction"
+  function_name = "${var.runner_configs.prefix}-update-ec2-tags"
+  principal     = "events.amazonaws.com"
+  statement_id  = "AllowExecutionFromCloudWatch"
+  source_arn    = aws_cloudwatch_event_rule.update_ec2_tags.arn
+
+  depends_on = [module.update_ec2_tags]
+}
+
+resource "aws_cloudwatch_event_rule" "update_ec2_tags" {
+  name           = "${var.runner_configs.prefix}-update-ec2-tags"
+  description    = "Workflow job event rule for job queued."
+  event_bus_name = module.runners.webhook.eventbridge.event_bus.name
+
+  tags     = var.tenant_configs.tags
+  tags_all = var.tenant_configs.tags
+
+  event_pattern = <<EOF
+{
+  "detail-type": ["workflow_job"],
+  "detail": {
+    "action": ["in_progress","completed"]
+  }
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "update_ec2_tags" {
+  arn            = module.update_ec2_tags.lambda_function_arn
+  rule           = aws_cloudwatch_event_rule.update_ec2_tags.name
+  event_bus_name = module.runners.webhook.eventbridge.event_bus.name
+}


### PR DESCRIPTION
## Description

Use github events to tag ec2 with job id and job url

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
