### PR TITLE
chore(scripts): wait 5 minutes after EKS apply before applying dependents

### DIFF
--- a/scripts/reinstall-eks-with-deps.sh
+++ b/scripts/reinstall-eks-with-deps.sh
@@ -88,6 +88,9 @@ apply_with_deps() {
     echo ">>> Applying main module: $orig_dir"
     terragrunt apply -auto-approve --non-interactive
 
+    debug "Sleeping for 5 minutes to allow for resource stabilization before applying dependents"
+    sleep 300
+
     while IFS= read -r dep; do
         debug "Applying dependent module from: $dep"
         echo ">>> Applying dependent module: $dep"


### PR DESCRIPTION
## Description

Adds a 5-minute pause in `scripts/reinstall-eks-with-deps.sh` between applying the main EKS module and applying its dependents. After an EKS cluster apply, the API server and add-ons need a few minutes to stabilize; without this wait, dependent modules (e.g. those installing Helm releases or Kubernetes resources) can fail intermittently with connection or readiness errors.

The sleep only runs in the `create`/`apply` path — `destroy` is unchanged.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass