### PR TITLE
feat: update calico and karpenter to support eks 1.34 (requires cluster reinstall)

### DIFF
--- a/modules/infra/eks/calico.tf
+++ b/modules/infra/eks/calico.tf
@@ -3,8 +3,8 @@ resource "null_resource" "patch_calico_installation" {
   provisioner "local-exec" {
     command = <<EOF
       kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} delete daemonset -n kube-system aws-node || true
-      kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.30.2/manifests/operator-crds.yaml --server-side
-      kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.30.2/manifests/tigera-operator.yaml --server-side
+      kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/operator-crds.yaml --server-side
+      kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/tigera-operator.yaml --server-side
 
       kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f - <<EOT
 apiVersion: operator.tigera.io/v1

--- a/modules/infra/eks/karpenter.tf
+++ b/modules/infra/eks/karpenter.tf
@@ -5,18 +5,13 @@ module "karpenter" {
   namespace    = "karpenter"
   cluster_name = var.cluster_name
 
-  create_node_iam_role    = true
   create_instance_profile = true
-  create_access_entry     = true
 
   tags = merge(local.all_security_tags, { "calico_dependency" = local._wait_for_calico })
 
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   }
-
-  create_pod_identity_association = true
-
 }
 
 resource "helm_release" "karpenter" {
@@ -25,7 +20,7 @@ resource "helm_release" "karpenter" {
   create_namespace = true
   repository       = "oci://public.ecr.aws/karpenter"
   chart            = "karpenter"
-  version          = "1.6.1"
+  version          = "1.8.2"
   wait             = false
 
   values = [


### PR DESCRIPTION
## Description

**This PR upgrades EKS dependencies and related components**

> ⚠ **Breaking change:** This upgrade requires a full EKS cluster reinstall.

Upgrade karpenter to 1.8.2 and calico to 3.31.0 to support eks 1.34

References:
Calico 3.31: https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#supported-versions
Karpenter 1.8.2: https://karpenter.sh/docs/upgrading/compatibility/



## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
