### PR TITLE
fix: run aws cli after send event json to logs

### DIFF
--- a/modules/platform/ec2_deployment/template_files/hook_job_completed.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_completed.tftpl
@@ -9,17 +9,6 @@ else
   EVENT_JSON="{}"
 fi
 
-INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.instanceId')
-aws ec2 create-tags --cli-input-json "$(jq -n \
-    --arg instance "$INSTANCE_ID" \
-    --arg completed_at "$(TZ=UTC date +"%Y-%m-%dT%H:%M:%SZ")" \
-    '{
-    Resources: [$instance],
-    Tags: [
-      {Key:"ghr:completed_at", Value:$completed_at}
-    ]
-  }')"
-
 {
     echo "{"
     echo "  \"timestamp\": \"$TIMESTAMP\","
@@ -73,3 +62,25 @@ aws ec2 create-tags --cli-input-json "$(jq -n \
 } | jq -c . >>"$LOG_FILE"
 
 echo "GitHub Actions environment variables exported to $LOG_FILE"
+
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE AWS_DEFAULT_PROFILE
+
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+
+# Get instance ID and region
+INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+
+# Generate timestamp
+COMPLETED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Tag instance
+aws ec2 create-tags \
+  --region "$REGION" \
+  --resources "$INSTANCE_ID" \
+  --tags "Key=ghr:completed_at,Value=$COMPLETED_AT"
+
+echo "Tagged $INSTANCE_ID with completion timestamp ($COMPLETED_AT)"

--- a/modules/platform/ec2_deployment/template_files/hook_job_started.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started.tftpl
@@ -9,37 +9,6 @@ else
   EVENT_JSON="{}"
 fi
 
-INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.instanceId')
-aws ec2 create-tags --cli-input-json "$(jq -n \
-    --arg instance "$INSTANCE_ID" \
-    --arg repository "$GITHUB_REPOSITORY" \
-    --arg ref "$GITHUB_REF" \
-    --arg commit "$GITHUB_SHA" \
-    --arg workflow "$GITHUB_WORKFLOW" \
-    --arg workflow_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
-    --arg job "$GITHUB_JOB" \
-    --arg run_id "$GITHUB_RUN_ID" \
-    --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
-    --arg run_number "$GITHUB_RUN_NUMBER" \
-    --arg actor "$GITHUB_ACTOR" \
-    --arg started_at "$(TZ=UTC date +"%Y-%m-%dT%H:%M:%SZ")" \
-    '{
-    Resources: [$instance],
-    Tags: [
-      {Key:"ghr:repository", Value:$repository},
-      {Key:"ghr:ref", Value:$ref},
-      {Key:"ghr:commit", Value:$commit},
-      {Key:"ghr:workflow", Value:$workflow},
-      {Key:"ghr:workflow_url", Value:$workflow_url},
-      {Key:"ghr:job", Value:$job},
-      {Key:"ghr:run_id", Value:$run_id},
-      {Key:"ghr:run_attempt", Value:$run_attempt},
-      {Key:"ghr:run_number", Value:$run_number},
-      {Key:"ghr:actor", Value:$actor},
-      {Key:"ghr:started_at", Value:$started_at}
-    ]
-  }')"
-
 {
     echo "{"
     echo "  \"timestamp\": \"$TIMESTAMP\","
@@ -93,3 +62,36 @@ aws ec2 create-tags --cli-input-json "$(jq -n \
 } | jq -c . >>"$LOG_FILE"
 
 echo "GitHub Actions environment variables exported to $LOG_FILE"
+
+INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.instanceId')
+aws ec2 create-tags --cli-input-json "$(jq -n \
+    --arg instance "$INSTANCE_ID" \
+    --arg repository "$GITHUB_REPOSITORY" \
+    --arg ref "$GITHUB_REF" \
+    --arg commit "$GITHUB_SHA" \
+    --arg workflow "$GITHUB_WORKFLOW" \
+    --arg workflow_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
+    --arg job "$GITHUB_JOB" \
+    --arg run_id "$GITHUB_RUN_ID" \
+    --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+    --arg run_number "$GITHUB_RUN_NUMBER" \
+    --arg actor "$GITHUB_ACTOR" \
+    --arg started_at "$(TZ=UTC date +"%Y-%m-%dT%H:%M:%SZ")" \
+    '{
+    Resources: [$instance],
+    Tags: [
+      {Key:"ghr:repository", Value:$repository},
+      {Key:"ghr:ref", Value:$ref},
+      {Key:"ghr:commit", Value:$commit},
+      {Key:"ghr:workflow", Value:$workflow},
+      {Key:"ghr:workflow_url", Value:$workflow_url},
+      {Key:"ghr:job", Value:$job},
+      {Key:"ghr:run_id", Value:$run_id},
+      {Key:"ghr:run_attempt", Value:$run_attempt},
+      {Key:"ghr:run_number", Value:$run_number},
+      {Key:"ghr:actor", Value:$actor},
+      {Key:"ghr:started_at", Value:$started_at}
+    ]
+  }')"
+
+echo "Instance $INSTANCE_ID tagged with GitHub Actions metadata"


### PR DESCRIPTION
## Description

Move instance tag after send event json to logs in runner hooks

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
