### PR TITLE
fix: add missing policy to terminate instances

### DIFF
--- a/modules/infra/cloud_custodian/main.tf
+++ b/modules/infra/cloud_custodian/main.tf
@@ -17,6 +17,7 @@ data "aws_iam_policy_document" "cloud_custodian_policy" {
       "ec2:DescribeSecurityGroupReferences",
       "ec2:DescribeVolumes",
       "ec2:DeleteVolume",
+      "ec2:TerminateInstances",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description

Add missing permission to allow cleanup broken packer build via cloud custodian

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
