### PR TITLE
chore(eks): ignore addon version drift

### DIFF
--- a/modules/infra/eks/addons.tf
+++ b/modules/infra/eks/addons.tf
@@ -27,6 +27,10 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
     delete = "60m"
   }
 
+  lifecycle {
+    ignore_changes = [addon_version]
+  }
+
   depends_on = [module.self_managed_node_group]
 }
 
@@ -48,6 +52,10 @@ resource "aws_eks_addon" "eks_pod_identity_agent" {
     }
   })
 
+  lifecycle {
+    ignore_changes = [addon_version]
+  }
+
   depends_on = [module.self_managed_node_group]
 }
 
@@ -59,6 +67,10 @@ resource "aws_eks_addon" "coredns" {
     create = "60m"
     update = "60m"
     delete = "60m"
+  }
+
+  lifecycle {
+    ignore_changes = [addon_version]
   }
 
   depends_on = [module.self_managed_node_group]


### PR DESCRIPTION
## Description

Prevents Terraform from automatically upgrading managed EKS addons when AWS publishes a newer compatible addon version.

The EKS addon resources still use `aws_eks_addon_version` to select the version at creation time, but now ignore subsequent drift on `addon_version`. This keeps existing clusters pinned to their currently installed addon versions unless an addon upgrade is intentionally performed.

Affected addons:

- `aws-ebs-csi-driver`
- `eks-pod-identity-agent`
- `coredns`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other: Terraform lifecycle change

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass