### PR TITLE
chore: allow to use local cache in ec2 lambdas

### DIFF
--- a/examples/templates/tenant/tenant/config.yml
+++ b/examples/templates/tenant/tenant/config.yml
@@ -41,6 +41,9 @@ ec2_runner_specs:
     subnet_ids:
       - subnet-0abc1234def567890
     max_instances: <MAX_PARALLEL>
+    placement: <PLACEMENT>
+    license_specifications: <LICENSE_SPECIFICATIONS>
+    use_dedicated_host: <USE_DEDICATED_HOST>
     instance_types:
       - <AWS_INSTANCE_TYPE>
     pool_config:

--- a/examples/templates/tenant/tenant/config.yml
+++ b/examples/templates/tenant/tenant/config.yml
@@ -29,21 +29,17 @@ ec2_runner_specs:
     ami_kms_key_arn: <KMS_ARN>
     runner_os: <OS>
     runner_architecture: <ARCH>
-    runner_user: ubuntu
+    runner_user: <RUNNER_USER>
     placement:
-      host_resource_group_arn: arn:aws:resource-groups:eu-west-1:123456789012:group/acme-dedicated-hosts
+      host_resource_group_arn: <HOST_RESOURCE_GROUP_ARN>
       tenancy: host
-      availability_zone: eu-west-1b
-    license_specifications:
-      - license_configuration_arn: arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0
-    use_dedicated_host: true
-    vpc_id: vpc-0abc1234def567890
-    subnet_ids:
-      - subnet-0abc1234def567890
+      availability_zone: <AVAILABILITY_ZONE>
     max_instances: <MAX_PARALLEL>
-    placement: <PLACEMENT>
     license_specifications: <LICENSE_SPECIFICATIONS>
     use_dedicated_host: <USE_DEDICATED_HOST>
+    vpc_id: <VPC_ID>
+    subnet_ids:
+      - <SUBNET_ID>
     instance_types:
       - <AWS_INSTANCE_TYPE>
     pool_config:

--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -68,9 +68,9 @@ module "runners" {
   # Retention period for the logs in days.
   logging_retention_in_days = var.runner_configs.logging_retention_in_days
 
-  webhook_lambda_zip                = "/tmp/${var.runner_configs.prefix}/webhook.zip"
-  runner_binaries_syncer_lambda_zip = "/tmp/${var.runner_configs.prefix}/runner-binaries-syncer.zip"
-  runners_lambda_zip                = "/tmp/${var.runner_configs.prefix}/runners.zip"
+  webhook_lambda_zip                = "${data.external.download_lambdas.result.path}/webhook.zip"
+  runner_binaries_syncer_lambda_zip = "${data.external.download_lambdas.result.path}/runner-binaries-syncer.zip"
+  runners_lambda_zip                = "${data.external.download_lambdas.result.path}/runners.zip"
 
   # Configure the various types of runners we provide, along with on-demand
   # versus standby pools, etc.

--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -39,7 +39,7 @@ data "external" "download_lambdas" {
 
 
 module "runners" {
-  source = "git::https://github.com/edersonbrilhante/terraform-aws-github-runner.git//modules/multi-runner?ref=feat-ec2-dynamic-config"
+  source = "git::https://github.com/edersonbrilhante/terraform-aws-github-runner.git//modules/multi-runner?ref=feat-macos-support"
 
   aws_region = var.aws_region
 

--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -39,7 +39,7 @@ data "external" "download_lambdas" {
 
 
 module "runners" {
-  source = "git::https://github.com/edersonbrilhante/terraform-aws-github-runner.git//modules/multi-runner?ref=feat-macos-support"
+  source = "git::https://github.com/edersonbrilhante/terraform-aws-github-runner.git//modules/multi-runner?ref=feat-ec2-dynamic-config"
 
   aws_region = var.aws_region
 

--- a/modules/platform/ec2_deployment/scripts/download_lambdas.sh
+++ b/modules/platform/ec2_deployment/scripts/download_lambdas.sh
@@ -9,12 +9,18 @@ fi
 DOWNLOAD_PATH="$1"
 VERSION="$2"
 
-rm -rf "$DOWNLOAD_PATH"
-mkdir -p "$DOWNLOAD_PATH"
+if [ -n "$USE_CACHE" ] && [ -n "$CACHE_PATH" ] && [ -d "$CACHE_PATH" ]; then
+    echo "USE_CACHE is set and $CACHE_PATH exists, skipping download." >&2
+    DOWNLOAD_PATH="$CACHE_PATH"
+    VERSION="local-cache"
+else
+    rm -rf "$DOWNLOAD_PATH"
+    mkdir -p "$DOWNLOAD_PATH"
 
-# Download files to the specified director
-wget --no-verbose -P "$DOWNLOAD_PATH" "https://github.com/github-aws-runners/terraform-aws-github-runner/releases/download/${VERSION}/runner-binaries-syncer.zip"
-wget --no-verbose -P "$DOWNLOAD_PATH" "https://github.com/github-aws-runners/terraform-aws-github-runner/releases/download/${VERSION}/runners.zip"
-wget --no-verbose -P "$DOWNLOAD_PATH" "https://github.com/github-aws-runners/terraform-aws-github-runner/releases/download/${VERSION}/webhook.zip"
+    # Download files to the specified directory
+    wget --no-verbose -P "$DOWNLOAD_PATH" "https://github.com/github-aws-runners/terraform-aws-github-runner/releases/download/${VERSION}/runner-binaries-syncer.zip"
+    wget --no-verbose -P "$DOWNLOAD_PATH" "https://github.com/github-aws-runners/terraform-aws-github-runner/releases/download/${VERSION}/runners.zip"
+    wget --no-verbose -P "$DOWNLOAD_PATH" "https://github.com/github-aws-runners/terraform-aws-github-runner/releases/download/${VERSION}/webhook.zip"
+fi
 
-echo -n "{\"version\":\"${VERSION}\"}"
+echo -n "{\"version\":\"${VERSION}\",\"path\":\"${DOWNLOAD_PATH}\"}"


### PR DESCRIPTION
## Description

Adds support for using locally cached EC2 runner lambda artifacts during Terraform execution.

The `download_lambdas.sh` helper now checks `USE_CACHE` and `CACHE_PATH`; when both are set and the cache path exists, it skips downloading lambda artifacts and returns the cache path to Terraform. The EC2 deployment module now uses that returned path for the webhook, runner binaries syncer, and runners lambda zip files.

This also updates the tenant configuration template to use placeholders for runner user, VPC, subnet, placement, license specification, and dedicated host settings instead of hard-coded example values.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass