### PR TITLE
fix: upgrade kubernetes_config_map

### DIFF
--- a/modules/core/arc/scale_set/README.md
+++ b/modules/core/arc/scale_set/README.md
@@ -28,8 +28,8 @@ No modules.
 | [aws_iam_role.runner_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.runner_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.gha_runner_scale_set](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_config_map.hook_extension](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
-| [kubernetes_config_map.hook_pre_post_job](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_config_map_v1.hook_extension](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_config_map_v1.hook_pre_post_job](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_role.k8s](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
 | [kubernetes_role_binding.k8s](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
 | [kubernetes_service_account_v1.runner_sa](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |

--- a/modules/core/arc/scale_set/helm.tf
+++ b/modules/core/arc/scale_set/helm.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_config_map" "hook_extension" {
+resource "kubernetes_config_map_v1" "hook_extension" {
   count = var.migrate_arc_cluster == false ? 1 : 0
   metadata {
     name      = "hook-extension-${var.scale_set_name}"
@@ -23,7 +23,7 @@ resource "kubernetes_config_map" "hook_extension" {
   }
 }
 
-resource "kubernetes_config_map" "hook_pre_post_job" {
+resource "kubernetes_config_map_v1" "hook_pre_post_job" {
   count = var.migrate_arc_cluster == false ? 1 : 0
   metadata {
     name      = "hook-pre-post-job-${var.scale_set_name}"

--- a/modules/integrations/teleport/README.md
+++ b/modules/integrations/teleport/README.md
@@ -28,7 +28,7 @@
 | [aws_iam_policy.eks_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.teleport_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.attach_eks_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [kubernetes_config_map.aws_auth_teleport](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_config_map_v1.aws_auth_teleport](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |

--- a/modules/integrations/teleport/main.tf
+++ b/modules/integrations/teleport/main.tf
@@ -5,7 +5,7 @@ module "tenant" {
   namespace = each.value
 }
 
-resource "kubernetes_config_map" "aws_auth_teleport" {
+resource "kubernetes_config_map_v1" "aws_auth_teleport" {
   count = length(var.tenants) > 0 ? 1 : 0
   metadata {
     name      = "aws-auth"


### PR DESCRIPTION
## Description

Migrate kubernetes_config_map to kubernetes_config_map_v1 

```
18:07:58.886 STDOUT tofu: │ Warning: Deprecated Resource
18:07:58.886 STDOUT tofu: │
18:07:58.886 STDOUT tofu: │   with module.arc_runners.module.arc.module.scale_sets.kubernetes_config_map.hook_extension,
18:07:58.886 STDOUT tofu: │   on ../../core/arc/scale_set/helm.tf line 1, in resource "kubernetes_config_map" "hook_extension":
18:07:58.887 STDOUT tofu: │    1: resource "kubernetes_config_map" "hook_extension" {
18:07:58.887 STDOUT tofu: │
18:07:58.887 STDOUT tofu: │ Deprecated; use kubernetes_config_map_v1.
18:07:58.887 STDOUT tofu: │
18:07:58.887 STDOUT tofu: │ (and 17 more similar warnings elsewhere)
18:07:58.887 STDOUT tofu: ╵
```


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
