### PR TITLE
fix: replace hardcoded role for super admin in eks cluster for variable

### DIFF
--- a/examples/deployments/forge-eks/terragrunt/_global_settings/eks.hcl
+++ b/examples/deployments/forge-eks/terragrunt/_global_settings/eks.hcl
@@ -56,14 +56,17 @@ inputs = {
   aws_region     = local.region
 
   # EKS Cluster Settings
-  cluster_name       = local.eks_settings_data.locals.cluster_name
-  cluster_version    = local.eks_settings_data.locals.cluster_version
-  cluster_size       = local.eks_settings_data.locals.cluster_size
-  subnet_ids         = local.eks_settings_data.locals.subnet_ids
-  vpc_id             = local.eks_settings_data.locals.vpc_id
-  cluster_ami_filter = local.eks_settings_data.locals.cluster_ami_filter
-  cluster_ami_owners = local.eks_settings_data.locals.cluster_ami_owners
-  cluster_volume     = local.eks_settings_data.locals.cluster_volume
+  cluster_name                   = local.eks_settings_data.locals.cluster_name
+  cluster_version                = local.eks_settings_data.locals.cluster_version
+  cluster_size                   = local.eks_settings_data.locals.cluster_size
+  subnet_ids                     = local.eks_settings_data.locals.subnet_ids
+  vpc_id                         = local.eks_settings_data.locals.vpc_id
+  cluster_ami_filter             = local.eks_settings_data.locals.cluster_ami_filter
+  cluster_ami_owners             = local.eks_settings_data.locals.cluster_ami_owners
+  cluster_volume                 = local.eks_settings_data.locals.cluster_volume
+  cluster_endpoint_public_access = local.eks_settings_data.locals.cluster_endpoint_public_access
+  external_access_cidr_blocks    = local.eks_settings_data.locals.external_access_cidr_blocks
+  cluster_admin_role_arn         = local.eks_settings_data.locals.cluster_admin_role_arn
 
   # Misc
   cluster_tags = local.cluster_tags

--- a/examples/deployments/forge-eks/terragrunt/environments/prod/regions/eu-west-1/eks/config.hcl
+++ b/examples/deployments/forge-eks/terragrunt/environments/prod/regions/eu-west-1/eks/config.hcl
@@ -2,12 +2,15 @@ locals {
 
   config = yamldecode(file("config.yaml"))
 
-  cluster_name       = local.config.cluster_name
-  cluster_version    = local.config.cluster_version
-  cluster_size       = local.config.cluster_size
-  subnet_ids         = local.config.subnet_ids
-  vpc_id             = local.config.vpc_id
-  cluster_ami_filter = local.config.cluster_ami_filter
-  cluster_ami_owners = local.config.cluster_ami_owners
-  cluster_volume     = local.config.cluster_volume
+  cluster_name                   = local.config.cluster_name
+  cluster_version                = local.config.cluster_version
+  cluster_size                   = local.config.cluster_size
+  subnet_ids                     = local.config.subnet_ids
+  vpc_id                         = local.config.vpc_id
+  cluster_ami_filter             = local.config.cluster_ami_filter
+  cluster_ami_owners             = local.config.cluster_ami_owners
+  cluster_volume                 = local.config.cluster_volume
+  cluster_endpoint_public_access = local.config.cluster_endpoint_public_access
+  external_access_cidr_blocks    = local.config.external_access_cidr_blocks
+  cluster_admin_role_arn         = local.config.cluster_admin_role_arn
 }

--- a/examples/deployments/forge-eks/terragrunt/environments/prod/regions/eu-west-1/eks/config.yaml
+++ b/examples/deployments/forge-eks/terragrunt/environments/prod/regions/eu-west-1/eks/config.yaml
@@ -19,3 +19,7 @@ cluster_volume:
   iops: 3000
   throughput: 125
   type: gp3
+cluster_endpoint_public_access: false
+external_access_cidr_blocks:
+  - 10.0.0.0/8
+cluster_admin_role_arn: arn:aws:iam::123456789012:role/eks-cluster-admin

--- a/examples/templates/eks/eks/config.yaml
+++ b/examples/templates/eks/eks/config.yaml
@@ -19,3 +19,8 @@ cluster_volume:
   iops: <VOLUME_IOPS>                         # e.g., 3000
   throughput: <VOLUME_THROUGHPUT>             # e.g., 125
   type: <VOLUME_TYPE>                         # e.g., "gp3"
+cluster_endpoint_public_access: <CLUSTER_ENDPOINT_PUBLIC_ACCESS>   # e.g., false
+external_access_cidr_blocks:                                        # e.g., [ "10.0.0.0/8" ]
+  - <EXTERNAL_ACCESS_CIDR_BLOCK_1>
+  - <EXTERNAL_ACCESS_CIDR_BLOCK_2>
+cluster_admin_role_arn: <CLUSTER_ADMIN_ROLE_ARN>                   # e.g., "arn:aws:iam::123456789012:role/eks-cluster-admin"

--- a/modules/infra/eks/data.tf
+++ b/modules/infra/eks/data.tf
@@ -1,5 +1,3 @@
-data "aws_caller_identity" "current" {}
-
 data "aws_eks_cluster" "cluster" {
   name       = module.eks.cluster_name
   depends_on = [null_resource.wait_for_cluster]

--- a/modules/infra/eks/eks.tf
+++ b/modules/infra/eks/eks.tf
@@ -45,7 +45,7 @@ module "eks" {
 
   access_entries = {
     super-admin = {
-      principal_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/owner"
+      principal_arn = var.cluster_admin_role_arn
 
       policy_associations = {
         this = {

--- a/modules/infra/eks/variables.tf
+++ b/modules/infra/eks/variables.tf
@@ -84,3 +84,9 @@ variable "cluster_ami_owners" {
   description = "The AWS account ID that owns the EKS cluster AMI."
   type        = list(string)
 }
+
+variable "cluster_admin_role_arn" {
+  description = "Full ARN of IAM role for EKS cluster admin access."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Description

Replace hardcoded role with super admin privileges to manage eks cluster for a variable to allow custom role names

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
