### PR TITLE
fix: prevent runner pod evication and use the same instance type

### DIFF
--- a/docs/tenant-usage/index.md
+++ b/docs/tenant-usage/index.md
@@ -56,7 +56,7 @@ jobs:
     runs-on:
       - self-hosted
       - x64
-      - type: standard
+      - type:standard
 ```
 
 For Kubernetes pods, use:

--- a/docs/tenant-usage/renovatebot/index.md
+++ b/docs/tenant-usage/renovatebot/index.md
@@ -36,8 +36,8 @@ jobs:
     runs-on:
       - self-hosted
       - x64
-      - type: large
-      - env: ops-prod
+      - type:large
+      - env:ops-prod
 
     steps:
       - name: Checkout Repository

--- a/modules/core/arc/scale_set/template_files/k8s.yml.tftpl
+++ b/modules/core/arc/scale_set/template_files/k8s.yml.tftpl
@@ -20,6 +20,9 @@ containerMode:
 
 # with containerMode.type=kubernetes, we will populate the template.spec with following pod spec
 template:
+  metadata:
+    annotations:
+      karpenter.sh/do-not-evict: "true"
   spec:
     securityContext:
       fsGroup: 123

--- a/modules/infra/eks/karpenter.tf
+++ b/modules/infra/eks/karpenter.tf
@@ -98,7 +98,9 @@ locals {
     disk_throughput           = var.cluster_volume.throughput
   })
 
-  node_pool_manifest = templatefile("${path.module}/templates/node_pool.yaml.tpl", {})
+  node_pool_manifest = templatefile("${path.module}/templates/node_pool.yaml.tpl", {
+    instance_type = var.cluster_size.instance_type
+  })
 }
 
 resource "null_resource" "apply_ec2_node_class" {

--- a/modules/infra/eks/templates/node_pool.yaml.tpl
+++ b/modules/infra/eks/templates/node_pool.yaml.tpl
@@ -6,15 +6,10 @@ spec:
   template:
     spec:
       requirements:
-        - key: karpenter.k8s.aws/instance-family
+        - key: node.kubernetes.io/instance-type
           operator: In
           values:
-            - m6i
-            - m5
-            - c6i
-            - c5
-            - r6i
-            - r5
+            - ${instance_type}
         - key: kubernetes.io/arch
           operator: In
           values: ["amd64"]


### PR DESCRIPTION
## Description

Use annotation in runner pod to prevent pod to be evicted by karpenter. 
Use the same instance-type by default nodes and karpenter nodes

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
