### PR TITLE
chore: update terraform-aws-github-runner to v7.7.1

### DIFF
--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -34,12 +34,12 @@ data "aws_subnet" "runner_subnet" {
 }
 
 data "external" "download_lambdas" {
-  program = ["bash", "${path.module}/scripts/download_lambdas.sh", "/tmp/${var.runner_configs.prefix}/", "v7.7.0", "github-aws-runners/terraform-aws-github-runner"]
+  program = ["bash", "${path.module}/scripts/download_lambdas.sh", "/tmp/${var.runner_configs.prefix}/", "v7.7.1", "github-aws-runners/terraform-aws-github-runner"]
 }
 
 
 module "runners" {
-  source = "git::https://github.com/github-aws-runners/terraform-aws-github-runner.git//modules/multi-runner?ref=v7.7.0"
+  source = "git::https://github.com/github-aws-runners/terraform-aws-github-runner.git//modules/multi-runner?ref=v7.7.1"
 
   aws_region = var.aws_region
 


### PR DESCRIPTION
## Description

Updates the EC2 deployment module to consume `github-aws-runners/terraform-aws-github-runner` `v7.7.1` instead of `v7.7.0`, and keeps the Lambda artifact download version in sync.

`v7.7.1` is an upstream patch release that fixes a type mismatch in the runner pool role conditional. This should prevent Terraform evaluation failures around EC2 runner pool role configuration without changing Forge module inputs or intentionally altering local runner configuration.

References:

- Upstream release: [github-aws-runners/terraform-aws-github-runner v7.7.1](https://github.com/github-aws-runners/terraform-aws-github-runner/releases/tag/v7.7.1)
- Upstream fix: [github-aws-runners/terraform-aws-github-runner#5156](https://github.com/github-aws-runners/terraform-aws-github-runner/issues/5156)
- Upstream commit: [60de50f](https://github.com/github-aws-runners/terraform-aws-github-runner/commit/60de50f995794fe03f109234c79ca361ab86feaf)

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

Validation performed:

- `terraform fmt -check modules/platform/ec2_deployment/main.tf`
- Searched open PRs for other `terraform-aws-github-runner` updates; only this PR was returned.
- No full test suite was run locally.