### PR TITLE
fix: fix relative path in migrate-all-tenants.sh

### DIFF
--- a/scripts/migrate-all-tenants.sh
+++ b/scripts/migrate-all-tenants.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-SCRIPT="./migrate-tenant.sh"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+SCRIPT="$SCRIPT_DIR/migrate-tenant.sh"
 TENANTS_DIR=$1
 
 for tenant in "$TENANTS_DIR"/*; do

--- a/scripts/migrate-tenant.sh
+++ b/scripts/migrate-tenant.sh
@@ -12,7 +12,7 @@ get_terragrunt_var() {
     local value
 
     pushd "$dir" >/dev/null
-    value=$(TF_LOG=ERROR terragrunt console <<<"var.${var_name}" 2>/dev/null | tail -n1 | sed 's/^"//;s/"$//')
+    value=$(TF_LOG=ERROR terragrunt run -- console <<<"var.${var_name}" 2>/dev/null | tail -n1 | sed 's/^"//;s/"$//')
     popd >/dev/null
 
     if [[ -z "$value" ]]; then
@@ -95,7 +95,7 @@ scale_down_runners() {
 terragrunt_apply() {
     local target="$1"
     echo "🔧 Applying Terragrunt target: $target"
-    terragrunt apply --target "$target" -working-dir "$TF_DIR" -non-interactive -auto-approve
+    terragrunt apply --target "$target" --working-dir "$TF_DIR" --non-interactive -auto-approve
 }
 
 update_config() {


### PR DESCRIPTION
## Description

Fix relative path when executing `scripts/migrate-tenant.sh` from `scripts/migrate-all-tenants.sh`

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
