### PR TITLE
fix(terraform): use key_schema for DynamoDB GSIs

### DIFF
--- a/modules/core/arc/scale_set/versions.tf
+++ b/modules/core/arc/scale_set/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/core/arc/scale_set_controller/versions.tf
+++ b/modules/core/arc/scale_set_controller/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/core/arc/versions.tf
+++ b/modules/core/arc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     external = {
       source  = "hashicorp/external"

--- a/modules/infra/ami_policy/versions.tf
+++ b/modules/infra/ami_policy/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/infra/ami_sharing/versions.tf
+++ b/modules/infra/ami_sharing/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/infra/cloud_custodian/versions.tf
+++ b/modules/infra/cloud_custodian/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/infra/cloud_formation/versions.tf
+++ b/modules/infra/cloud_formation/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/infra/ecr/versions.tf
+++ b/modules/infra/ecr/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/infra/eks/versions.tf
+++ b/modules/infra/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/infra/forge_subscription/version.tf
+++ b/modules/infra/forge_subscription/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/infra/opt_in_regions/versions.tf
+++ b/modules/infra/opt_in_regions/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/infra/service_linked_roles/versions.tf
+++ b/modules/infra/service_linked_roles/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/infra/storage/versions.tf
+++ b/modules/infra/storage/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/integrations/github_webhook_relay_destination/versions.tf
+++ b/modules/integrations/github_webhook_relay_destination/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     external = {
       source  = "hashicorp/external"

--- a/modules/integrations/github_webhook_relay_destination_receivers/versions.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/versions.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     time = {
       source  = "hashicorp/time"

--- a/modules/integrations/github_webhook_relay_source/versions.tf
+++ b/modules/integrations/github_webhook_relay_source/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/integrations/splunk_aws_billing/versions.tf
+++ b/modules/integrations/splunk_aws_billing/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     external = {
       source  = "hashicorp/external"

--- a/modules/integrations/splunk_cloud_conf_shared/versions.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     splunk = {
       source  = "splunk/splunk"

--- a/modules/integrations/splunk_cloud_data_manager/data_input/versions.tf
+++ b/modules/integrations/splunk_cloud_data_manager/data_input/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/versions.tf
+++ b/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/integrations/splunk_cloud_data_manager/versions.tf
+++ b/modules/integrations/splunk_cloud_data_manager/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/integrations/splunk_cloud_data_manager_common/versions.tf
+++ b/modules/integrations/splunk_cloud_data_manager_common/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     external = {
       source  = "hashicorp/external"

--- a/modules/integrations/splunk_cloud_s3_runner_logs/versions.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     external = {
       source  = "hashicorp/external"

--- a/modules/integrations/splunk_o11y_aws_integration/versions.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/integrations/splunk_o11y_aws_integration_common/versions.tf
+++ b/modules/integrations/splunk_o11y_aws_integration_common/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     signalfx = {
       source  = "splunk-terraform/signalfx"

--- a/modules/integrations/splunk_o11y_conf_shared/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     signalfx = {
       source  = "splunk-terraform/signalfx"

--- a/modules/integrations/splunk_otel_eks/versions.tf
+++ b/modules/integrations/splunk_otel_eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/integrations/splunk_secrets/versions.tf
+++ b/modules/integrations/splunk_secrets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     time = {
       source  = "hashicorp/time"

--- a/modules/integrations/teleport/tenant/versions.tf
+++ b/modules/integrations/teleport/tenant/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/integrations/teleport/versions.tf
+++ b/modules/integrations/teleport/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/versions.tf
+++ b/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/platform/ec2_deployment/ec2_update_runner_tags/versions.tf
+++ b/modules/platform/ec2_deployment/ec2_update_runner_tags/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/platform/ec2_deployment/versions.tf
+++ b/modules/platform/ec2_deployment/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     external = {
       source  = "hashicorp/external"

--- a/modules/platform/forge_runners/forge_trust_validator/versions.tf
+++ b/modules/platform/forge_runners/forge_trust_validator/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/platform/forge_runners/github_actions_job_logs/versions.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/platform/forge_runners/github_app_runner_group/versions.tf
+++ b/modules/platform/forge_runners/github_app_runner_group/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/platform/forge_runners/github_global_lock/main.tf
+++ b/modules/platform/forge_runners/github_global_lock/main.tf
@@ -21,14 +21,22 @@ resource "aws_dynamodb_table" "lock_table" {
 
   global_secondary_index {
     name            = "workflow_run_id_index"
-    hash_key        = "workflow_run_id"
     projection_type = "ALL"
+
+    key_schema {
+      attribute_name = "workflow_run_id"
+      key_type       = "HASH"
+    }
   }
 
   global_secondary_index {
     name            = "workflow_run_attempt_index"
-    hash_key        = "workflow_run_attempt"
     projection_type = "ALL"
+
+    key_schema {
+      attribute_name = "workflow_run_attempt"
+      key_type       = "HASH"
+    }
   }
 
   ttl {

--- a/modules/platform/forge_runners/github_global_lock/versions.tf
+++ b/modules/platform/forge_runners/github_global_lock/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/platform/forge_runners/github_webhook_relay/versions.tf
+++ b/modules/platform/forge_runners/github_webhook_relay/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/platform/forge_runners/redrive_deadletter/versions.tf
+++ b/modules/platform/forge_runners/redrive_deadletter/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
   }
 

--- a/modules/platform/forge_runners/versions.tf
+++ b/modules/platform/forge_runners/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.25"
+      version = ">= 6.47"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## Description

Updates the GitHub global lock DynamoDB table configuration to replace deprecated `hash_key` arguments on global secondary indexes with `key_schema` blocks.

This keeps the existing GSI partition keys unchanged (`workflow_run_id` and `workflow_run_attempt`) while aligning the module with the AWS provider 6.x DynamoDB schema. The table-level primary key remains `hash_key = "lock_id"` because `key_schema` is only supported for the GSI configuration in this provider schema.

Technical reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table.html

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass