### PR TITLE
fix(eks): add additional policy for public ecr

### DIFF
--- a/modules/infra/eks/karpenter.tf
+++ b/modules/infra/eks/karpenter.tf
@@ -13,6 +13,7 @@ module "karpenter" {
 
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    ECRPublicReadOnly            = "arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly"
   }
 }
 

--- a/modules/infra/eks/nodes.tf
+++ b/modules/infra/eks/nodes.tf
@@ -36,6 +36,7 @@ module "self_managed_node_group" {
 
   iam_role_additional_policies = {
     "AmazonSSMManagedInstanceCore" = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    "ECRPublicReadOnly"            = "arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly"
   }
 
   // The following variables are necessary if you decide to use the module outside of the parent EKS module context.


### PR DESCRIPTION
## Description

Adds the AWS managed `AmazonElasticContainerRegistryPublicReadOnly` policy to EKS node IAM roles.

This allows both Karpenter-managed nodes and self-managed node groups to pull images from Amazon ECR Public, preventing image pull failures when workloads depend on public ECR images.

No related issue identified.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass