### PR TITLE
chore(deps): update helm release splunk-otel-collector to v0.153.0

### DIFF
--- a/modules/integrations/splunk_otel_eks/otel.tf
+++ b/modules/integrations/splunk_otel_eks/otel.tf
@@ -2,7 +2,7 @@ resource "helm_release" "splunk_otel_collector" {
   name             = "splunk-otel-collector"
   repository       = "https://signalfx.github.io/splunk-otel-collector-chart"
   chart            = "splunk-otel-collector"
-  version          = "0.145.1"
+  version          = "0.153.0"
   namespace        = "splunk-otel-collector"
   create_namespace = true
 
@@ -16,16 +16,28 @@ resource "helm_release" "splunk_otel_collector" {
       value = "eks"
     },
     {
-      name  = "splunkObservability.accessToken"
-      value = data.aws_secretsmanager_secret_version.secrets["splunk_o11y_ingest_token_eks"].secret_string
-    },
-    {
       name  = "clusterName"
       value = var.cluster_name
     },
     {
       name  = "splunkObservability.realm"
       value = var.splunk_otel_collector.splunk_observability_realm
+    },
+    {
+      name  = "splunkObservability.accessToken"
+      value = data.aws_secretsmanager_secret_version.secrets["splunk_o11y_ingest_token_eks"].secret_string
+    },
+    {
+      name  = "splunkObservability.ingestUrl"
+      value = var.splunk_otel_collector.splunk_observability_ingest_url
+    },
+    {
+      name  = "splunkObservability.apiUrl"
+      value = var.splunk_otel_collector.splunk_observability_api_url
+    },
+    {
+      name  = "splunkObservability.profilingEnabled"
+      value = var.splunk_otel_collector.splunk_observability_profiling
     },
     {
       name  = "splunkPlatform.endpoint"
@@ -42,10 +54,6 @@ resource "helm_release" "splunk_otel_collector" {
     {
       name  = "gateway.enabled"
       value = var.splunk_otel_collector.gateway
-    },
-    {
-      name  = "splunkObservability.profilingEnabled"
-      value = var.splunk_otel_collector.splunk_observability_profiling
     },
     {
       name  = "environment"

--- a/modules/integrations/splunk_otel_eks/variables.tf
+++ b/modules/integrations/splunk_otel_eks/variables.tf
@@ -16,13 +16,15 @@ variable "cluster_name" {
 variable "splunk_otel_collector" {
   description = "Configuration for the Splunk OpenTelemetry Collector"
   type = object({
-    splunk_observability_realm     = string
-    splunk_platform_endpoint       = string
-    splunk_platform_index          = string
-    gateway                        = bool
-    splunk_observability_profiling = bool
-    environment                    = string
-    discovery                      = bool
+    splunk_platform_endpoint        = string
+    splunk_platform_index           = string
+    gateway                         = bool
+    environment                     = string
+    discovery                       = bool
+    splunk_observability_realm      = string
+    splunk_observability_ingest_url = string
+    splunk_observability_api_url    = string
+    splunk_observability_profiling  = bool
   })
 }
 


### PR DESCRIPTION
## Description

Updates the `splunk-otel-collector` Helm release to `v0.153.0`.

This keeps the Splunk OpenTelemetry Collector deployment current with the upstream chart release and pulls in the latest chart fixes, compatibility updates, and collector packaging changes.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other: dependency update

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass