### PR TITLE
chore: update dependencies for TFLint, Packer, and AWS modules

### DIFF
--- a/.docker/pre-commit/Dockerfile
+++ b/.docker/pre-commit/Dockerfile
@@ -87,7 +87,7 @@ RUN set -eux; \
     chmod 755 /usr/local/bin/terragrunt
 
 # renovate: datasource=github-releases depName=terraform-linters/tflint registryUrl=https://github.com/
-ARG TFLINT_VERSION="0.63.0"
+ARG TFLINT_VERSION="0.63.1"
 ARG TFLINT_SRC="https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip"
 ARG TFLINT_ARTIFACT="tflint.zip"
 RUN set -eux; \

--- a/.docker/pre-commit/Dockerfile
+++ b/.docker/pre-commit/Dockerfile
@@ -40,7 +40,7 @@ RUN set -eux; \
     chmod 755 /usr/local/bin/jq
 
 # renovate: datasource=github-releases depName=hashicorp/packer registryUrl=https://github.com/
-ARG PACKER_VERSION="1.15.3"
+ARG PACKER_VERSION="1.15.4"
 ARG PACKER_SRC="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"
 ARG PACKER_ARTIFACT="packer.zip"
 RUN set -eux; \

--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -34,7 +34,7 @@ data "aws_subnet" "runner_subnet" {
 }
 
 data "external" "download_lambdas" {
-  program = ["bash", "${path.module}/scripts/download_lambdas.sh", "/tmp/${var.runner_configs.prefix}/", "v7.5.0"]
+  program = ["bash", "${path.module}/scripts/download_lambdas.sh", "/tmp/${var.runner_configs.prefix}/", "v7.6.0"]
 }
 
 


### PR DESCRIPTION
## Description

Updates Renovate-managed dependencies used by Forge tooling and EC2 runner deployment:

- Updates Packer in `.docker/pre-commit/Dockerfile` from `1.15.3` to `1.15.4`.
- Updates TFLint in `.docker/pre-commit/Dockerfile` from `0.63.0` to `0.63.1`.
- Updates the EC2 runner lambda artifact download tag in `modules/platform/ec2_deployment/main.tf` from `v7.5.0` to `v7.6.0`.

These changes keep the pre-commit container and EC2 runner deployment artifacts aligned with the versions proposed by Renovate without changing Forge module inputs.

## Related / Notes

- No tracking issue was identified for this dependency-only update.
- Partial overlap: #302 also updates the EC2 runner lambda artifact tag to `v7.6.0` as part of broader EC2/macOS runner work.

## Validation

- `run-pre-commit` passed on this PR.
- `Build and push Docker image` passed on this PR.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other: dependency update

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (N/A: dependency-only update with no user-facing documentation changes)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests (N/A: no new code paths)
- [x] All new and existing tests pass