### PR TITLE
fix: add missing input in splunk_otel_els example

### DIFF
--- a/examples/deployments/splunk-deployment/terragrunt/_global_settings/splunk_otel_eks.hcl
+++ b/examples/deployments/splunk-deployment/terragrunt/_global_settings/splunk_otel_eks.hcl
@@ -58,5 +58,6 @@ inputs = {
   splunk_otel_collector = local.eks_settings_data.locals.splunk_otel_collector
 
   # Misc
+  tags         = local.tags
   default_tags = local.default_tags
 }


### PR DESCRIPTION
## Description

Add input `tags` in example splunk_otel_eks

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
