### PR TITLE
fix(ec2): handle runner role output for v7.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ override.tf.json
 *.tflock
 .terraform.lock.hcl
 .terragrunt-cache
+.ansible/
 providers
 
 # Auth files. Sensitive.

--- a/modules/core/arc/README.md
+++ b/modules/core/arc/README.md
@@ -14,7 +14,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |

--- a/modules/core/arc/scale_set/README.md
+++ b/modules/core/arc/scale_set/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 3.2.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.2.0 |
 

--- a/modules/infra/ami_policy/README.md
+++ b/modules/infra/ami_policy/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/infra/ami_sharing/README.md
+++ b/modules/infra/ami_sharing/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/infra/cloud_custodian/README.md
+++ b/modules/infra/cloud_custodian/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/infra/cloud_formation/README.md
+++ b/modules/infra/cloud_formation/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/infra/ecr/README.md
+++ b/modules/infra/ecr/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/infra/eks/README.md
+++ b/modules/infra/eks/README.md
@@ -16,7 +16,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 

--- a/modules/infra/forge_subscription/roles.tf
+++ b/modules/infra/forge_subscription/roles.tf
@@ -1,18 +1,5 @@
 # Role assumed by Forge Runners
 data "aws_iam_policy_document" "assume_role_for_forge_runners" {
-  # Allows us to access S3, SecretsManager immediately when we SSH into a runner VM.
-  statement {
-    actions = [
-      "sts:AssumeRole",
-    ]
-    principals {
-      type = "Service"
-      identifiers = [
-        "ec2.amazonaws.com",
-        "s3.amazonaws.com",
-      ]
-    }
-  }
 
   # Allow GH runners to assume dedicated role.
   statement {

--- a/modules/infra/opt_in_regions/README.md
+++ b/modules/infra/opt_in_regions/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/infra/service_linked_roles/README.md
+++ b/modules/infra/service_linked_roles/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/infra/storage/README.md
+++ b/modules/infra/storage/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/integrations/github_webhook_relay_destination/README.md
+++ b/modules/integrations/github_webhook_relay_destination/README.md
@@ -48,7 +48,7 @@ graph TD
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 
 ## Modules

--- a/modules/integrations/github_webhook_relay_destination_receivers/README.md
+++ b/modules/integrations/github_webhook_relay_destination_receivers/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/README.md
+++ b/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/README.md
@@ -55,7 +55,7 @@ Both `token` and `room_id` keys are required. The function will prepend `Bearer 
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
 
 ## Modules

--- a/modules/integrations/github_webhook_relay_source/README.md
+++ b/modules/integrations/github_webhook_relay_source/README.md
@@ -66,7 +66,7 @@ curl -X POST "$(terraform output -raw webhook_endpoint)/webhook" \
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/integrations/splunk_aws_billing/README.md
+++ b/modules/integrations/splunk_aws_billing/README.md
@@ -14,7 +14,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/integrations/splunk_cloud_conf_shared/README.md
+++ b/modules/integrations/splunk_cloud_conf_shared/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_splunk"></a> [splunk](#provider\_splunk) | 1.5.1 |
 
 ## Modules

--- a/modules/integrations/splunk_cloud_data_manager_common/README.md
+++ b/modules/integrations/splunk_cloud_data_manager_common/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 
 ## Modules

--- a/modules/integrations/splunk_cloud_s3_runner_logs/README.md
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 
 ## Modules

--- a/modules/integrations/splunk_o11y_aws_integration/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_aws_integration_common/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration_common/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.1 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
 

--- a/modules/integrations/splunk_o11y_conf_shared/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.1 |
 
 ## Modules

--- a/modules/integrations/splunk_otel_eks/README.md
+++ b/modules/integrations/splunk_otel_eks/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 3.2.0 |
 
 ## Modules

--- a/modules/integrations/teleport/README.md
+++ b/modules/integrations/teleport/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.2.0 |
 
 ## Modules

--- a/modules/platform/ec2_deployment/README.md
+++ b/modules/platform/ec2_deployment/README.md
@@ -21,7 +21,7 @@
 | ---- | ------ | ------- |
 | <a name="module_ec2_update_runner_ssm_ami"></a> [ec2\_update\_runner\_ssm\_ami](#module\_ec2\_update\_runner\_ssm\_ami) | ./ec2_update_runner_ssm_ami | n/a |
 | <a name="module_ec2_update_runner_tags"></a> [ec2\_update\_runner\_tags](#module\_ec2\_update\_runner\_tags) | ./ec2_update_runner_tags | n/a |
-| <a name="module_runners"></a> [runners](#module\_runners) | git::https://github.com/edersonbrilhante/terraform-aws-github-runner.git//modules/multi-runner | pre-7.7.0 |
+| <a name="module_runners"></a> [runners](#module\_runners) | git::https://github.com/github-aws-runners/terraform-aws-github-runner.git//modules/multi-runner | v7.7.0 |
 
 ## Resources
 

--- a/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/README.md
+++ b/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/platform/ec2_deployment/ec2_update_runner_tags/README.md
+++ b/modules/platform/ec2_deployment/ec2_update_runner_tags/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/platform/ec2_deployment/outputs.tf
+++ b/modules/platform/ec2_deployment/outputs.tf
@@ -5,7 +5,7 @@ output "webhook_endpoint" {
 
 output "ec2_runners_arn_map" {
   value = {
-    for runner_key, runner in module.runners.runners_map : runner_key => runner.role_runner.arn
+    for runner_key, runner in module.runners.runners_map : runner_key => runner.role_runner[0].arn
   }
   description = "Map of EC2 runner keys to their IAM role ARNs."
 }

--- a/modules/platform/forge_runners/README.md
+++ b/modules/platform/forge_runners/README.md
@@ -16,7 +16,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |

--- a/modules/platform/forge_runners/forge_trust_validator/README.md
+++ b/modules/platform/forge_runners/forge_trust_validator/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/platform/forge_runners/github_actions_job_logs/README.md
+++ b/modules/platform/forge_runners/github_actions_job_logs/README.md
@@ -130,7 +130,7 @@ See parent repository license.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/platform/forge_runners/github_app_runner_group/README.md
+++ b/modules/platform/forge_runners/github_app_runner_group/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/platform/forge_runners/github_global_lock/README.md
+++ b/modules/platform/forge_runners/github_global_lock/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 

--- a/modules/platform/forge_runners/github_webhook_relay/README.md
+++ b/modules/platform/forge_runners/github_webhook_relay/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 
 ## Modules

--- a/modules/platform/forge_runners/redrive_deadletter/README.md
+++ b/modules/platform/forge_runners/redrive_deadletter/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
 
 ## Modules
 


### PR DESCRIPTION
## Description

Fixes the EC2 runner deployment output after upgrading `github-aws-runners/terraform-aws-github-runner` to `v7.7.0`.

In `v7.7.0`, the upstream runner IAM role is now returned as a counted resource, so `runner.role_runner` is a tuple. Forge was still reading `runner.role_runner.arn`, which caused Terraform/OpenTofu to fail with:

```text
Unsupported attribute: runner.role_runner is tuple with 1 element
```

This PR updates the EC2 runner ARN output to read `runner.role_runner[0].arn`, updates the generated Terraform module docs, ignores local `.ansible/` cache files, and tightens the Forge subscription trust policy by removing direct EC2/S3 service-principal assume-role access.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [x] Other: gitignore and IAM trust policy cleanup

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

Validation: pre-commit passed, including Terraform/OpenTofu formatting and validation.