### PR TITLE
feat: allow to use different vpc and subnet for runners

### DIFF
--- a/examples/deployments/forge-tenant/terragrunt/_global_settings/tenant.hcl
+++ b/examples/deployments/forge-tenant/terragrunt/_global_settings/tenant.hcl
@@ -55,6 +55,7 @@ inputs = {
 
   ec2_deployment_specs = {
     lambda_subnet_ids = local.config.locals.lambda_subnet_ids
+    lambda_vpc_id     = local.config.locals.lambda_vpc_id
     subnet_ids        = local.config.locals.subnet_ids
     vpc_id            = local.config.locals.vpc_id
     runner_specs      = local.config.locals.ec2_runner_specs

--- a/examples/deployments/forge-tenant/terragrunt/environments/prod/regions/eu-west-1/vpcs/sl/tenants/acme/runner_settings.hcl
+++ b/examples/deployments/forge-tenant/terragrunt/environments/prod/regions/eu-west-1/vpcs/sl/tenants/acme/runner_settings.hcl
@@ -18,6 +18,7 @@ include "vpc" {
 
 locals {
   # VPC & region info from includes
+  lambda_vpc_id     = include.vpc.locals.vpc_id
   lambda_subnet_ids = include.vpc.locals.lambda_subnet_ids
   vpc_id            = include.vpc.locals.vpc_id
   subnet_ids        = include.vpc.locals.subnet_ids
@@ -98,7 +99,8 @@ locals {
         volume_size           = spec.volume.size
         volume_type           = spec.volume.type
       }]
-      pool_config = spec.pool_config
+      vpc_id = local.vpc_id
+
     }
   }
   arc_cluster_name    = local.config.arc_cluster_name

--- a/examples/templates/tenant/_global_settings/tenant.hcl
+++ b/examples/templates/tenant/_global_settings/tenant.hcl
@@ -56,6 +56,7 @@ inputs = {
   # Runners (EC2/ARC)
   ec2_deployment_specs = {
     lambda_subnet_ids = local.config.locals.lambda_subnet_ids
+    lambda_vpc_id     = local.config.locals.lambda_vpc_id
     subnet_ids        = local.config.locals.subnet_ids
     vpc_id            = local.config.locals.vpc_id
     runner_specs      = local.config.locals.ec2_runner_specs

--- a/examples/templates/tenant/tenant/runner_settings.hcl
+++ b/examples/templates/tenant/tenant/runner_settings.hcl
@@ -18,6 +18,7 @@ include "vpc" {
 
 locals {
   # VPC & region info from includes
+  lambda_vpc_id     = include.vpc.locals.vpc_id
   lambda_subnet_ids = include.vpc.locals.lambda_subnet_ids
   vpc_id            = include.vpc.locals.vpc_id
   subnet_ids        = include.vpc.locals.subnet_ids
@@ -98,7 +99,7 @@ locals {
         volume_size           = spec.volume.size
         volume_type           = spec.volume.type
       }]
-      pool_config = spec.pool_config
+      vpc_id = local.vpc_id
     }
   }
   arc_cluster_name    = local.config.arc_cluster_name

--- a/modules/platform/ec2_deployment/security_group.tf
+++ b/modules/platform/ec2_deployment/security_group.tf
@@ -1,7 +1,7 @@
 # Allow the lambda to egress to any destination via any protocol.
 resource "aws_security_group" "gh_runner_lambda_egress" {
   name   = "${var.runner_configs.prefix}-gh-runner-lambda-egress-all"
-  vpc_id = var.network_configs.vpc_id
+  vpc_id = var.network_configs.lambda_vpc_id
 
   egress {
     from_port   = 0

--- a/modules/platform/ec2_deployment/variables.tf
+++ b/modules/platform/ec2_deployment/variables.tf
@@ -62,6 +62,7 @@ variable "network_configs" {
   type = object({
     vpc_id            = string
     subnet_ids        = list(string)
+    lambda_vpc_id     = string
     lambda_subnet_ids = list(string)
   })
 }

--- a/modules/platform/forge_runners/ec2_runners.tf
+++ b/modules/platform/forge_runners/ec2_runners.tf
@@ -21,6 +21,7 @@ module "ec2_runners" {
     vpc_id            = var.ec2_deployment_specs.vpc_id
     subnet_ids        = var.ec2_deployment_specs.subnet_ids
     lambda_subnet_ids = var.ec2_deployment_specs.lambda_subnet_ids
+    lambda_vpc_id     = var.ec2_deployment_specs.lambda_vpc_id
   }
 
   tenant_configs = {

--- a/modules/platform/forge_runners/variables.tf
+++ b/modules/platform/forge_runners/variables.tf
@@ -12,6 +12,7 @@ variable "ec2_deployment_specs" {
   type = object({
     lambda_subnet_ids = list(string)
     subnet_ids        = list(string)
+    lambda_vpc_id     = string
     vpc_id            = string
     runner_specs = map(object({
       ami_filter = object({


### PR DESCRIPTION
## Description

Allow to use different vpc and subnets that one use to deploy lambdas

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
