### PR TITLE
fix: adjust migration script for terragrunt v1

### DIFF
--- a/scripts/reinstall-eks-with-deps.sh
+++ b/scripts/reinstall-eks-with-deps.sh
@@ -1,42 +1,107 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Function to apply modules and their dependencies
+find_stack_root() {
+    local dir="$1"
+
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/root.hcl" ]]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+
+        dir=$(dirname "$dir")
+    done
+
+    printf '%s\n' "$1"
+}
+
+terragrunt_find_filter() {
+    local stack_root="$1"
+    local filter="$2"
+    local stderr_file
+    local status
+
+    stderr_file=$(mktemp "${TMPDIR:-/tmp}/terragrunt-find.XXXXXX")
+
+    if terragrunt find --working-dir "$stack_root" --filter "$filter" 2>"$stderr_file"; then
+        if [[ -s "$stderr_file" ]]; then
+            cat "$stderr_file" >&2
+        fi
+        rm -f "$stderr_file"
+        return 0
+    fi
+
+    status=$?
+
+    if grep -q "filter-flag" "$stderr_file"; then
+        rm -f "$stderr_file"
+        terragrunt find --experiment=filter-flag --working-dir "$stack_root" --filter "$filter"
+        return $?
+    fi
+
+    cat "$stderr_file" >&2
+    rm -f "$stderr_file"
+    return "$status"
+}
+
+find_dependents() {
+    local orig_dir="$1"
+    local stack_root
+    local unit_name
+    local dep
+
+    stack_root="${TG_STACK_ROOT:-$(find_stack_root "$orig_dir")}"
+    stack_root=$(cd "$stack_root" && pwd -P)
+    unit_name=$(basename "$orig_dir")
+
+    while IFS= read -r dep; do
+        [[ -z "$dep" ]] && continue
+
+        case "$dep" in
+        /*)
+            printf '%s\n' "$dep"
+            ;;
+        .)
+            printf '%s\n' "$stack_root"
+            ;;
+        *)
+            printf '%s/%s\n' "$stack_root" "$dep"
+            ;;
+        esac
+    done < <(terragrunt_find_filter "$stack_root" "...^${unit_name}")
+}
+
+# Function to apply modules and their dependents
 apply_with_deps() {
     local orig_dir
-    orig_dir=$(pwd)
-    local deps
-
-    # Get dependent modules (absolute paths)
-    deps=$(terragrunt render --format json | jq -r '.dependent_modules[]')
+    local dep
+    orig_dir=$(pwd -P)
 
     echo ">>> Applying main module: $orig_dir"
     terragrunt apply -auto-approve --non-interactive
 
-    for dep in $deps; do
-        echo ">>> Applying dependency: $dep"
+    while IFS= read -r dep; do
+        echo ">>> Applying dependent module: $dep"
         pushd "$dep" >/dev/null
         terragrunt apply -auto-approve --non-interactive
         popd >/dev/null
-    done
+    done < <(find_dependents "$orig_dir")
 }
 
-# Function to destroy modules and their dependencies
+# Function to destroy modules and their dependents
 destroy_with_deps() {
     local orig_dir
-    orig_dir=$(pwd)
-    local deps
+    local dep
+    orig_dir=$(pwd -P)
 
-    # Get dependent modules (absolute paths)
-    deps=$(terragrunt render --format json | jq -r '.dependent_modules[]')
-
-    # Destroy dependencies first (reverse order)
-    for dep in $deps; do
-        echo ">>> Destroying dependency: $dep"
+    # Destroy dependents before the current module.
+    while IFS= read -r dep; do
+        echo ">>> Destroying dependent module: $dep"
         pushd "$dep" >/dev/null
         terragrunt destroy -auto-approve --non-interactive
         popd >/dev/null
-    done
+    done < <(find_dependents "$orig_dir")
 
     echo ">>> Destroying current module: $orig_dir"
     terragrunt destroy -auto-approve --non-interactive
@@ -45,8 +110,8 @@ destroy_with_deps() {
 # Function to show usage
 usage() {
     echo "Usage: $0 {create|destroy}"
-    echo "  create  - Apply main module and its dependencies"
-    echo "  destroy - Destroy dependencies and main module"
+    echo "  create  - Apply main module and its dependents"
+    echo "  destroy - Destroy dependents and main module"
     exit 1
 }
 


### PR DESCRIPTION
## Description

Adjusts the tenant migration script for Terragrunt v1 compatibility.

This change removes the migration script’s dependency on `terragrunt render --format json` for runtime context and derives the required values directly from tenant and parent configuration files instead:

- reads `arc_cluster_name` from `config.yml` or `config.yaml`
- derives `aws_profile` from `_global_settings/_global.yaml` and `_environment_wide_settings/_environment.yaml`
- derives `aws_region` from the `regions/<region>` path segment
- adds validation for missing config files, parent settings, tenant directory, and region path
- removes a stray early `return` that made the final migration step unreachable

Also updates the EKS reinstall helper to stop reading `.dependent_modules[]` from `terragrunt render --format json`, replacing it with `terragrunt find --filter`.

Technical reference: [Terragrunt v1.0 breaking change: render --format=json no longer discovers dependents by default](https://github.com/gruntwork-io/terragrunt/releases/tag/v1.0.0)

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass