### PR TITLE
fix(eks): use latest compatible kube-proxy add-on version

### DIFF
--- a/.docker/pre-commit/Dockerfile
+++ b/.docker/pre-commit/Dockerfile
@@ -96,7 +96,7 @@ RUN set -eux; \
     chmod 755 /usr/local/bin/tflint;
 
 # renovate: datasource=github-releases depName=opentofu/opentofu registryUrl=https://github.com/
-ARG TOFU_VERSION="1.12.2"
+ARG TOFU_VERSION="1.12.3"
 ARG TOFU_SRC="https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_linux_amd64.zip"
 ARG TOFU_ARTIFACT="tofu.zip"
 RUN set -eux; \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -230,7 +230,7 @@ repos:
         always_run: true
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.106.0
+    rev: v1.107.0
     hooks:
       - id: terraform_fmt
         name: Terraform · Formatter

--- a/modules/infra/eks/addons.tf
+++ b/modules/infra/eks/addons.tf
@@ -16,6 +16,12 @@ data "aws_eks_addon_version" "coredns" {
   kubernetes_version = var.cluster_version
 }
 
+# Fetch the most recent version of the kube-proxy
+data "aws_eks_addon_version" "kube_proxy" {
+  addon_name         = "kube-proxy"
+  kubernetes_version = var.cluster_version
+}
+
 resource "aws_eks_addon" "aws_ebs_csi_driver" {
   cluster_name             = var.cluster_name
   addon_name               = "aws-ebs-csi-driver"

--- a/modules/infra/eks/eks.tf
+++ b/modules/infra/eks/eks.tf
@@ -26,7 +26,9 @@ module "eks" {
   subnet_ids = var.subnet_ids
 
   addons = {
-    kube-proxy = {}
+    kube-proxy = {
+      addon_version = data.aws_eks_addon_version.kube_proxy.version
+    }
   }
 
   endpoint_public_access = var.cluster_endpoint_public_access

--- a/modules/integrations/splunk_otel_eks/otel.tf
+++ b/modules/integrations/splunk_otel_eks/otel.tf
@@ -2,7 +2,7 @@ resource "helm_release" "splunk_otel_collector" {
   name             = "splunk-otel-collector"
   repository       = "https://signalfx.github.io/splunk-otel-collector-chart"
   chart            = "splunk-otel-collector"
-  version          = "0.153.1"
+  version          = "0.154.0"
   namespace        = "splunk-otel-collector"
   create_namespace = true
 


### PR DESCRIPTION
## Description

Fixes EKS kube-proxy add-on version handling by resolving the kube-proxy add-on version from AWS for the configured Kubernetes cluster version and passing it explicitly into the EKS module.

This avoids leaving the kube-proxy add-on version unspecified in the module configuration.

Also includes Renovate dependency updates:

- `opentofu` `1.12.2` -> `1.12.3`
- `pre-commit-terraform` `v1.106.0` -> `v1.107.0`
- `splunk-otel-collector` Helm chart `0.153.1` -> `0.154.0`

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other: dependency maintenance

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced where applicable
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented or not applicable
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests or not applicable
- [ ] All new and existing tests pass