### PR TITLE
fix: remove helm chart provider and use null resource

### DIFF
--- a/modules/infra/eks/providers.tf
+++ b/modules/infra/eks/providers.tf
@@ -9,16 +9,8 @@ provider "aws" {
   }
 }
 
-provider "helm" {
-  kubernetes = {
-    host                   = data.aws_eks_cluster.cluster.endpoint
-    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
-    token                  = data.aws_eks_cluster_auth.cluster.token
-  }
-}
-
 provider "kubectl" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
+  host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false


### PR DESCRIPTION
## Description

With opentofu adding `deferral` provider helm chart is not working.

```
  │ Error: Provider configuration is incomplete
  │ 
  │   on karpenter.tf line 17, in resource "helm_release" "karpenter":
  │   17: resource "helm_release" "karpenter" {
  │ 
  │ The provider was unable to work with this resource because the associated
  │ provider configuration makes use of values from other resources that will
  │ not be known until after apply.
  │ 
  │ To work around this, use the planning option
  │ -exclude="helm_release.karpenter" to first apply without this object, and
  │ then apply normally to converge.
  ╵
  ```
  
  As workaround I replaced for a null resource

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
