### PR TITLE
fix: fix bug that creates a drift in gh app webhook

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,4 @@ exclude_paths:
   - .cache/
   - .github/
   - .terraform/
+  - skills/

--- a/modules/platform/forge_runners/locals.tf
+++ b/modules/platform/forge_runners/locals.tf
@@ -9,5 +9,5 @@ locals {
   )
 
   github_app_installation = "${var.deployment_config.github.ghes_url == "" ? "https://github.com" : var.deployment_config.github.ghes_url}/apps/${var.deployment_config.github_app.name}/installations/${var.deployment_config.github_app.installation_id}"
-  github_api              = var.deployment_config.github.ghes_url == "" ? "https://api.github.com" : "https://api.${replace(var.deployment_config.github.ghes_url, "https://", "")}"
+  github_api              = var.deployment_config.github.ghes_url == "" ? "https://api.github.com" : "${var.deployment_config.github.ghes_url}/api/v3"
 }

--- a/modules/platform/forge_runners/update_gh_app.tf
+++ b/modules/platform/forge_runners/update_gh_app.tf
@@ -1,14 +1,17 @@
 resource "null_resource" "update_github_app_webhook" {
   triggers = {
-    ghes_org        = var.deployment_config.github.ghes_org
-    ghes_url        = var.deployment_config.github.ghes_url
-    webhook_url     = try(module.ec2_runners[0].webhook_endpoint, "https://cisco-open.github.io/forge")
-    secret          = aws_ssm_parameter.github_app_webhook_secret.value
-    secret_version  = aws_ssm_parameter.github_app_webhook_secret.version
-    id              = var.deployment_config.github_app.id
-    client_id       = var.deployment_config.github_app.client_id
-    installation_id = var.deployment_config.github_app.installation_id
-    name            = var.deployment_config.github_app.name
+    ghes_org               = var.deployment_config.github.ghes_org
+    ghes_url               = var.deployment_config.github.ghes_url
+    webhook_url            = try(module.ec2_runners[0].webhook_endpoint, "https://cisco-open.github.io/forge")
+    secret                 = aws_ssm_parameter.github_app_webhook_secret.value
+    secret_version         = aws_ssm_parameter.github_app_webhook_secret.version
+    id                     = var.deployment_config.github_app.id
+    client_id              = var.deployment_config.github_app.client_id
+    installation_id        = var.deployment_config.github_app.installation_id
+    name                   = var.deployment_config.github_app.name
+    github_app_key_version = data.aws_ssm_parameter.github_app_key.version
+    env                    = var.deployment_config.env
+    deployment_prefix      = var.deployment_config.deployment_prefix
   }
 
   provisioner "local-exec" {
@@ -25,4 +28,8 @@ resource "null_resource" "update_github_app_webhook" {
 
     command = "${path.module}/scripts/generate_and_patch_github_app.sh"
   }
+
+  depends_on = [
+    random_password.github_app_webhook_secret,
+  ]
 }

--- a/scripts/reinstall-eks-with-deps.sh
+++ b/scripts/reinstall-eks-with-deps.sh
@@ -88,8 +88,9 @@ apply_with_deps() {
     echo ">>> Applying main module: $orig_dir"
     terragrunt apply -auto-approve --non-interactive
 
-    debug "Sleeping for 5 minutes to allow for resource stabilization before applying dependents"
-    sleep 300
+    debug "Sleeping for 10 minutes to allow for resource stabilization before applying dependents"
+    echo ">>> Sleeping for 10 minutes to allow for resource stabilization before applying dependents..."
+    sleep 600
 
     while IFS= read -r dep; do
         debug "Applying dependent module from: $dep"


### PR DESCRIPTION
## Description

Fixes Terraform drift in the Forge GitHub App webhook configuration.

The webhook patching step now explicitly depends on `random_password.github_app_webhook_secret`, ensuring the generated secret exists before the GitHub App webhook update runs. This should prevent repeated drift caused by Terraform applying the webhook update before the secret value is ready.

This PR also includes small supporting updates:
- Excludes `skills/` from ansible-lint.
- Increases the EKS reinstall stabilization wait from 5 to 10 minutes before applying dependent modules.

No related issue identified.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass