### PR TITLE
chore(deps): update infra module versions

### DIFF
--- a/modules/infra/eks/README.md
+++ b/modules/infra/eks/README.md
@@ -25,9 +25,9 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | 6.6.1 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 21.22.0 |
-| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 21.22.0 |
-| <a name="module_self_managed_node_group"></a> [self\_managed\_node\_group](#module\_self\_managed\_node\_group) | terraform-aws-modules/eks/aws//modules/self-managed-node-group | 21.22.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 21.23.0 |
+| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 21.23.0 |
+| <a name="module_self_managed_node_group"></a> [self\_managed\_node\_group](#module\_self\_managed\_node\_group) | terraform-aws-modules/eks/aws//modules/self-managed-node-group | 21.23.0 |
 
 ## Resources
 

--- a/modules/infra/eks/README.md
+++ b/modules/infra/eks/README.md
@@ -24,10 +24,10 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | 6.4.0 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 21.15.1 |
-| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 21.15.1 |
-| <a name="module_self_managed_node_group"></a> [self\_managed\_node\_group](#module\_self\_managed\_node\_group) | terraform-aws-modules/eks/aws//modules/self-managed-node-group | 21.15.1 |
+| <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | 6.6.1 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 21.22.0 |
+| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 21.22.0 |
+| <a name="module_self_managed_node_group"></a> [self\_managed\_node\_group](#module\_self\_managed\_node\_group) | terraform-aws-modules/eks/aws//modules/self-managed-node-group | 21.22.0 |
 
 ## Resources
 

--- a/modules/infra/eks/calico.tf
+++ b/modules/infra/eks/calico.tf
@@ -3,8 +3,8 @@ resource "null_resource" "patch_calico_installation" {
   provisioner "local-exec" {
     command = <<EOF
       kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} delete daemonset -n kube-system aws-node || true
-      kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/operator-crds.yaml --server-side
-      kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/tigera-operator.yaml --server-side
+      kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.0/manifests/operator-crds.yaml --server-side
+      kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.0/manifests/tigera-operator.yaml --server-side
 
       kubectl --context ${var.cluster_name}-${var.aws_profile}-${var.aws_region} apply -f - <<EOT
 apiVersion: operator.tigera.io/v1

--- a/modules/infra/eks/eks.tf
+++ b/modules/infra/eks/eks.tf
@@ -17,7 +17,7 @@ module "ebs_csi_irsa_role" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.22.0"
+  version = "21.23.0"
 
   name               = var.cluster_name
   kubernetes_version = var.cluster_version

--- a/modules/infra/eks/eks.tf
+++ b/modules/infra/eks/eks.tf
@@ -1,6 +1,6 @@
 module "ebs_csi_irsa_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version = "6.4.0"
+  version = "6.6.1"
 
   name                  = "${var.cluster_name}-${var.aws_region}-ebs-csi"
   use_name_prefix       = false
@@ -17,7 +17,7 @@ module "ebs_csi_irsa_role" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.15.1"
+  version = "21.22.0"
 
   name               = var.cluster_name
   kubernetes_version = var.cluster_version

--- a/modules/infra/eks/karpenter.tf
+++ b/modules/infra/eks/karpenter.tf
@@ -1,11 +1,13 @@
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "21.22.0"
+  version = "21.23.0"
 
   namespace    = "karpenter"
   cluster_name = var.cluster_name
 
   create_instance_profile = true
+
+  enable_inline_policy = true
 
   tags = merge(local.all_security_tags, { "calico_dependency" = local._wait_for_calico })
 

--- a/modules/infra/eks/karpenter.tf
+++ b/modules/infra/eks/karpenter.tf
@@ -1,6 +1,6 @@
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "21.15.1"
+  version = "21.22.0"
 
   namespace    = "karpenter"
   cluster_name = var.cluster_name
@@ -18,7 +18,7 @@ resource "null_resource" "karpenter" {
   depends_on = [module.eks]
 
   triggers = {
-    chart_version      = "1.8.3"
+    chart_version      = "1.12.0"
     service_account    = module.karpenter.service_account
     cluster_name       = module.eks.cluster_name
     cluster_endpoint   = module.eks.cluster_endpoint

--- a/modules/infra/eks/nodes.tf
+++ b/modules/infra/eks/nodes.tf
@@ -9,7 +9,7 @@ data "aws_ami" "eks_default" {
 }
 module "self_managed_node_group" {
   source  = "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
-  version = "21.22.0"
+  version = "21.23.0"
 
   name                = var.cluster_name
   cluster_name        = var.cluster_name

--- a/modules/infra/eks/nodes.tf
+++ b/modules/infra/eks/nodes.tf
@@ -9,7 +9,7 @@ data "aws_ami" "eks_default" {
 }
 module "self_managed_node_group" {
   source  = "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
-  version = "21.15.1"
+  version = "21.22.0"
 
   name                = var.cluster_name
   cluster_name        = var.cluster_name

--- a/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/README.md
+++ b/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/README.md
@@ -62,7 +62,7 @@ Both `token` and `room_id` keys are required. The function will prepend `Bearer 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_webex"></a> [webex](#module\_webex) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_webex"></a> [webex](#module\_webex) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/lambda.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/lambda.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_log_group" "webex" {
 
 module "webex" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = "webex-webhook-relay-destination-receiver"
   handler       = "handler.lambda_handler"

--- a/modules/integrations/github_webhook_relay_source/README.md
+++ b/modules/integrations/github_webhook_relay_source/README.md
@@ -72,7 +72,7 @@ curl -X POST "$(terraform output -raw webhook_endpoint)/webhook" \
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_validate_signature_lambda"></a> [validate\_signature\_lambda](#module\_validate\_signature\_lambda) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_validate_signature_lambda"></a> [validate\_signature\_lambda](#module\_validate\_signature\_lambda) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/integrations/github_webhook_relay_source/lambda.tf
+++ b/modules/integrations/github_webhook_relay_source/lambda.tf
@@ -1,6 +1,6 @@
 module "validate_signature_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = "${var.name_prefix}-validate-signature"
   handler       = "validate_signature.lambda_handler"

--- a/modules/integrations/splunk_aws_billing/README.md
+++ b/modules/integrations/splunk_aws_billing/README.md
@@ -20,9 +20,9 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cur_per_resource"></a> [cur\_per\_resource](#module\_cur\_per\_resource) | terraform-aws-modules/lambda/aws | 8.7.0 |
-| <a name="module_cur_per_resource_process"></a> [cur\_per\_resource\_process](#module\_cur\_per\_resource\_process) | terraform-aws-modules/lambda/aws | 8.7.0 |
-| <a name="module_cur_per_service"></a> [cur\_per\_service](#module\_cur\_per\_service) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_cur_per_resource"></a> [cur\_per\_resource](#module\_cur\_per\_resource) | terraform-aws-modules/lambda/aws | 8.8.0 |
+| <a name="module_cur_per_resource_process"></a> [cur\_per\_resource\_process](#module\_cur\_per\_resource\_process) | terraform-aws-modules/lambda/aws | 8.8.0 |
+| <a name="module_cur_per_service"></a> [cur\_per\_service](#module\_cur\_per\_service) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/integrations/splunk_aws_billing/billing_per_resource.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource.tf
@@ -4,7 +4,7 @@ locals {
 
 module "cur_per_resource" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = local.cur_per_resource_lambda_name
   description   = "Processes AWS Billing CUR reports per resource and sends data to Splunk"

--- a/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
@@ -4,7 +4,7 @@ locals {
 
 module "cur_per_resource_process" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = local.cur_per_resource_process_lambda_name
   description   = "Processes AWS billing data and sends to Splunk"

--- a/modules/integrations/splunk_aws_billing/billing_per_service.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_service.tf
@@ -4,7 +4,7 @@ locals {
 
 module "cur_per_service" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = local.cur_per_service_lambda_name
   description   = "Processes AWS Billing CUR reports per service and sends data to Splunk"

--- a/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/main.tf
+++ b/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/main.tf
@@ -1,6 +1,6 @@
 module "splunk_dm_metadata_ec2inst_pattern_tags_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   role_name = "SplunkDMMetadataEC2InstPatternTags-${var.region}"
 

--- a/modules/integrations/splunk_cloud_s3_runner_logs/README.md
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/README.md
@@ -18,7 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_splunk_s3_runner_logs_lambda"></a> [splunk\_s3\_runner\_logs\_lambda](#module\_splunk\_s3\_runner\_logs\_lambda) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_splunk_s3_runner_logs_lambda"></a> [splunk\_s3\_runner\_logs\_lambda](#module\_splunk\_s3\_runner\_logs\_lambda) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
@@ -4,7 +4,7 @@ locals {
 
 module "splunk_s3_runner_logs_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = "${local.prefix_lambda}-lambda-${var.aws_region}"
   handler       = "splunk_s3_runner_logs.lambda_handler"

--- a/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/README.md
+++ b/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/README.md
@@ -16,7 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2_update_runner_ssm_ami_lambda"></a> [ec2\_update\_runner\_ssm\_ami\_lambda](#module\_ec2\_update\_runner\_ssm\_ami\_lambda) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_ec2_update_runner_ssm_ami_lambda"></a> [ec2\_update\_runner\_ssm\_ami\_lambda](#module\_ec2\_update\_runner\_ssm\_ami\_lambda) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/main.tf
+++ b/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/main.tf
@@ -1,6 +1,6 @@
 module "ec2_update_runner_ssm_ami_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = "${var.prefix}-ec2-update-runner-ssm-ami"
   handler       = "ec2_update_runner_ssm_ami.lambda_handler"

--- a/modules/platform/ec2_deployment/ec2_update_runner_tags/README.md
+++ b/modules/platform/ec2_deployment/ec2_update_runner_tags/README.md
@@ -16,7 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2_update_runner_tags_lambda"></a> [ec2\_update\_runner\_tags\_lambda](#module\_ec2\_update\_runner\_tags\_lambda) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_ec2_update_runner_tags_lambda"></a> [ec2\_update\_runner\_tags\_lambda](#module\_ec2\_update\_runner\_tags\_lambda) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/platform/ec2_deployment/ec2_update_runner_tags/main.tf
+++ b/modules/platform/ec2_deployment/ec2_update_runner_tags/main.tf
@@ -1,6 +1,6 @@
 module "ec2_update_runner_tags_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = "${var.prefix}-ec2-update-runner-tags"
   handler       = "ec2_update_runner_tags.lambda_handler"

--- a/modules/platform/forge_runners/forge_trust_validator/README.md
+++ b/modules/platform/forge_runners/forge_trust_validator/README.md
@@ -18,7 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_forge_trust_validator_lambda"></a> [forge\_trust\_validator\_lambda](#module\_forge\_trust\_validator\_lambda) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_forge_trust_validator_lambda"></a> [forge\_trust\_validator\_lambda](#module\_forge\_trust\_validator\_lambda) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/platform/forge_runners/forge_trust_validator/main.tf
+++ b/modules/platform/forge_runners/forge_trust_validator/main.tf
@@ -1,6 +1,6 @@
 module "forge_trust_validator_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = "${var.prefix}-forge-trust-validator"
   handler       = "forge_trust_validator.lambda_handler"

--- a/modules/platform/forge_runners/github_actions_job_logs/README.md
+++ b/modules/platform/forge_runners/github_actions_job_logs/README.md
@@ -136,8 +136,8 @@ See parent repository license.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_job_log_archiver"></a> [job\_log\_archiver](#module\_job\_log\_archiver) | terraform-aws-modules/lambda/aws | 8.7.0 |
-| <a name="module_job_log_dispatcher"></a> [job\_log\_dispatcher](#module\_job\_log\_dispatcher) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_job_log_archiver"></a> [job\_log\_archiver](#module\_job\_log\_archiver) | terraform-aws-modules/lambda/aws | 8.8.0 |
+| <a name="module_job_log_dispatcher"></a> [job\_log\_dispatcher](#module\_job\_log\_dispatcher) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/platform/forge_runners/github_actions_job_logs/job_log_archiver.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/job_log_archiver.tf
@@ -5,7 +5,7 @@ locals {
 
 module "job_log_archiver" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = local.resource_name_archiver
   handler       = "job_log_archiver.lambda_handler"

--- a/modules/platform/forge_runners/github_actions_job_logs/job_log_dispatcher.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/job_log_dispatcher.tf
@@ -4,7 +4,7 @@ locals {
 
 module "job_log_dispatcher" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = local.resource_name_dispatcher
   handler       = "job_log_dispatcher.lambda_handler"

--- a/modules/platform/forge_runners/github_app_runner_group/README.md
+++ b/modules/platform/forge_runners/github_app_runner_group/README.md
@@ -16,7 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_register_github_app_runner_group_lambda"></a> [register\_github\_app\_runner\_group\_lambda](#module\_register\_github\_app\_runner\_group\_lambda) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_register_github_app_runner_group_lambda"></a> [register\_github\_app\_runner\_group\_lambda](#module\_register\_github\_app\_runner\_group\_lambda) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/platform/forge_runners/github_app_runner_group/main.tf
+++ b/modules/platform/forge_runners/github_app_runner_group/main.tf
@@ -1,6 +1,6 @@
 module "register_github_app_runner_group_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = "${var.prefix}-register-github-app-runner-group"
   handler       = "github_app_runner_group.lambda_handler"

--- a/modules/platform/forge_runners/github_global_lock/README.md
+++ b/modules/platform/forge_runners/github_global_lock/README.md
@@ -16,7 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_clean_global_lock_lambda"></a> [clean\_global\_lock\_lambda](#module\_clean\_global\_lock\_lambda) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_clean_global_lock_lambda"></a> [clean\_global\_lock\_lambda](#module\_clean\_global\_lock\_lambda) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/platform/forge_runners/github_global_lock/main.tf
+++ b/modules/platform/forge_runners/github_global_lock/main.tf
@@ -70,7 +70,7 @@ resource "aws_iam_policy" "dynamodb_policy" {
 ## GitHub Clean Global Lock Lambda
 module "clean_global_lock_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = "${var.prefix}-clean-global-lock"
   handler       = "github_clean_global_lock.lambda_handler"

--- a/modules/platform/forge_runners/redrive_deadletter/README.md
+++ b/modules/platform/forge_runners/redrive_deadletter/README.md
@@ -16,7 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_redrive_deadletter_lambda"></a> [redrive\_deadletter\_lambda](#module\_redrive\_deadletter\_lambda) | terraform-aws-modules/lambda/aws | 8.7.0 |
+| <a name="module_redrive_deadletter_lambda"></a> [redrive\_deadletter\_lambda](#module\_redrive\_deadletter\_lambda) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 

--- a/modules/platform/forge_runners/redrive_deadletter/main.tf
+++ b/modules/platform/forge_runners/redrive_deadletter/main.tf
@@ -1,6 +1,6 @@
 module "redrive_deadletter_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "8.7.0"
+  version = "8.8.0"
 
   function_name = "${var.prefix}-redrive-deadletter"
   handler       = "redrive_deadletter.lambda_handler"


### PR DESCRIPTION
## Description

Updates infrastructure dependency versions across Forge modules.

This update is intended for EKS `1.35`; clusters must be upgraded to EKS `1.35` before adopting this dependency set.

- Calico manifests from `v3.31.0` to `v3.32.0`
- Karpenter Helm chart from `1.8.3` to `1.12.0`
- `terraform-aws-modules/eks/aws` from `21.15.1` to `21.22.0`
- `terraform-aws-modules/iam/aws` from `6.4.0` to `6.6.1`
- `terraform-aws-modules/lambda/aws` from `8.7.0` to `8.8.0`

Also updates the generated module version tables in affected README files.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [x] Other: dependency updates

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass