### PR TITLE
ci: exclude changelog from markdown formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -286,4 +286,4 @@ repos:
           - mdformat-ruff
           - mdformat-frontmatter
           - ruff
-        exclude: (modules/)
+        exclude: (modules/|CHANGELOG.md)


### PR DESCRIPTION
## Description

Excludes `CHANGELOG.md` from the markdown formatting pre-commit hook so generated release notes are not reformatted by local or CI markdown tooling.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: CI/tooling

## Testing

- Ran `pre-commit run --files .pre-commit-config.yaml`
- Commit hook passed