### PR TITLE
fix: add lambda permission in webhook relay destination

### DIFF
--- a/modules/integrations/github_webhook_relay_destination/webhook_relay_destination.tf
+++ b/modules/integrations/github_webhook_relay_destination/webhook_relay_destination.tf
@@ -46,3 +46,11 @@ resource "aws_cloudwatch_event_target" "lambda" {
   event_bus_name = each.value.event_bus_name
   arn            = local.targets_indexed[each.key].lambda_function_arn
 }
+
+resource "aws_lambda_permission" "eventbridge_invoke" {
+  for_each      = aws_cloudwatch_event_rule.receive
+  action        = "lambda:InvokeFunction"
+  function_name = local.targets_indexed[each.key].lambda_function_arn
+  principal     = "events.amazonaws.com"
+  source_arn    = each.value.arn
+}


### PR DESCRIPTION
## Description

Adding missing lambda permission to allow event bus trigger webhook relay functions

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
