### PR TITLE
fix: use prefix in policy name

### DIFF
--- a/modules/platform/forge_runners/github_actions_job_logs/reader_role.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/reader_role.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "internal_s3_reader_policy_doc" {
 }
 
 resource "aws_iam_policy" "internal_s3_reader_policy" {
-  name   = "InternalS3ReaderPolicy"
+  name   = "${var.prefix}-s3-reader-policy"
   policy = data.aws_iam_policy_document.internal_s3_reader_policy_doc.json
 }
 


### PR DESCRIPTION
## Description

Use prefix in policy name to allow multiple policies in the same account

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
