### PR TITLE
fix: use lambda arn instead of name

### DIFF
--- a/modules/integrations/github_webhook_relay_destination/README.md
+++ b/modules/integrations/github_webhook_relay_destination/README.md
@@ -66,10 +66,8 @@ No modules.
 | [aws_cloudwatch_event_target.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_role.reader](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.allow_assume_external_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_lambda_permission.allow_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_iam_policy_document.allow_assume_external](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_lambda_function.receiver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_function) | data source |
 | [aws_secretsmanager_secret_version.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [external_external.reader_profile](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
@@ -82,7 +80,7 @@ No modules.
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | n/a | `map(string)` | n/a | yes |
 | <a name="input_reader_config"></a> [reader\_config](#input\_reader\_config) | Configuration for IAM role creation and secret retrieval | <pre>object({<br/>    role_name              = string<br/>    role_trust_principals  = list(string)<br/>    source_secret_role_arn = string<br/>    enable_secret_fetch    = bool<br/>    source_secret_arn      = string<br/>    source_secret_region   = string<br/>  })</pre> | <pre>{<br/>  "enable_secret_fetch": false,<br/>  "role_name": "github-webhook-relay-secret-reader",<br/>  "role_trust_principals": [],<br/>  "source_secret_arn": "",<br/>  "source_secret_region": "",<br/>  "source_secret_role_arn": ""<br/>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
-| <a name="input_webhook_relay_destination_config"></a> [webhook\_relay\_destination\_config](#input\_webhook\_relay\_destination\_config) | All configuration for the destination EventBridge relay | <pre>object({<br/>    name_prefix                = string<br/>    destination_event_bus_name = string<br/>    source_account_id          = string<br/>    targets = list(object({<br/>      event_pattern        = string<br/>      lambda_function_name = string<br/>    }))<br/>  })</pre> | <pre>{<br/>  "destination_event_bus_name": "webhook-relay-destination",<br/>  "name_prefix": "webhook-relay-destination",<br/>  "source_account_id": "",<br/>  "targets": []<br/>}</pre> | no |
+| <a name="input_webhook_relay_destination_config"></a> [webhook\_relay\_destination\_config](#input\_webhook\_relay\_destination\_config) | All configuration for the destination EventBridge relay | <pre>object({<br/>    name_prefix                = string<br/>    destination_event_bus_name = string<br/>    source_account_id          = string<br/>    targets = list(object({<br/>      event_pattern       = string<br/>      lambda_function_arn = string<br/>    }))<br/>  })</pre> | <pre>{<br/>  "destination_event_bus_name": "webhook-relay-destination",<br/>  "name_prefix": "webhook-relay-destination",<br/>  "source_account_id": "",<br/>  "targets": []<br/>}</pre> | no |
 
 ## Outputs
 

--- a/modules/integrations/github_webhook_relay_destination/variables.tf
+++ b/modules/integrations/github_webhook_relay_destination/variables.tf
@@ -44,8 +44,8 @@ variable "webhook_relay_destination_config" {
     destination_event_bus_name = string
     source_account_id          = string
     targets = list(object({
-      event_pattern        = string
-      lambda_function_name = string
+      event_pattern       = string
+      lambda_function_arn = string
     }))
   })
   default = {

--- a/modules/integrations/splunk_cloud_data_manager_common/README.md
+++ b/modules/integrations/splunk_cloud_data_manager_common/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.16.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.3.5 |
 
 ## Modules

--- a/modules/integrations/splunk_o11y_aws_integration_common/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration_common/README.md
@@ -13,7 +13,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 6.16.0 |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.21.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.22.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.13.1 |
 
 ## Modules


### PR DESCRIPTION
## Description

Use lambda arn instead lambda name `github_webhook_relay_destination`

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
