### PR TITLE
fix: add python script parse terragrunt list

### DIFF
--- a/scripts/reinstall-eks-with-deps.sh
+++ b/scripts/reinstall-eks-with-deps.sh
@@ -1,11 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+DEPS_SCRIPT="${TG_DEPS_SCRIPT:-${SCRIPT_DIR}/terragrunt-deps.py}"
+PYTHON_BIN="${PYTHON_BIN:-python3.12}"
+
+debug() {
+    case "${DEBUG:-}" in
+    1 | true | TRUE | yes | YES | on | ON)
+        printf 'DEBUG: %s\n' "$*" >&2
+        ;;
+    esac
+}
+
 find_stack_root() {
     local dir="$1"
 
+    debug "Looking for Terragrunt stack root from: $dir"
+
     while [[ "$dir" != "/" ]]; do
         if [[ -f "$dir/root.hcl" ]]; then
+            debug "Found Terragrunt stack root: $dir"
             printf '%s\n' "$dir"
             return 0
         fi
@@ -13,63 +28,54 @@ find_stack_root() {
         dir=$(dirname "$dir")
     done
 
+    debug "No root.hcl found; using module dir as stack root: $1"
     printf '%s\n' "$1"
-}
-
-terragrunt_find_filter() {
-    local stack_root="$1"
-    local filter="$2"
-    local stderr_file
-    local status
-
-    stderr_file=$(mktemp "${TMPDIR:-/tmp}/terragrunt-find.XXXXXX")
-
-    if terragrunt find --working-dir "$stack_root" --filter "$filter" 2>"$stderr_file"; then
-        if [[ -s "$stderr_file" ]]; then
-            cat "$stderr_file" >&2
-        fi
-        rm -f "$stderr_file"
-        return 0
-    fi
-
-    status=$?
-
-    if grep -q "filter-flag" "$stderr_file"; then
-        rm -f "$stderr_file"
-        terragrunt find --experiment=filter-flag --working-dir "$stack_root" --filter "$filter"
-        return $?
-    fi
-
-    cat "$stderr_file" >&2
-    rm -f "$stderr_file"
-    return "$status"
 }
 
 find_dependents() {
     local orig_dir="$1"
     local stack_root
-    local unit_name
+    local deps_json
+    local deps_output
+    local deps_parser
     local dep
+    local normalized_dep
 
     stack_root="${TG_STACK_ROOT:-$(find_stack_root "$orig_dir")}"
     stack_root=$(cd "$stack_root" && pwd -P)
-    unit_name=$(basename "$orig_dir")
+
+    debug "Finding dependents for module directory: $orig_dir"
+    debug "Using Terragrunt stack root: $stack_root"
+    debug "Using dependency script: $DEPS_SCRIPT"
+
+    deps_json=$(
+        "$PYTHON_BIN" "$DEPS_SCRIPT" "$orig_dir" \
+            --working-dir "$stack_root"
+    )
+
+    deps_parser='import json, sys; '
+    deps_parser+='sys.stdout.write("\n".join('
+    deps_parser+='json.load(sys.stdin).get("deps", [])))'
+    deps_output=$("$PYTHON_BIN" -c "$deps_parser" <<<"$deps_json")
 
     while IFS= read -r dep; do
         [[ -z "$dep" ]] && continue
 
         case "$dep" in
         /*)
-            printf '%s\n' "$dep"
+            normalized_dep="$dep"
             ;;
         .)
-            printf '%s\n' "$stack_root"
+            normalized_dep="$stack_root"
             ;;
         *)
-            printf '%s/%s\n' "$stack_root" "$dep"
+            normalized_dep="${stack_root}/${dep}"
             ;;
         esac
-    done < <(terragrunt_find_filter "$stack_root" "...^${unit_name}")
+
+        debug "Found dependent '${dep}', normalized path: ${normalized_dep}"
+        printf '%s\n' "$normalized_dep"
+    done <<<"$deps_output"
 }
 
 # Function to apply modules and their dependents
@@ -78,14 +84,17 @@ apply_with_deps() {
     local dep
     orig_dir=$(pwd -P)
 
+    debug "Starting create/apply workflow from: $orig_dir"
     echo ">>> Applying main module: $orig_dir"
     terragrunt apply -auto-approve --non-interactive
 
     while IFS= read -r dep; do
+        debug "Applying dependent module from: $dep"
         echo ">>> Applying dependent module: $dep"
         pushd "$dep" >/dev/null
         terragrunt apply -auto-approve --non-interactive
         popd >/dev/null
+        debug "Returned to original module directory: $orig_dir"
     done < <(find_dependents "$orig_dir")
 }
 
@@ -95,12 +104,16 @@ destroy_with_deps() {
     local dep
     orig_dir=$(pwd -P)
 
+    debug "Starting destroy workflow from: $orig_dir"
+
     # Destroy dependents before the current module.
     while IFS= read -r dep; do
+        debug "Destroying dependent module from: $dep"
         echo ">>> Destroying dependent module: $dep"
         pushd "$dep" >/dev/null
         terragrunt destroy -auto-approve --non-interactive
         popd >/dev/null
+        debug "Returned to original module directory: $orig_dir"
     done < <(find_dependents "$orig_dir")
 
     echo ">>> Destroying current module: $orig_dir"
@@ -112,6 +125,9 @@ usage() {
     echo "Usage: $0 {create|destroy}"
     echo "  create  - Apply main module and its dependents"
     echo "  destroy - Destroy dependents and main module"
+    echo "  DEBUG=1 - Print debug output to stderr"
+    echo "  PYTHON_BIN=python3.12 - Python binary for deps"
+    echo "  TG_DEPS_SCRIPT=<path> - Override dependency resolver script"
     exit 1
 }
 

--- a/scripts/terragrunt-deps.py
+++ b/scripts/terragrunt-deps.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3.12
-"""Print child dependencies from `terragrunt list -T --dag` tree output."""
+"""Return direct Terragrunt DAG dependents as JSON."""
 
 from __future__ import annotations
 
@@ -7,111 +7,40 @@ import argparse
 import json
 import subprocess
 import sys
-from collections import defaultdict
 from pathlib import Path
 
 BRANCH_MARKERS = ('├──', '└──', '╰──', '+--', '`--', '\\--')
 
 
-class DagError(Exception):
-    """Raised when the requested DAG path cannot be resolved."""
-
-
-def normalize_path(path: str) -> str:
-    normalized = path.strip().rstrip('/')
-    while normalized.startswith('./'):
-        normalized = normalized[2:]
-    return normalized
+def normalize(path: str) -> str:
+    path = path.strip().rstrip('/')
+    while path.startswith('./'):
+        path = path[2:]
+    return path
 
 
 def parse_tree_line(line: str) -> tuple[int, str] | None:
     for marker in BRANCH_MARKERS:
-        marker_at = line.find(marker)
-        if marker_at == -1:
+        marker_index = line.find(marker)
+        if marker_index == -1:
             continue
 
-        path = line[marker_at + len(marker):].strip()
-        if not path:
-            return None
-
-        prefix = line[:marker_at].replace('\t', '    ')
+        prefix = line[:marker_index].replace('\t', '    ')
+        path = line[marker_index + len(marker):].strip()
         return len(prefix) // 4, path
 
     return None
 
 
-def append_unique(items: list[str], item: str) -> None:
-    if item not in items:
-        items.append(item)
+def read_dag(args: argparse.Namespace) -> list[str]:
+    if args.dag_file:
+        if args.dag_file == '-':
+            return sys.stdin.read().splitlines()
+        return Path(args.dag_file).read_text(encoding='utf-8').splitlines()
 
-
-class TerragruntDag:
-    def __init__(self) -> None:
-        self.children: dict[str, list[str]] = defaultdict(list)
-        self.original_paths: dict[str, str] = {}
-
-    @classmethod
-    def from_lines(cls, lines: list[str]) -> TerragruntDag:
-        dag = cls()
-        stack: list[str] = []
-
-        for line in lines:
-            parsed = parse_tree_line(line)
-            if parsed is None:
-                continue
-
-            depth, path = parsed
-            key = normalize_path(path)
-            if not key:
-                continue
-
-            dag.original_paths.setdefault(key, path)
-            dag.children.setdefault(key, [])
-
-            if depth > len(stack):
-                raise DagError(
-                    f"cannot parse tree line with skipped depth: {line}")
-
-            stack = stack[:depth]
-            if depth > 0:
-                append_unique(dag.children[stack[depth - 1]], key)
-
-            stack.append(key)
-
-        return dag
-
-    def resolve(self, path: str) -> str:
-        target = normalize_path(path)
-        if target in self.original_paths:
-            return target
-
-        suffix_matches = [
-            key for key in self.original_paths
-            if key.endswith(f"/{target}") or target.endswith(f"/{key}")
-        ]
-
-        if not suffix_matches:
-            raise DagError(f"path not found in DAG: {path}")
-        if len(suffix_matches) > 1:
-            matches = '\n'.join(
-                f"  {self.original_paths[key]}" for key in suffix_matches
-            )
-            raise DagError(f"path is ambiguous: {path}\nMatches:\n{matches}")
-
-        return suffix_matches[0]
-
-
-def read_dag_file(path: str) -> list[str]:
-    if path == '-':
-        return sys.stdin.read().splitlines()
-
-    return Path(path).read_text(encoding='utf-8').splitlines()
-
-
-def run_terragrunt_list(terragrunt_bin: str, working_dir: str | None) -> list[str]:
-    command = [terragrunt_bin, 'list', '-T', '--dag']
-    if working_dir:
-        command.extend(['--working-dir', working_dir])
+    command = [args.terragrunt_bin, 'list', '-T', '--dag']
+    if args.working_dir:
+        command.extend(['--working-dir', args.working_dir])
 
     result = subprocess.run(
         command,
@@ -122,118 +51,79 @@ def run_terragrunt_list(terragrunt_bin: str, working_dir: str | None) -> list[st
     )
     if result.returncode != 0:
         if result.stderr:
-            sys.stderr.write(result.stderr)
-        raise DagError(f"terragrunt exited with status {result.returncode}")
+            print(result.stderr, end='', file=sys.stderr)
+        raise RuntimeError(f'terragrunt exited with {result.returncode}')
 
     return result.stdout.splitlines()
 
 
-def collect_paths(dag: TerragruntDag, root: str, transitive: bool) -> list[str]:
-    paths: list[str] = []
-    seen: set[str] = set()
+def build_dependency_map(
+    lines: list[str],
+) -> tuple[dict[str, list[str]], dict[str, str]]:
+    children: dict[str, list[str]] = {}
+    original_paths: dict[str, str] = {}
+    stack: list[str] = []
 
-    def visit(parent: str) -> None:
-        for child in dag.children[parent]:
-            if child in seen:
-                continue
-            seen.add(child)
-            paths.append(dag.original_paths[child])
-            if transitive:
-                visit(child)
+    for line in lines:
+        parsed = parse_tree_line(line)
+        if parsed is None:
+            continue
 
-    visit(root)
-    return paths
+        depth, original_path = parsed
+        path = normalize(original_path)
+        if not path:
+            continue
+        if depth > len(stack):
+            raise RuntimeError(f'cannot parse DAG line: {line}')
 
+        children.setdefault(path, [])
+        original_paths.setdefault(path, original_path)
 
-def format_tree(
-    dag: TerragruntDag,
-    root: str,
-    *,
-    include_root: bool,
-    transitive: bool,
-) -> list[str]:
-    lines: list[str] = []
-    active: set[str] = set()
+        stack = stack[:depth]
+        if depth > 0 and path not in children[stack[-1]]:
+            children[stack[-1]].append(path)
+        stack.append(path)
 
-    if include_root:
-        lines.append(dag.original_paths[root])
-
-    def visit(parent: str, prefix: str) -> None:
-        if parent in active:
-            lines.append(f"{prefix}╰── [cycle] {dag.original_paths[parent]}")
-            return
-
-        active.add(parent)
-        children = dag.children[parent]
-        for index, child in enumerate(children):
-            is_last = index == len(children) - 1
-            branch = '╰──' if is_last else '├──'
-            lines.append(f"{prefix}{branch} {dag.original_paths[child]}")
-
-            if transitive and dag.children[child]:
-                child_prefix = '    ' if is_last else '│   '
-                visit(child, f"{prefix}{child_prefix}")
-
-        active.remove(parent)
-
-    visit(root, '')
-    return lines
+    return children, original_paths
 
 
-def format_json(path: str, deps: list[str], *, transitive: bool) -> str:
-    return json.dumps(
-        {
-            'path': path,
-            'deps': deps,
-            'transitive': transitive,
-        },
-        indent=2,
-    )
+def resolve_path(path: str, original_paths: dict[str, str]) -> str:
+    target = normalize(path)
+    if target in original_paths:
+        return target
+
+    matches = [
+        candidate for candidate in original_paths
+        if candidate.endswith(f'/{target}') or target.endswith(f'/{candidate}')
+    ]
+    if not matches:
+        raise RuntimeError(f'path not found in DAG: {path}')
+    if len(matches) > 1:
+        joined = '\n'.join(f'  {original_paths[match]}' for match in matches)
+        raise RuntimeError(f'path is ambiguous: {path}\nMatches:\n{joined}')
+
+    return matches[0]
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description=(
-            'Print child dependencies for a path from '
-            '`terragrunt list -T --dag` output.'
-        )
+        description='Return direct Terragrunt DAG dependents as JSON.'
     )
-    parser.add_argument('path', help='Terragrunt path to look up in the DAG')
+    parser.add_argument('path', help='Terragrunt path to look up')
     parser.add_argument(
         '-f',
         '--dag-file',
-        help="Read saved DAG output from a file. Use '-' to read stdin.",
+        help="Read saved DAG output from a file. Use '-' for stdin.",
     )
     parser.add_argument(
         '-w',
         '--working-dir',
-        help='Stack root to pass to terragrunt when --dag-file is not used.',
+        help='Terragrunt stack root when --dag-file is not used.',
     )
     parser.add_argument(
         '--terragrunt-bin',
         default='terragrunt',
-        help='Terragrunt executable to run when --dag-file is not used.',
-    )
-    parser.add_argument(
-        '--transitive',
-        action='store_true',
-        help='Include nested child dependencies, not only direct children.',
-    )
-    parser.add_argument(
-        '--include-root',
-        action='store_true',
-        help='Print the requested path before its child dependencies.',
-    )
-    parser.add_argument(
-        '--format',
-        choices=('json', 'paths', 'tree'),
-        default='json',
-        help='Output format. Defaults to json.',
-    )
-    parser.add_argument(
-        '--paths-only',
-        action='store_true',
-        help='Deprecated alias for --format paths.',
+        help='Terragrunt executable to run.',
     )
     return parser.parse_args(argv)
 
@@ -242,40 +132,17 @@ def main(argv: list[str]) -> int:
     args = parse_args(argv)
 
     try:
-        if args.dag_file:
-            dag_lines = read_dag_file(args.dag_file)
-        else:
-            dag_lines = run_terragrunt_list(
-                args.terragrunt_bin, args.working_dir)
-
-        dag = TerragruntDag.from_lines(dag_lines)
-        root = dag.resolve(args.path)
-
-        output_format = 'paths' if args.paths_only else args.format
-        deps = collect_paths(dag, root, args.transitive)
-
-        if output_format == 'json':
-            print(
-                format_json(
-                    dag.original_paths[root],
-                    deps,
-                    transitive=args.transitive,
-                )
+        children, original_paths = build_dependency_map(read_dag(args))
+        path = resolve_path(args.path, original_paths)
+        deps = [original_paths[dep] for dep in children.get(path, [])]
+        print(
+            json.dumps(
+                {'path': original_paths[path], 'deps': deps},
+                indent=2,
             )
-        elif output_format == 'paths':
-            if deps:
-                print('\n'.join(deps))
-        else:
-            output = format_tree(
-                dag,
-                root,
-                include_root=args.include_root,
-                transitive=args.transitive,
-            )
-            if output:
-                print('\n'.join(output))
-    except DagError as error:
-        print(f"Error: {error}", file=sys.stderr)
+        )
+    except RuntimeError as error:
+        print(f'Error: {error}', file=sys.stderr)
         return 1
 
     return 0

--- a/scripts/terragrunt-deps.py
+++ b/scripts/terragrunt-deps.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3.12
+"""Print child dependencies from `terragrunt list -T --dag` tree output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+BRANCH_MARKERS = ('├──', '└──', '╰──', '+--', '`--', '\\--')
+
+
+class DagError(Exception):
+    """Raised when the requested DAG path cannot be resolved."""
+
+
+def normalize_path(path: str) -> str:
+    normalized = path.strip().rstrip('/')
+    while normalized.startswith('./'):
+        normalized = normalized[2:]
+    return normalized
+
+
+def parse_tree_line(line: str) -> tuple[int, str] | None:
+    for marker in BRANCH_MARKERS:
+        marker_at = line.find(marker)
+        if marker_at == -1:
+            continue
+
+        path = line[marker_at + len(marker):].strip()
+        if not path:
+            return None
+
+        prefix = line[:marker_at].replace('\t', '    ')
+        return len(prefix) // 4, path
+
+    return None
+
+
+def append_unique(items: list[str], item: str) -> None:
+    if item not in items:
+        items.append(item)
+
+
+class TerragruntDag:
+    def __init__(self) -> None:
+        self.children: dict[str, list[str]] = defaultdict(list)
+        self.original_paths: dict[str, str] = {}
+
+    @classmethod
+    def from_lines(cls, lines: list[str]) -> TerragruntDag:
+        dag = cls()
+        stack: list[str] = []
+
+        for line in lines:
+            parsed = parse_tree_line(line)
+            if parsed is None:
+                continue
+
+            depth, path = parsed
+            key = normalize_path(path)
+            if not key:
+                continue
+
+            dag.original_paths.setdefault(key, path)
+            dag.children.setdefault(key, [])
+
+            if depth > len(stack):
+                raise DagError(
+                    f"cannot parse tree line with skipped depth: {line}")
+
+            stack = stack[:depth]
+            if depth > 0:
+                append_unique(dag.children[stack[depth - 1]], key)
+
+            stack.append(key)
+
+        return dag
+
+    def resolve(self, path: str) -> str:
+        target = normalize_path(path)
+        if target in self.original_paths:
+            return target
+
+        suffix_matches = [
+            key for key in self.original_paths
+            if key.endswith(f"/{target}") or target.endswith(f"/{key}")
+        ]
+
+        if not suffix_matches:
+            raise DagError(f"path not found in DAG: {path}")
+        if len(suffix_matches) > 1:
+            matches = '\n'.join(
+                f"  {self.original_paths[key]}" for key in suffix_matches
+            )
+            raise DagError(f"path is ambiguous: {path}\nMatches:\n{matches}")
+
+        return suffix_matches[0]
+
+
+def read_dag_file(path: str) -> list[str]:
+    if path == '-':
+        return sys.stdin.read().splitlines()
+
+    return Path(path).read_text(encoding='utf-8').splitlines()
+
+
+def run_terragrunt_list(terragrunt_bin: str, working_dir: str | None) -> list[str]:
+    command = [terragrunt_bin, 'list', '-T', '--dag']
+    if working_dir:
+        command.extend(['--working-dir', working_dir])
+
+    result = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+        raise DagError(f"terragrunt exited with status {result.returncode}")
+
+    return result.stdout.splitlines()
+
+
+def collect_paths(dag: TerragruntDag, root: str, transitive: bool) -> list[str]:
+    paths: list[str] = []
+    seen: set[str] = set()
+
+    def visit(parent: str) -> None:
+        for child in dag.children[parent]:
+            if child in seen:
+                continue
+            seen.add(child)
+            paths.append(dag.original_paths[child])
+            if transitive:
+                visit(child)
+
+    visit(root)
+    return paths
+
+
+def format_tree(
+    dag: TerragruntDag,
+    root: str,
+    *,
+    include_root: bool,
+    transitive: bool,
+) -> list[str]:
+    lines: list[str] = []
+    active: set[str] = set()
+
+    if include_root:
+        lines.append(dag.original_paths[root])
+
+    def visit(parent: str, prefix: str) -> None:
+        if parent in active:
+            lines.append(f"{prefix}╰── [cycle] {dag.original_paths[parent]}")
+            return
+
+        active.add(parent)
+        children = dag.children[parent]
+        for index, child in enumerate(children):
+            is_last = index == len(children) - 1
+            branch = '╰──' if is_last else '├──'
+            lines.append(f"{prefix}{branch} {dag.original_paths[child]}")
+
+            if transitive and dag.children[child]:
+                child_prefix = '    ' if is_last else '│   '
+                visit(child, f"{prefix}{child_prefix}")
+
+        active.remove(parent)
+
+    visit(root, '')
+    return lines
+
+
+def format_json(path: str, deps: list[str], *, transitive: bool) -> str:
+    return json.dumps(
+        {
+            'path': path,
+            'deps': deps,
+            'transitive': transitive,
+        },
+        indent=2,
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            'Print child dependencies for a path from '
+            '`terragrunt list -T --dag` output.'
+        )
+    )
+    parser.add_argument('path', help='Terragrunt path to look up in the DAG')
+    parser.add_argument(
+        '-f',
+        '--dag-file',
+        help="Read saved DAG output from a file. Use '-' to read stdin.",
+    )
+    parser.add_argument(
+        '-w',
+        '--working-dir',
+        help='Stack root to pass to terragrunt when --dag-file is not used.',
+    )
+    parser.add_argument(
+        '--terragrunt-bin',
+        default='terragrunt',
+        help='Terragrunt executable to run when --dag-file is not used.',
+    )
+    parser.add_argument(
+        '--transitive',
+        action='store_true',
+        help='Include nested child dependencies, not only direct children.',
+    )
+    parser.add_argument(
+        '--include-root',
+        action='store_true',
+        help='Print the requested path before its child dependencies.',
+    )
+    parser.add_argument(
+        '--format',
+        choices=('json', 'paths', 'tree'),
+        default='json',
+        help='Output format. Defaults to json.',
+    )
+    parser.add_argument(
+        '--paths-only',
+        action='store_true',
+        help='Deprecated alias for --format paths.',
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    try:
+        if args.dag_file:
+            dag_lines = read_dag_file(args.dag_file)
+        else:
+            dag_lines = run_terragrunt_list(
+                args.terragrunt_bin, args.working_dir)
+
+        dag = TerragruntDag.from_lines(dag_lines)
+        root = dag.resolve(args.path)
+
+        output_format = 'paths' if args.paths_only else args.format
+        deps = collect_paths(dag, root, args.transitive)
+
+        if output_format == 'json':
+            print(
+                format_json(
+                    dag.original_paths[root],
+                    deps,
+                    transitive=args.transitive,
+                )
+            )
+        elif output_format == 'paths':
+            if deps:
+                print('\n'.join(deps))
+        else:
+            output = format_tree(
+                dag,
+                root,
+                include_root=args.include_root,
+                transitive=args.transitive,
+            )
+            if output:
+                print('\n'.join(output))
+    except DagError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Description

Adds a Python 3.12 dependency resolver for Terragrunt DAG output and refactors `scripts/reinstall-eks-with-deps.sh` to use it instead of `terragrunt find`.

The new `scripts/terragrunt-deps.py` script reads `terragrunt list -T --dag` output, resolves dependencies by full path, and emits JSON with a `deps` array. This avoids basename-based matching issues for repeated units like `blue` and `green`.

`reinstall-eks-with-deps.sh` now consumes that JSON to apply or destroy EKS dependents in the existing workflow.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

Validation performed:

- `bash -n scripts/reinstall-eks-with-deps.sh`
- `shellcheck scripts/reinstall-eks-with-deps.sh`
- Python 3.12 syntax validation
- Manual JSON dependency lookup against sample Terragrunt DAG output