### PR TITLE
fix(runner): enforce instance profile usage and disable shared AWS creds

### DIFF
--- a/modules/platform/ec2_deployment/template_files/hook_job_completed.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_completed.tftpl
@@ -64,6 +64,9 @@ fi
 echo "GitHub Actions environment variables exported to $LOG_FILE"
 
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE AWS_DEFAULT_PROFILE
+export AWS_SHARED_CREDENTIALS_FILE=/dev/null
+export AWS_CONFIG_FILE=/dev/null
+export AWS_SDK_LOAD_CONFIG=0
 
 TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
   -H "X-aws-ec2-metadata-token-ttl-seconds: 300")


### PR DESCRIPTION
## Description

Prevent runner using non-forge aws session in hook

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
