### PR TITLE
deprecated: remove variable aws_account_id

### DIFF
--- a/modules/infra/cloud_formation/data.tf
+++ b/modules/infra/cloud_formation/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/modules/infra/cloud_formation/main.tf
+++ b/modules/infra/cloud_formation/main.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "execution_assume_admin_role_policy" {
     actions = ["sts:AssumeRole"]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.aws_account_id}:role/AWSCloudFormationStackSetAdministrationRole"]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSCloudFormationStackSetAdministrationRole"]
     }
   }
 }

--- a/modules/infra/cloud_formation/variables.tf
+++ b/modules/infra/cloud_formation/variables.tf
@@ -1,8 +1,3 @@
-variable "aws_account_id" {
-  description = "AWS account ID associated with the infra/backend."
-  type        = string
-}
-
 variable "aws_profile" {
   type        = string
   description = "AWS profile to use."

--- a/modules/infra/storage/data.tf
+++ b/modules/infra/storage/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/modules/infra/storage/main.tf
+++ b/modules/infra/storage/main.tf
@@ -2,7 +2,7 @@
 # Long-term storage (i.e. release builds and SBOMs we need to retain long-term
 # for stability and auditing purposes).
 resource "aws_s3_bucket" "s3_long_term" {
-  bucket = "${var.aws_account_id}-long-term-storage"
+  bucket = "${data.aws_caller_identity.current.account_id}-long-term-storage"
   tags   = local.all_security_tags
 }
 
@@ -47,7 +47,7 @@ resource "aws_s3_bucket_public_access_block" "s3_long_term" {
 # Short-term storage (i.e. temporary/feature-branch builds, core dumps, and
 # other artifacts we aren't obligated to retain long-term).
 resource "aws_s3_bucket" "s3_short_term" {
-  bucket = "${var.aws_account_id}-short-term-storage"
+  bucket = "${data.aws_caller_identity.current.account_id}-short-term-storage"
   tags   = local.all_security_tags
 }
 

--- a/modules/infra/storage/variables.tf
+++ b/modules/infra/storage/variables.tf
@@ -1,8 +1,3 @@
-variable "aws_account_id" {
-  type        = string
-  description = "AWS account ID (not SL AWS account ID) associated with the infra/backend."
-}
-
 variable "aws_profile" {
   description = "AWS profile to use."
   type        = string

--- a/modules/integrations/github_webhook_relay_destination_receivers/variables.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_profile" {
-  description = "AWS profile (i.e., generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
   type        = string
 }
 

--- a/modules/integrations/splunk_aws_billing/variables.tf
+++ b/modules/integrations/splunk_aws_billing/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  description = "AWS profile (i.e., generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
 }
 
 variable "aws_region" {

--- a/modules/integrations/splunk_cloud_conf_shared/README.md
+++ b/modules/integrations/splunk_cloud_conf_shared/README.md
@@ -73,7 +73,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile (i.e. generated via 'sl aws session generate') to use. | `string` | n/a | yes |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile to use. | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | Assuming single region for now. | `string` | n/a | yes |
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
 | <a name="input_splunk_conf"></a> [splunk\_conf](#input\_splunk\_conf) | n/a | <pre>object({<br/>    splunk_cloud = string<br/>    acl = object({<br/>      app     = string<br/>      owner   = string<br/>      sharing = string<br/>      read    = list(string)<br/>      write   = list(string)<br/>    })<br/>    index   = string<br/>    tenant_names = list(string)<br/>  })</pre> | n/a | yes |

--- a/modules/integrations/splunk_cloud_conf_shared/variables.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  description = "AWS profile (i.e. generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
 }
 
 variable "aws_region" {

--- a/modules/integrations/splunk_cloud_data_manager/cloudwatch.tf
+++ b/modules/integrations/splunk_cloud_data_manager/cloudwatch.tf
@@ -35,7 +35,7 @@ locals {
       iamRegion    = var.aws_region
       regions      = var.cloudwatch_log_groups_config.regions
       datasetInfo  = local.dataset_info_cloudwatch
-      dataAccounts = [var.aws_account_id]
+      dataAccounts = [data.aws_caller_identity.current.account_id]
       resourceTags = local.resource_tags
     }
   }

--- a/modules/integrations/splunk_cloud_data_manager/custom_cloudwatch.tf
+++ b/modules/integrations/splunk_cloud_data_manager/custom_cloudwatch.tf
@@ -46,7 +46,7 @@ locals {
           }
         }
       }
-      dataAccounts = [var.aws_account_id]
+      dataAccounts = [data.aws_caller_identity.current.account_id]
       resourceTags = local.resource_tags
     }
   }

--- a/modules/integrations/splunk_cloud_data_manager/data.tf
+++ b/modules/integrations/splunk_cloud_data_manager/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/modules/integrations/splunk_cloud_data_manager/sec_meta.tf
+++ b/modules/integrations/splunk_cloud_data_manager/sec_meta.tf
@@ -40,7 +40,7 @@ locals {
       iamRegion    = var.aws_region
       regions      = var.security_metadata_config.regions
       datasetInfo  = local.dataset_info_security_metadata
-      dataAccounts = [var.aws_account_id]
+      dataAccounts = [data.aws_caller_identity.current.account_id]
       resourceTags = local.resource_tags
     }
   }

--- a/modules/integrations/splunk_cloud_data_manager/variables.tf
+++ b/modules/integrations/splunk_cloud_data_manager/variables.tf
@@ -1,11 +1,6 @@
-variable "aws_account_id" {
-  description = "AWS account ID (not SL AWS account ID) associated with the infra/backend."
-  type        = string
-}
-
 variable "aws_profile" {
   type        = string
-  description = "AWS profile (i.e., generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
 }
 
 variable "aws_region" {

--- a/modules/integrations/splunk_cloud_data_manager_common/data.tf
+++ b/modules/integrations/splunk_cloud_data_manager_common/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/modules/integrations/splunk_cloud_data_manager_common/role.tf
+++ b/modules/integrations/splunk_cloud_data_manager_common/role.tf
@@ -11,15 +11,15 @@ data "aws_iam_policy_document" "splunk_dm_policy" {
       "iam:GetPolicyVersion"
     ]
     resources = [
-      "arn:aws:iam::${var.aws_account_id}:role/SplunkDM*",
-      "arn:aws:iam::${var.aws_account_id}:policy/*"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/SplunkDM*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/*"
     ]
   }
 
   statement {
     effect    = "Allow"
     actions   = ["guardduty:GetMasterAccount"]
-    resources = ["arn:aws:guardduty:*:${var.aws_account_id}:detector/*"]
+    resources = ["arn:aws:guardduty:*:${data.aws_caller_identity.current.account_id}:detector/*"]
   }
 
   statement {
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "splunk_dm_policy" {
       "securityhub:ListMembers",
       "securityhub:ListInvitations"
     ]
-    resources = ["arn:aws:securityhub:*:${var.aws_account_id}:hub/default"]
+    resources = ["arn:aws:securityhub:*:${data.aws_caller_identity.current.account_id}:hub/default"]
   }
 
   statement {
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "splunk_dm_policy" {
       "cloudformation:DescribeStacks",
       "cloudformation:GetTemplate"
     ]
-    resources = ["arn:aws:cloudformation:*:${var.aws_account_id}:stack/SplunkDM*/*"]
+    resources = ["arn:aws:cloudformation:*:${data.aws_caller_identity.current.account_id}:stack/SplunkDM*/*"]
   }
 
   statement {
@@ -65,19 +65,19 @@ data "aws_iam_policy_document" "splunk_dm_policy" {
       "logs:DescribeLogGroups",
       "logs:DescribeSubscriptionFilters"
     ]
-    resources = ["arn:aws:logs:*:${var.aws_account_id}:log-group:*"]
+    resources = ["arn:aws:logs:*:${data.aws_caller_identity.current.account_id}:log-group:*"]
   }
 
   statement {
     effect    = "Allow"
     actions   = ["firehose:DescribeDeliveryStream"]
-    resources = ["arn:aws:firehose:*:${var.aws_account_id}:deliverystream/SplunkDM*"]
+    resources = ["arn:aws:firehose:*:${data.aws_caller_identity.current.account_id}:deliverystream/SplunkDM*"]
   }
 
   statement {
     effect    = "Allow"
     actions   = ["events:DescribeRule"]
-    resources = ["arn:aws:events:*:${var.aws_account_id}:rule/SplunkDM*"]
+    resources = ["arn:aws:events:*:${data.aws_caller_identity.current.account_id}:rule/SplunkDM*"]
   }
 
   statement {
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "splunk_dm_policy" {
   statement {
     effect    = "Allow"
     actions   = ["lambda:GetFunction"]
-    resources = ["arn:aws:lambda:*:${var.aws_account_id}:function:SplunkDM*"]
+    resources = ["arn:aws:lambda:*:${data.aws_caller_identity.current.account_id}:function:SplunkDM*"]
   }
 }
 

--- a/modules/integrations/splunk_cloud_data_manager_common/variables.tf
+++ b/modules/integrations/splunk_cloud_data_manager_common/variables.tf
@@ -1,11 +1,8 @@
-variable "aws_account_id" {
-  description = "AWS account ID (not SL AWS account ID) associated with the infra/backend."
-  type        = string
-}
+
 
 variable "aws_profile" {
   type        = string
-  description = "AWS profile (i.e., generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
 }
 
 variable "aws_region" {

--- a/modules/integrations/splunk_cloud_s3_runner_logs/variables.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  description = "AWS profile (i.e., generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
 }
 
 variable "aws_region" {

--- a/modules/integrations/splunk_o11y_aws_integration/variables.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  description = "AWS profile (i.e., generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
 }
 
 variable "aws_region" {

--- a/modules/integrations/splunk_o11y_aws_integration_common/data.tf
+++ b/modules/integrations/splunk_o11y_aws_integration_common/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/modules/integrations/splunk_o11y_aws_integration_common/role.tf
+++ b/modules/integrations/splunk_o11y_aws_integration_common/role.tf
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "splunk_managed_policy" {
     effect  = "Allow"
     actions = ["iam:PassRole"]
     # Role to be created by Cloudformation stack
-    resources = ["arn:aws:iam::${var.aws_account_id}:role/splunk-metric-streams*"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/splunk-metric-streams*"]
   }
 }
 

--- a/modules/integrations/splunk_o11y_aws_integration_common/variables.tf
+++ b/modules/integrations/splunk_o11y_aws_integration_common/variables.tf
@@ -1,11 +1,6 @@
-variable "aws_account_id" {
-  description = "AWS account ID (not SL AWS account ID) associated with the infra/backend."
-  type        = string
-}
-
 variable "aws_profile" {
   type        = string
-  description = "AWS profile (i.e., generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
 }
 
 variable "aws_region" {

--- a/modules/integrations/splunk_o11y_conf_shared/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  description = "AWS profile (i.e., generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
 }
 
 variable "aws_region" {

--- a/modules/integrations/teleport/README.md
+++ b/modules/integrations/teleport/README.md
@@ -39,7 +39,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile (i.e. generated via 'sl aws session generate') to use. | `string` | n/a | yes |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile to use. | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | Assuming single region for now. | `string` | n/a | yes |
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |

--- a/modules/integrations/teleport/variables.tf
+++ b/modules/integrations/teleport/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  description = "AWS profile (i.e. generated via 'sl aws session generate') to use."
+  description = "AWS profile to use."
 }
 
 variable "aws_region" {


### PR DESCRIPTION
## Description

Remove variable `aws_account_id`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
