### PR TITLE
docs: update splunk examples to use new cf template

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,9 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: forge-ec2-medium  # Your ForgeMT runner
-    permissions:
-      id-token: write  # Required for OIDC
+    runs-on: forge-ec2-medium  # Your ForgeMT runner  
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/examples/deployments/splunk-deployment/terragrunt/environments/prod/regions/eu-west-1/splunk_o11y_aws_integration/config.yml
+++ b/examples/deployments/splunk-deployment/terragrunt/environments/prod/regions/eu-west-1/splunk_o11y_aws_integration/config.yml
@@ -1,3 +1,3 @@
 ---
 splunk_ingest_url: https://ingest.us0.signalfx.com
-template_url: https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_all_features_regional.yaml
+template_url: https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_metric_streams_regional.yaml

--- a/examples/infra-forge/terragrunt/environments/dev/regions/eu-west-1/splunk_o11y_regional_integration/config.hcl
+++ b/examples/infra-forge/terragrunt/environments/dev/regions/eu-west-1/splunk_o11y_regional_integration/config.hcl
@@ -1,4 +1,4 @@
 locals {
   splunk_ingest_url = "https://ingest.<your region>.signalfx.com"
-  template_url      = "https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_all_features_regional.yaml"
+  template_url      = "https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_metric_streams_regional.yaml"
 }

--- a/examples/templates/splunk/_environment_wide_settings/_environment.yml
+++ b/examples/templates/splunk/_environment_wide_settings/_environment.yml
@@ -6,5 +6,5 @@ splunk:
   splunk_api_url: <SPLUNK_API_URL>          # e.g., "https://api.us0.signalfx.com"
   splunk_ingest_url: <SPLUNK_INGEST_URL>      # e.g., "https://ingest.us0.signalfx.com"
   splunk_organization_id: <SPLUNK_ORGANIZATION_ID>  # e.g., "ORG1234567890"
-  data_manager_template_url: <DATA_MANAGER_TEMPLATE_URL>  # e.g., "https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_all_features_regional.yaml"
+  data_manager_template_url: <DATA_MANAGER_TEMPLATE_URL>  # e.g., "https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_metric_streams_regional.yaml"
   splunk_cloud: <SPLUNK_CLOUD_URL>          # e.g., "https://mycompany.splunkcloud.com"

--- a/examples/templates/splunk/splunk_o11y_aws_integration/config.yml
+++ b/examples/templates/splunk/splunk_o11y_aws_integration/config.yml
@@ -1,3 +1,3 @@
 ---
 splunk_ingest_url: <SPLUNK_INGEST_URL>  # e.g., https://ingest.us0.signalfx.com
-template_url: <SPLUNK_TEMPLATE_URL>  # e.g., https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_all_features_regional.yaml
+template_url: <SPLUNK_TEMPLATE_URL>  # e.g., https://o11y-public.s3.amazonaws.com/aws-cloudformation-templates/release/template_metric_streams_regional.yaml


### PR DESCRIPTION
## Description

Updates the Splunk Observability examples to use the metric streams regional CloudFormation template instead of the all-features regional template.

This changes the template URL in the Splunk deployment example, the infra-forge Terragrunt example, and the reusable Splunk template files. It also updates the README workflow example by pinning `actions/checkout` to the `v6.0.2` commit and removing the unused OIDC permissions block from the sample job.

Note: open PR #302 partially overlaps with the Splunk template URL changes as part of broader EC2/macOS runner work.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass