### PR TITLE
docs: add human-readable Terraform module README overviews

### DIFF
--- a/modules/core/arc/README.md
+++ b/modules/core/arc/README.md
@@ -1,3 +1,25 @@
+# ARC Core
+
+This module installs the core Actions Runner Controller resources for one Forge tenant on an EKS cluster.
+
+## Why This Module Exists
+
+In Forge, the Kubernetes lane turns GitHub Actions jobs into ephemeral pods. This module is the tenant-level orchestrator: it installs the controller, creates scale sets, and applies the Karpenter objects that give each tenant its own scheduling boundary.
+
+## What It Manages
+
+- The ARC scale set controller.
+- One ARC scale set per configured runner pool.
+- Tenant-scoped Karpenter EC2NodeClass and NodePool manifests.
+- A Kubernetes storage class used by runner volumes.
+- Outputs for runner role ARNs and subnet CIDR visibility.
+
+## Operational Notes
+
+- `migrate_arc_cluster` is the blue/green cutover switch; it should be true only during an intentional tenant migration.
+- The DinD path depends on tenant-specific node pools for blast-radius isolation.
+- Provider configuration resolves from the EKS cluster name, so changing the target cluster name repoints the in-cluster resources.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -14,7 +36,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |

--- a/modules/core/arc/scale_set/README.md
+++ b/modules/core/arc/scale_set/README.md
@@ -1,3 +1,25 @@
+# ARC Runner Scale Set
+
+This module creates one GitHub Actions runner scale set for the Kubernetes/ARC lane.
+
+## Why This Module Exists
+
+Forge exposes Kubernetes runners through labels such as `k8s` and `dind`. A scale set is the concrete runtime behind one of those labels: ARC creates one ephemeral runner pod per job, with identity, hooks, limits, and optional DinD behavior defined here.
+
+## What It Manages
+
+- The `gha-runner-scale-set` Helm release.
+- Runner hook ConfigMaps for job-started and job-completed handling.
+- The runner IAM role, Kubernetes service account, and EKS Pod Identity association.
+- Kubernetes RBAC needed by the runner pod.
+- Scale set labels, container images, resources, and volumes.
+
+## Operational Notes
+
+- `scale_set_type` selects the pod template; keep it aligned with the supported templates such as `k8s` and `dind`.
+- DinD scale sets carry the strongest isolation expectations because Docker builds are the highest-risk runner workload.
+- CPU and memory requests are part of the scheduling contract; wrong units can leave pods pending.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -12,7 +34,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 3.2.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.2.0 |
 

--- a/modules/core/arc/scale_set_controller/README.md
+++ b/modules/core/arc/scale_set_controller/README.md
@@ -1,3 +1,23 @@
+# ARC Scale Set Controller
+
+This module installs the GitHub Actions Runner Controller scale set controller for a tenant namespace.
+
+## Why This Module Exists
+
+The controller is the Kubernetes-side reconciler that watches GitHub demand and manages runner scale sets. Forge installs it as code so each tenant namespace has a predictable controller, GitHub App secret, and logging posture.
+
+## What It Manages
+
+- The tenant namespace.
+- The GitHub App Kubernetes secret used by ARC.
+- The `gha-runner-scale-set-controller` Helm release.
+
+## Operational Notes
+
+- Controller version should move deliberately with ARC chart upgrades.
+- During ARC cluster migration, `migrate_arc_cluster` removes the in-cluster controller resources while leaving external tenant identity intact.
+- Controller logs are the first place to inspect when GitHub sees demand but runner pods are not being created.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/infra/ami_policy/README.md
+++ b/modules/infra/ami_policy/README.md
@@ -1,3 +1,24 @@
+# AMI Policy
+
+This module applies account-level guardrails around AMI and EBS lifecycle management for Forge runner images.
+
+## Why This Module Exists
+
+Forge runners are intentionally disposable, but the images behind them are long-lived platform assets. This module keeps the AWS account ready for encrypted runner volumes and automated AMI lifecycle cleanup so image hygiene does not become manual work.
+
+## What It Manages
+
+- Enables EBS encryption by default in the target region.
+- Creates the Data Lifecycle Manager role used by AMI lifecycle policies.
+- Defines lifecycle policy permissions for AMI and snapshot cleanup.
+- Applies the common Forge tags used for ownership and cost reporting.
+
+## Operational Notes
+
+- Use this in accounts that build, store, or operate runner AMIs.
+- Review lifecycle timing before applying it to an account that also hosts non-Forge AMIs.
+- Encryption-by-default is account and region scoped, so treat this module as a regional foundation step.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/infra/ami_sharing/README.md
+++ b/modules/infra/ami_sharing/README.md
@@ -1,3 +1,23 @@
+# AMI Sharing
+
+This module shares selected runner AMIs with one or more AWS accounts.
+
+## Why This Module Exists
+
+Forge separates image building from runner execution. The platform can produce hardened, tested runner images in one account and grant launch permission to the accounts that run EC2-based GitHub Actions jobs.
+
+## What It Manages
+
+- Looks up AMIs by name and state filters.
+- Grants AMI launch permission to the configured AWS account IDs.
+- Keeps AMI distribution as code instead of a console operation.
+
+## Operational Notes
+
+- The filters should be narrow enough to select only intended runner images.
+- Sharing an AMI does not copy its KMS permissions; encrypted AMIs also require compatible KMS access.
+- Use this with the EC2 runner modules when runner accounts consume centrally built images.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +30,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/infra/cloud_custodian/README.md
+++ b/modules/infra/cloud_custodian/README.md
@@ -1,3 +1,23 @@
+# Cloud Custodian Role
+
+This module creates the IAM role and policy used by Cloud Custodian automation in Forge-managed AWS accounts.
+
+## Why This Module Exists
+
+Forge relies on automation to keep multi-tenant runner infrastructure clean and compliant. Cloud Custodian is one of the account-level tools used for inspection and remediation, so its role needs to be reproducible and consistently trusted.
+
+## What It Manages
+
+- An IAM role that the configured Forge role can assume.
+- A policy document for the Cloud Custodian actions required in the account.
+- Policy attachment and standard Forge tags.
+
+## Operational Notes
+
+- Keep the trust principal aligned with the platform role that actually runs custodian policies.
+- Policy scope should be reviewed when new remediation policies are added.
+- This module prepares access; it does not define the custodian policy files themselves.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +30,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/infra/cloud_formation/README.md
+++ b/modules/infra/cloud_formation/README.md
@@ -1,3 +1,24 @@
+# CloudFormation Roles
+
+This module provisions the paired admin and execution roles used for CloudFormation operations in a Forge account.
+
+## Why This Module Exists
+
+Some Forge integrations and AWS-managed setup paths still use CloudFormation. Keeping the admin and execution trust model in Terraform gives the platform a predictable way to deploy those stacks without hand-created IAM roles.
+
+## What It Manages
+
+- A CloudFormation admin role.
+- A CloudFormation execution role.
+- Policies that allow the admin role to assume the execution role and the execution role to perform stack work.
+- Common account and region tagging.
+
+## Operational Notes
+
+- Use this before modules that expect pre-existing CloudFormation execution roles.
+- Treat these roles as sensitive because broad CloudFormation permissions can create or mutate many AWS resource types.
+- Review the policy when adding new CloudFormation-backed integrations.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/infra/ecr/README.md
+++ b/modules/infra/ecr/README.md
@@ -1,3 +1,23 @@
+# ECR Repositories
+
+This module creates and manages ECR repositories used by Forge operational images.
+
+## Why This Module Exists
+
+Forge uses images for runners, sidecars, Lambdas, and integration helpers. Central ECR repositories keep those artifacts under platform control and make lifecycle cleanup repeatable.
+
+## What It Manages
+
+- One or more ECR repositories from the `repositories` input.
+- Lifecycle policies for repository cleanup.
+- Repository names exported for downstream modules or pipelines.
+
+## Operational Notes
+
+- Repository names are part of the contract with image-build and runner configuration.
+- Lifecycle rules should match the release and rollback window used by the platform.
+- Cross-account pull access is handled elsewhere; this module creates the repositories themselves.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +30,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/infra/eks/README.md
+++ b/modules/infra/eks/README.md
@@ -1,3 +1,26 @@
+# EKS Cluster Foundation
+
+This module builds the EKS foundation used by the Kubernetes/ARC runner lane.
+
+## Why This Module Exists
+
+Forge runs fast, container-native jobs through Actions Runner Controller on EKS. The article highlights why this cluster is not a generic EKS install: it uses Calico overlay networking to avoid VPC IP exhaustion, Karpenter for elastic nodes, and blue/green style cluster replacement for safer upgrades.
+
+## What It Manages
+
+- The EKS control plane and self-managed node group bootstrap path.
+- Karpenter installation and default node class/node pool manifests.
+- Calico CNI installation after removing `aws-node`.
+- EBS CSI, CoreDNS, and EKS Pod Identity add-ons.
+- Cluster outputs consumed by ARC, Teleport, and observability modules.
+
+## Operational Notes
+
+- Calico is load-bearing: it lets pods use overlay IPs so runner density is not capped by subnet IPs.
+- Cluster upgrades should be treated as replacement/cutover work rather than in-place mutation.
+- Karpenter and CNI ordering matters; nodes joining before networking is ready can fail in confusing ways.
+- This module creates the shared cluster; tenant runner scale sets are created by the ARC modules.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -16,7 +39,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 

--- a/modules/infra/forge_subscription/README.md
+++ b/modules/infra/forge_subscription/README.md
@@ -1,3 +1,24 @@
+# Forge Subscription Access
+
+This module prepares a tenant or subscription account so Forge runners can access the resources that tenant jobs require.
+
+## Why This Module Exists
+
+Forge keeps runner credentials short-lived. A runner starts with the identity attached by the platform, then assumes tenant-approved roles for actual workload access. This module creates the tenant-side role and supporting policies that make that model explicit.
+
+## What It Manages
+
+- IAM role trust for Forge runner principals.
+- Policies for tenant S3, Secrets Manager, Packer, and ECR access patterns.
+- ECR repository policy statements that allow runner pulls where configured.
+- Tags for tenant ownership and auditability.
+
+## Operational Notes
+
+- The tenant still owns what its role can do; this module only wires the Forge bridge.
+- Trust and `sts:TagSession` behavior should be validated with the Forge trust-validator after changes.
+- Keep this narrow when onboarding a tenant; broad tenant roles are harder to reason about later.
+
 <!-- BEGIN_TF_DOCS -->
 
 ## Requirements

--- a/modules/infra/opt_in_regions/README.md
+++ b/modules/infra/opt_in_regions/README.md
@@ -1,3 +1,22 @@
+# AWS Opt-In Regions
+
+This module enables configured opt-in AWS regions for an account.
+
+## Why This Module Exists
+
+Forge can run tenants across regions, but AWS opt-in regions must be enabled before regional infrastructure can be planned or applied there. Making that step code-driven keeps account bootstrap repeatable.
+
+## What It Manages
+
+- AWS account region enablement for each entry in `opt_in_regions`.
+- Provider and tagging inputs needed by the account bootstrap flow.
+
+## Operational Notes
+
+- Region opt-in can take time to complete in AWS; plan downstream regional applies accordingly.
+- Use this only for regions that the organization has approved for Forge workloads.
+- This module does not create VPCs, subnets, or runners in the region.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +29,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/infra/service_linked_roles/README.md
+++ b/modules/infra/service_linked_roles/README.md
@@ -1,3 +1,22 @@
+# Service-Linked Roles
+
+This module creates AWS service-linked roles that Forge expects to exist in runner accounts.
+
+## Why This Module Exists
+
+EC2 runner pools can use Spot capacity and other AWS services that depend on account-level service-linked roles. Creating those roles up front avoids first-use failures during runner scale-up.
+
+## What It Manages
+
+- The EC2 Spot service-linked role.
+- Standard account and region inputs for bootstrap consistency.
+
+## Operational Notes
+
+- Apply this before enabling Spot-backed EC2 runner pools.
+- AWS service-linked roles are account scoped and may already exist; Terraform should own them only where this module is the bootstrap authority.
+- This does not decide whether a runner pool uses Spot; that is configured in the EC2 deployment specs.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +29,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/infra/storage/README.md
+++ b/modules/infra/storage/README.md
@@ -1,3 +1,24 @@
+# Shared Storage Buckets
+
+This module creates the long-term and short-term S3 buckets used by Forge account-level workflows.
+
+## Why This Module Exists
+
+Forge produces operational artifacts, logs, and temporary data across many tenants. Separate encrypted buckets with lifecycle controls let the platform keep durable evidence while automatically aging out short-lived material.
+
+## What It Manages
+
+- Long-term and short-term S3 buckets.
+- Versioning, ownership controls, server-side encryption, and public access blocks.
+- Lifecycle configuration for the short-term bucket.
+- Bucket settings exported for downstream modules.
+
+## Operational Notes
+
+- Use the short-term bucket for generated or transient artifacts, not compliance evidence.
+- Retention periods and encryption defaults should match the account data-classification policy.
+- Bucket names and outputs are often consumed by integration modules, so avoid renames without migration planning.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/integrations/github_webhook_relay_destination/README.md
+++ b/modules/integrations/github_webhook_relay_destination/README.md
@@ -35,6 +35,12 @@ graph TD
   classDef lambda fill:#d9f7d9,stroke:#2d7a2d,stroke-width:1px;
 ```
 
+## Forge Context
+
+This is the receiving side of the Forge webhook relay. It creates the destination EventBridge bus, authorizes the source account to put events, and fans matching events into one or more Lambda receivers.
+
+Use narrow event patterns for each receiver so unrelated GitHub events do not trigger noisy or expensive automation. Cross-account secret reading is optional and should stay limited to the roles that need to validate or consume the forwarded webhook flow.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -48,7 +54,7 @@ graph TD
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 
 ## Modules

--- a/modules/integrations/github_webhook_relay_destination_receivers/README.md
+++ b/modules/integrations/github_webhook_relay_destination_receivers/README.md
@@ -1,3 +1,24 @@
+# GitHub Webhook Relay Destination Receivers
+
+This module composes a destination EventBridge bus with one or more receiver Lambdas for GitHub webhook events.
+
+## Why This Module Exists
+
+The Forge control plane emits useful workflow events, but the consumers may live in a separate destination account. This module is the receiver-side composition point for operational automations such as Webex notifications or delayed review workers.
+
+## What It Manages
+
+- The destination relay module.
+- Optional Webex webhook receiver module.
+- Reader configuration for fetching the source webhook secret when cross-account wiring is enabled.
+- Outputs for the destination role and webhook metadata.
+
+## Operational Notes
+
+- Use event patterns to keep receivers narrow; broad webhook rules create noisy automations.
+- Destination permissions must match the source account and bus names.
+- Receiver Lambdas should be idempotent because EventBridge delivery can retry.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/README.md
+++ b/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/README.md
@@ -41,6 +41,11 @@ Secret value format (JSON string):
 
 Both `token` and `room_id` keys are required. The function will prepend `Bearer ` to `token` automatically if not present.
 
+## Forge Context
+
+This receiver is the notification endpoint for forwarded Forge GitHub webhook events. It is useful for operator alerts where the platform should post a concise Webex message without giving the sender account direct access to the bot token.
+
+The secret is stored in Secrets Manager and read by the Lambda at runtime. Treat the Webex room and bot token as operational routing configuration: wrong values do not break the relay infrastructure, but they do send the alert to the wrong place or nowhere at all.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -55,7 +60,7 @@ Both `token` and `room_id` keys are required. The function will prepend `Bearer 
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
 
 ## Modules

--- a/modules/integrations/github_webhook_relay_source/README.md
+++ b/modules/integrations/github_webhook_relay_source/README.md
@@ -54,6 +54,12 @@ curl -X POST "$(terraform output -raw webhook_endpoint)/webhook" \
   -d '{"hello":"world"}'
 ```
 
+## Forge Context
+
+Forge uses this relay pattern when GitHub webhook events need to cross account boundaries before they are consumed by operational automations. The source module is the public ingress edge: it validates the webhook secret, writes the event to a source EventBridge bus, and forwards only the configured event source to the destination bus.
+
+Operationally, this sits in the same control-plane path as runner scaling, job-log archival, and notification workflows. If a downstream automation misses events, verify the API Gateway/Lambda validation logs first, then the source EventBridge rule, and finally the destination account permissions.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -66,7 +72,7 @@ curl -X POST "$(terraform output -raw webhook_endpoint)/webhook" \
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/integrations/splunk_aws_billing/README.md
+++ b/modules/integrations/splunk_aws_billing/README.md
@@ -1,3 +1,24 @@
+# Splunk AWS Billing Export
+
+This module sends AWS Billing and Cost Management export data into Splunk-oriented processing pipelines.
+
+## Why This Module Exists
+
+Forge needs tenant-level cost visibility to make runner-size, warm-pool, and EC2-vs-Kubernetes decisions from data. Billing exports give the platform the raw cost feed needed for those dashboards and recommendations.
+
+## What It Manages
+
+- Billing Data Exports for service-level and resource-level cost data.
+- An encrypted S3 bucket for billing report delivery.
+- Lambda functions that process billing files.
+- S3 notifications, permissions, log groups, and optional Splunk secrets.
+
+## Operational Notes
+
+- Billing data is delayed by AWS, so dashboards should not be treated as real-time usage telemetry.
+- Resource tags and runner metadata determine how useful tenant attribution will be.
+- Keep S3 retention and access aligned with financial-data handling rules.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -14,7 +35,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/integrations/splunk_cloud_conf_shared/README.md
+++ b/modules/integrations/splunk_cloud_conf_shared/README.md
@@ -1,3 +1,24 @@
+# Splunk Cloud Shared Configuration
+
+This module manages Splunk Cloud saved objects, field extractions, transforms, and dashboards for Forge logs.
+
+## Why This Module Exists
+
+Forge runners are ephemeral, so logs are the durable evidence trail. This module turns raw CloudWatch and runner logs into searchable, tenant-aware Splunk data with dashboards that map symptoms to subsystems.
+
+## What It Manages
+
+- Forge Splunk dashboards for runner lifecycle, capacity, webhooks, job logs, trust failures, tenants, and troubleshooting.
+- Props and transforms for CloudWatch logs, runner logs, Kubernetes logs, Lambda logs, EC2 logs, and billing data.
+- Splunk provider configuration sourced from Secrets Manager.
+- Shared field extraction standards used by operators.
+
+## Operational Notes
+
+- Field names are an operational contract with runbooks and dashboards; change them carefully.
+- This module is log-search configuration, not metrics ingestion.
+- When a dashboard looks wrong, also check ingestion quality and source log fields before assuming the infrastructure failed.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -11,8 +32,8 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
-| <a name="provider_splunk"></a> [splunk](#provider\_splunk) | 1.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_splunk"></a> [splunk](#provider\_splunk) | 1.5.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_cloud_data_manager/README.md
+++ b/modules/integrations/splunk_cloud_data_manager/README.md
@@ -1,3 +1,24 @@
+# Splunk Cloud Data Manager
+
+This module configures Splunk Data Manager integrations for AWS log and metadata ingestion.
+
+## Why This Module Exists
+
+Forge sends EC2, Lambda, EKS, CloudWatch, and security metadata through supported Splunk Cloud ingestion paths. Managing Data Manager as code keeps observability reproducible instead of click-driven.
+
+## What It Manages
+
+- CloudFormation stacks for CloudWatch, custom CloudWatch, and security metadata integrations.
+- Generated Splunk data input modules for each integration payload.
+- A metadata Lambda trigger for EC2 tag enrichment.
+- Outputs containing the resulting Splunk input JSON.
+
+## Operational Notes
+
+- This module expects valid Splunk Cloud credentials and Data Manager configuration.
+- CloudFormation stack failures usually point to AWS-side permissions or region support.
+- Custom log group selection determines which Forge logs arrive in Splunk Cloud.
+
 <!-- BEGIN_TF_DOCS -->
 
 <!-- END_TF_DOCS -->

--- a/modules/integrations/splunk_cloud_data_manager/data_input/README.md
+++ b/modules/integrations/splunk_cloud_data_manager/data_input/README.md
@@ -1,3 +1,24 @@
+# Splunk Data Manager Data Input
+
+This module creates or deletes one Splunk Data Manager integration input and uploads its generated CloudFormation template.
+
+## Why This Module Exists
+
+The parent Data Manager module needs repeatable, reviewable creation of individual Splunk inputs. This submodule handles the API call and template handoff for one integration payload.
+
+## What It Manages
+
+- A generated Splunk integration UUID.
+- External calls that create and delete the Splunk integration.
+- An S3 object containing the CloudFormation template returned by Splunk.
+- Outputs for integration name, tags, and template URL.
+
+## Operational Notes
+
+- The external create/delete scripts are part of the Terraform lifecycle, so failed API calls can affect plan/apply behavior.
+- Do not hand-edit generated CloudFormation templates without reflecting the change in code.
+- Use parent-module outputs to confirm which inputs were created.
+
 <!-- BEGIN_TF_DOCS -->
 
 ## Requirements

--- a/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/README.md
+++ b/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/README.md
@@ -1,3 +1,24 @@
+# Splunk Security Metadata EC2 Tags
+
+This module deploys a Lambda that enriches Splunk security metadata with EC2 tag patterns.
+
+## Why This Module Exists
+
+Forge depends on tags to connect AWS resources back to tenants, runner types, and jobs. This helper keeps EC2 tag metadata visible to Splunk Data Manager so operational and cost queries can group data correctly.
+
+## What It Manages
+
+- A Lambda function for EC2 tag metadata processing.
+- CloudWatch schedule and invocation permission.
+- Log group and IAM policy for the Lambda.
+- Environment variables that describe the tag-processing configuration.
+
+## Operational Notes
+
+- Tag key changes should be coordinated with Splunk dashboards and Data Manager mappings.
+- Use Lambda logs to diagnose missing or malformed metadata.
+- This module augments security metadata; it does not replace runner-side tagging.
+
 <!-- BEGIN_TF_DOCS -->
 
 ## Requirements

--- a/modules/integrations/splunk_cloud_data_manager_common/README.md
+++ b/modules/integrations/splunk_cloud_data_manager_common/README.md
@@ -1,3 +1,24 @@
+# Splunk Data Manager Common IAM
+
+This module creates the common AWS IAM role and policy used by Splunk Cloud Data Manager.
+
+## Why This Module Exists
+
+Data Manager needs a read-only AWS role to inventory and ingest logs or metadata. Forge manages that role as code so every account exposes a predictable, least-privilege integration surface to Splunk.
+
+## What It Manages
+
+- A Data Manager read-only IAM role.
+- Policy permissions assembled for the Splunk integration.
+- Splunk and AWS account discovery through external data sources.
+- Secret lookup for Splunk Cloud credentials.
+
+## Operational Notes
+
+- Keep the role trust aligned with Splunk Data Manager requirements.
+- When Splunk integration setup fails, confirm both the secret values and the external data-source scripts.
+- This module is shared foundation for several Data Manager inputs.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -11,7 +32,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 
 ## Modules

--- a/modules/integrations/splunk_cloud_s3_runner_logs/README.md
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/README.md
@@ -1,3 +1,24 @@
+# Splunk Cloud S3 Runner Logs
+
+This module streams runner log objects from S3 into Splunk Cloud through Kinesis and Firehose.
+
+## Why This Module Exists
+
+Forge archives job logs and operational logs because runners are destroyed after each job. This module moves those S3-backed records into Splunk Cloud so troubleshooting and audit queries can survive the runner lifecycle.
+
+## What It Manages
+
+- Kinesis stream and Firehose delivery stream to Splunk HEC.
+- S3 bucket notifications, SQS buffering, and DLQ handling.
+- A Lambda that transforms or forwards runner log events.
+- KMS keys, backup bucket, IAM roles, and CloudWatch logs.
+
+## Operational Notes
+
+- Splunk HEC endpoint and secret configuration must be correct before enabling delivery.
+- Use the backup bucket and DLQ when logs are missing from Splunk.
+- The S3 event path should match the job-log archiver bucket layout.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -11,7 +32,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 
 ## Modules

--- a/modules/integrations/splunk_o11y_aws_integration/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration/README.md
@@ -1,3 +1,23 @@
+# Splunk Observability AWS Integration Stack
+
+This module deploys the Splunk Observability AWS integration through a CloudFormation stack.
+
+## Why This Module Exists
+
+Forge uses Splunk Observability for AWS metrics while Splunk Cloud handles logs. This module is the regional stack entry point that links AWS metrics into the O11y account.
+
+## What It Manages
+
+- A CloudFormation stack created from the configured template URL.
+- Secret lookups for Splunk access material.
+- Region, ingest URL, and tagging inputs for the integration.
+
+## Operational Notes
+
+- This module depends on a valid Splunk-provided template URL.
+- CloudFormation failures should be debugged in both Terraform output and the CloudFormation events.
+- Use the common integration module for IAM role setup when needed.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +30,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_aws_integration_common/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration_common/README.md
@@ -1,3 +1,24 @@
+# Splunk Observability AWS Integration Common
+
+This module creates the IAM and SignalFx/Splunk Observability objects for AWS metric ingestion.
+
+## Why This Module Exists
+
+Forge separates logs and metrics. This module wires CloudWatch metrics into Splunk Observability so operators can see capacity, Lambda, SQS, DynamoDB, EBS, and runner infrastructure behavior from the metrics side.
+
+## What It Manages
+
+- An AWS IAM role and policies for Splunk Observability integration.
+- SignalFx external and AWS integration resources.
+- Managed policy attachments required by the integration.
+- Secret lookup and a short wait for propagation.
+
+## Operational Notes
+
+- The integration regions should match where Forge infrastructure actually runs.
+- If metrics are missing, validate both AWS role trust and SignalFx integration state.
+- This is metrics plumbing; log field extraction lives in the Splunk Cloud configuration module.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -12,8 +33,8 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
 
 ## Modules

--- a/modules/integrations/splunk_o11y_conf_shared/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/README.md
@@ -1,3 +1,24 @@
+# Splunk Observability Shared Dashboards
+
+This module creates the shared Splunk Observability dashboard group, dashboards, and detectors for Forge metrics.
+
+## Why This Module Exists
+
+Forge operators need dashboards that connect capacity, cost, and health signals to concrete subsystems. This module builds the metrics-side views for EC2 runners, Kubernetes runners, Lambda, SQS, DynamoDB, EBS, billing, and platform impact.
+
+## What It Manages
+
+- A Forge dashboard group in Splunk Observability.
+- Dashboard modules for EC2, Kubernetes, Lambda, SQS, DynamoDB, EBS, billing, and Forge impact.
+- Kubernetes detector modules and notification wiring.
+- Dynamic variables that let dashboards filter by tenant and environment.
+
+## Operational Notes
+
+- Keep dashboard variables aligned with metric dimensions emitted by collectors and AWS integrations.
+- Detector thresholds should be tuned with production noise in mind.
+- Use this alongside the Splunk Cloud log dashboards for full triage context.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -11,8 +32,8 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/README.md
@@ -1,3 +1,24 @@
+# Splunk Observability Billing Dashboard
+
+This module creates the billing dashboard for Forge costs in Splunk Observability.
+
+## Why This Module Exists
+
+Cost is one of the core Forge operating signals because runner choices involve trade-offs between latency, isolation, and spend. This dashboard helps compare tenant and service cost trends instead of guessing.
+
+## What It Manages
+
+- Charts for cost and net cost by service and tenant.
+- Top tenant/service cost lists.
+- Runner-related cost summaries.
+- Dashboard placement in the shared Forge O11y group.
+
+## Operational Notes
+
+- The dashboard is only as accurate as billing exports, tags, and tenant dimensions.
+- Expect billing data to lag behind live infrastructure state.
+- Use this when reviewing warm pools, DinD node pools, and tenant right-sizing.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/README.md
@@ -1,3 +1,24 @@
+# Splunk Observability DynamoDB Dashboard
+
+This module creates DynamoDB health and throughput charts for Forge support tables.
+
+## Why This Module Exists
+
+Forge uses DynamoDB for platform coordination patterns such as global locks and dedupe tables. Operators need visibility into throttling, latency, and errors because those tables sit in critical control-plane paths.
+
+## What It Manages
+
+- Read/write capacity percentage charts.
+- Throttle, system error, user error, and latency charts.
+- Returned item count and request trend views.
+- Dashboard placement in the shared Forge O11y group.
+
+## Operational Notes
+
+- Throttle spikes can affect locks, dedupe, or other self-healing workflows.
+- Use tenant and table filters to separate noisy tables from control-plane issues.
+- Pair this with Lambda and SQS dashboards when debugging end-to-end pipelines.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/README.md
@@ -1,3 +1,24 @@
+# Splunk Observability EBS Dashboard
+
+This module creates EBS volume performance charts for Forge runner and cluster storage.
+
+## Why This Module Exists
+
+ARC runners and EKS infrastructure depend on storage behaving predictably. This dashboard surfaces queue length, latency, throughput, utilization, and volume state when pods are slow to start or jobs are I/O bound.
+
+## What It Manages
+
+- Read/write throughput, operations, and latency charts.
+- Queue length, idle time, byte utilization, and state views.
+- Read/write breakdowns for EBS-backed runner or platform volumes.
+- Dashboard placement in the shared Forge O11y group.
+
+## Operational Notes
+
+- Use this with Kubernetes pending-pod and PVC symptoms.
+- High latency can look like runner slowness even when compute is healthy.
+- Volume dimensions must be tagged or discoverable for tenant attribution.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/README.md
@@ -1,3 +1,25 @@
+# Splunk Observability Forge Impact Dashboard
+
+This module creates the high-level Forge usage and impact dashboard.
+
+## Why This Module Exists
+
+The platform needs to show adoption and workload shape across tenants, not just raw health. This dashboard summarizes EC2 and Kubernetes runner usage, active capacity, runner hours, and runtime distribution.
+
+## What It Manages
+
+- Runner totals and minutes by runtime.
+- Active EC2 runners by tenant and instance type.
+- EC2 runner hours and total runners by tenant.
+- Kubernetes runner totals and hours by tenant.
+- Dashboard parent relationship in the shared O11y group.
+
+## Operational Notes
+
+- Use this for capacity planning and stakeholder reporting.
+- Tenant names must be consistently emitted as dimensions.
+- This dashboard explains platform usage; use subsystem dashboards for incident triage.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +32,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/README.md
@@ -1,3 +1,24 @@
+# Splunk Observability Lambda Dashboard
+
+This module creates Lambda operational charts for Forge control-plane functions.
+
+## Why This Module Exists
+
+Forge relies heavily on Lambdas for webhooks, scaling, tagging, log archival, trust validation, and redrive loops. Lambda errors or throttles often explain platform symptoms before the runner itself is involved.
+
+## What It Manages
+
+- Invocation, error, throttle, and duration charts.
+- Provisioned concurrency and spillover views.
+- Version-level percentages and average duration lists.
+- Dashboard placement in the shared Forge O11y group.
+
+## Operational Notes
+
+- Start here when an EventBridge, SQS, webhook, or trust-validation workflow behaves inconsistently.
+- Version-level charts help catch partial deployments or aliases pointing at unexpected code.
+- Pair Lambda errors with CloudWatch/Splunk logs for request-level detail.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/README.md
@@ -1,3 +1,24 @@
+# Splunk Observability EC2 Runner Dashboard
+
+This module creates EC2 host-level health charts for Forge runner instances.
+
+## Why This Module Exists
+
+EC2 runners are short-lived, but their lifecycle still needs visibility while jobs run. This dashboard helps explain slow jobs, failed registrations, host health issues, and resource pressure in the VM lane.
+
+## What It Manages
+
+- CPU, memory, disk, network, and status-check charts.
+- Top hosts and images by utilization.
+- Active hosts by instance type and availability zone.
+- Dashboard placement in the shared Forge O11y group.
+
+## Operational Notes
+
+- Because runners are ephemeral, use time windows that include the job execution period.
+- Correlate host metrics with job IDs and tags from runner hooks where available.
+- Capacity failures may still appear first in scaling Lambda logs rather than host metrics.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
@@ -1,3 +1,25 @@
+# Splunk Observability Kubernetes Runner Dashboard
+
+This module creates Kubernetes pod and deployment charts for the ARC runner lane.
+
+## Why This Module Exists
+
+Kubernetes runner failures often show up as pending pods, restarts, resource pressure, or collector gaps. This dashboard provides the pod-level view that complements EKS and Karpenter logs.
+
+## What It Manages
+
+- Active, desired, available, and phase-based pod charts.
+- CPU, memory, network, and restart views.
+- Top pod lists for resource usage.
+- OTel collector pod visibility.
+- Dashboard placement in the shared Forge O11y group.
+
+## Operational Notes
+
+- Use this when ARC scale sets see demand but jobs do not start.
+- Pending pods usually require checking Karpenter, taints/tolerations, resource requests, and storage.
+- Collector health affects dashboard reliability, so treat no-data signals seriously.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +32,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/README.md
@@ -1,3 +1,24 @@
+# Splunk Observability SQS Dashboard
+
+This module creates SQS health charts for Forge queue-backed workflows.
+
+## Why This Module Exists
+
+Forge intentionally buffers work through SQS for durability and backpressure. The queues behind job log archival, redrive, and other support flows need visibility into backlog, age, deletes, retries, and DLQ growth.
+
+## What It Manages
+
+- Queue count and top queue charts.
+- Message size, sent/received/deleted, empty receive, and processing trend charts.
+- Oldest-message and dead-letter backlog views.
+- Dashboard placement in the shared Forge O11y group.
+
+## Operational Notes
+
+- Rising oldest-message age means workers are not keeping up or messages are failing repeatedly.
+- DLQ growth should point to either transient provider issues or bad event shapes.
+- Use this with Lambda dashboards to see both queue pressure and worker errors.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
@@ -1,3 +1,24 @@
+# Splunk Observability Kubernetes Detectors
+
+This module creates alert detectors for Kubernetes and OTel health in the Forge ARC lane.
+
+## Why This Module Exists
+
+A small platform team cannot watch every tenant manually. These detectors convert repeated Kubernetes failure modes into routed alerts for missing telemetry, unhealthy platform pods, pending tenant pods, failed pods, and container restarts.
+
+## What It Manages
+
+- No-data and collector-health detectors for the OTel path.
+- Platform namespace health detectors.
+- Tenant pending-pod, failed-pod, and restart detectors.
+- Notification and team routing configuration.
+
+## Operational Notes
+
+- Tune thresholds to avoid alert fatigue; ARC clusters can be bursty by design.
+- No-data alerts may mean telemetry failure, not workload health.
+- Keep platform namespace lists current as new controllers or agents are added.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.2 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
 
 ## Modules
 

--- a/modules/integrations/splunk_otel_eks/README.md
+++ b/modules/integrations/splunk_otel_eks/README.md
@@ -1,3 +1,24 @@
+# Splunk OpenTelemetry for EKS
+
+This module installs the Splunk OpenTelemetry Collector on a Forge EKS cluster.
+
+## Why This Module Exists
+
+Forge sends AWS metrics through the Splunk Observability integration, but Kubernetes needs additional pod-level telemetry. This module supplies that cluster-side collector and the AWS identity needed to enrich metrics.
+
+## What It Manages
+
+- A Helm release for the Splunk OTel Collector.
+- IAM role and policy for EC2 describe permissions.
+- EKS Pod Identity association for the collector service account.
+- Secret lookup for Splunk ingest credentials and collector configuration.
+
+## Operational Notes
+
+- This is metrics-oriented telemetry; EKS logs still flow through CloudWatch and Splunk Cloud paths.
+- Collector no-data issues affect dashboards and detectors, so validate this after cluster upgrades.
+- The collector config should include the namespaces and dimensions used by O11y dashboards.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -12,7 +33,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 3.2.0 |
 
 ## Modules

--- a/modules/integrations/splunk_secrets/README.md
+++ b/modules/integrations/splunk_secrets/README.md
@@ -1,3 +1,24 @@
+# Splunk Secrets
+
+This module creates regional Secrets Manager entries and KMS keys for Splunk-related integrations.
+
+## Why This Module Exists
+
+Forge integrates with Splunk Cloud and Splunk Observability across several modules. Keeping the shared secret material in a consistent, encrypted regional structure avoids each integration inventing its own credential storage.
+
+## What It Manages
+
+- A regional KMS key and alias.
+- A Secrets Manager secret with optional replicas.
+- A generated initial secret version based on random secret seeds.
+- Tags for shared ownership and audit.
+
+## Operational Notes
+
+- Treat generated placeholder values as bootstrap material if real Splunk credentials are populated later.
+- Replica regions should match where Splunk integrations run.
+- Secret names are consumed by other modules, so coordinate renames carefully.
+
 <!-- BEGIN_TF_DOCS -->
 
 ## Requirements

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/README.md
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/README.md
@@ -104,6 +104,87 @@ module "splunk_stuck_workflow_job_dispatcher" {
 }
 ```
 
-<!-- BEGIN_TF_DOCS -->
+## Forge Context
 
+This module closes a specific operational loop in Forge: a queued GitHub Actions job may be stuck because the original webhook delivery did not result in runner creation. Splunk already has the workflow and dispatch evidence, so the saved search turns that evidence into a controlled redelivery request instead of a manual GitHub UI action.
+
+The tenant mapping is stored in SSM chunks because large multi-tenant configuration does not fit comfortably in Lambda environment variables. When changing tenant discovery, verify both the saved search fields and the Lambda-side mapping lookup.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.11 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.47 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.7 |
+| <a name="requirement_splunk"></a> [splunk](#requirement\_splunk) | >= 1.4.30 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_splunk"></a> [splunk](#provider\_splunk) | 1.5.3 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_dispatcher"></a> [dispatcher](#module\_dispatcher) | terraform-aws-modules/lambda/aws | 8.8.0 |
+| <a name="module_worker"></a> [worker](#module\_worker) | terraform-aws-modules/lambda/aws | 8.8.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_apigatewayv2_api.splunk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api) | resource |
+| [aws_apigatewayv2_integration.dispatcher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_integration) | resource |
+| [aws_apigatewayv2_route.splunk_webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_route) | resource |
+| [aws_apigatewayv2_stage.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_stage) | resource |
+| [aws_cloudwatch_log_group.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.dispatcher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_dynamodb_table.dedupe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_lambda_event_source_mapping.worker_from_dedupe_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
+| [aws_lambda_permission.apigw_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_ssm_parameter.tenant_configs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [random_password.webhook_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [splunk_configs_conf.stuck_workflow_job_dispatcher](https://registry.terraform.io/providers/splunk/splunk/latest/docs/resources/configs_conf) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.dispatcher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_secretsmanager_secret.splunk_cloud_api_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret_version.splunk_cloud_api_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile to use. | `string` | n/a | yes |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | Default AWS region. | `string` | n/a | yes |
+| <a name="input_dedupe_ttl_seconds"></a> [dedupe\_ttl\_seconds](#input\_dedupe\_ttl\_seconds) | Seconds to suppress duplicate redelivery work for the same workflow job. | `number` | `1800` | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of default tags to apply to resources. | `map(string)` | n/a | yes |
+| <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Log level for application logging (e.g., INFO, DEBUG, WARN, ERROR). | `string` | `"INFO"` | no |
+| <a name="input_logging_retention_in_days"></a> [logging\_retention\_in\_days](#input\_logging\_retention\_in\_days) | Number of days to retain Lambda and API logs. | `number` | `14` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for created AWS resources. | `string` | `"forge-stuck-workflow-job-dispatcher"` | no |
+| <a name="input_redelivery_config"></a> [redelivery\_config](#input\_redelivery\_config) | GitHub App webhook redelivery behavior.<br/><br/>Nested attributes:<br/>- tenant\_configs: Tenant-specific GitHub Enterprise and deployment prefix mappings.<br/>- tenant\_configs.tenant: Forge tenant name from Splunk logs.<br/>- tenant\_configs.github\_api\_version: Optional GitHub API version header; defaults to 2022-11-28.<br/>- tenant\_configs.gh\_config: GitHub deployment settings for the tenant.<br/>- tenant\_configs.gh\_config.ghes\_url: GitHub Enterprise Server base URL; empty string selects github.com.<br/>- tenant\_configs.prefixes: AWS region-specific deployment prefix mappings for the tenant.<br/>- tenant\_configs.prefixes.aws\_region: AWS region where the tenant GitHub App SSM parameters are stored.<br/>- tenant\_configs.prefixes.deployment\_prefix: SSM prefix under /forge/<deployment\_prefix>/ for GitHub App credentials. | <pre>object({<br/>    tenant_configs = optional(list(object({<br/>      tenant             = string<br/>      github_api_version = optional(string)<br/>      gh_config = object({<br/>        ghes_url = string<br/>      })<br/>      prefixes = list(object({<br/>        aws_region        = string<br/>        deployment_prefix = string<br/>      }))<br/>    })), [])<br/>  })</pre> | `{}` | no |
+| <a name="input_splunk_alert"></a> [splunk\_alert](#input\_splunk\_alert) | Splunk saved-search alert configuration.<br/><br/>Nested attributes:<br/>- name: Splunk saved-search name.<br/>- description: Splunk saved-search description.<br/>- disabled: Whether to create the saved search in a disabled state.<br/>- cron\_schedule: Cron schedule for evaluating the saved search.<br/>- dispatch\_earliest\_time: Earliest Splunk search time for each alert run.<br/>- dispatch\_latest\_time: Latest Splunk search time for each alert run.<br/>- stuck\_minutes\_threshold: Minimum queued duration before redelivery is triggered.<br/>- suppress\_period: Splunk alert suppression window for duplicate stuck-job results. | <pre>object({<br/>    name                    = optional(string, "Forge stuck workflow_job dispatcher")<br/>    description             = optional(string, "Queues GitHub App webhook redelivery when Forge workflow_job queued events stay stuck after dispatch.")<br/>    disabled                = optional(bool, false)<br/>    cron_schedule           = optional(string, "*/1 * * * *")<br/>    dispatch_earliest_time  = optional(string, "-24h")<br/>    dispatch_latest_time    = optional(string, "now")<br/>    stuck_minutes_threshold = optional(number, 5)<br/>    suppress_period         = optional(string, "30m")<br/>  })</pre> | `{}` | no |
+| <a name="input_splunk_conf"></a> [splunk\_conf](#input\_splunk\_conf) | Splunk Cloud connection, ACL, and Forge index settings.<br/><br/>Nested attributes:<br/>- splunk\_cloud: Splunk Cloud host name used by the Splunk provider.<br/>- acl: Access control settings for the saved search.<br/>- acl.app: Splunk app that owns the saved search.<br/>- acl.owner: Splunk owner for the saved search.<br/>- acl.sharing: Splunk sharing scope for the saved search ACL.<br/>- acl.read: Splunk roles allowed to read the saved search.<br/>- acl.write: Splunk roles allowed to update the saved search.<br/>- index: Splunk index containing Forge CICD webhook and dispatch logs.<br/>- tenant\_names: Optional tenant allow-list retained for compatibility with shared Splunk configuration. | <pre>object({<br/>    splunk_cloud = string<br/>    acl = object({<br/>      app     = string<br/>      owner   = string<br/>      sharing = string<br/>      read    = list(string)<br/>      write   = list(string)<br/>    })<br/>    index        = string<br/>    tenant_names = optional(list(string), [])<br/>  })</pre> | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_api_endpoint"></a> [api\_endpoint](#output\_api\_endpoint) | Base HTTP API endpoint for the Splunk alert webhook receiver. |
+| <a name="output_api_log_group_name"></a> [api\_log\_group\_name](#output\_api\_log\_group\_name) | CloudWatch log group containing API Gateway HTTP API access logs. |
+| <a name="output_dedupe_table_name"></a> [dedupe\_table\_name](#output\_dedupe\_table\_name) | DynamoDB table used to suppress duplicate dispatches. |
+| <a name="output_receiver_lambda_function_arn"></a> [receiver\_lambda\_function\_arn](#output\_receiver\_lambda\_function\_arn) | Splunk webhook receiver Lambda ARN. |
+| <a name="output_receiver_lambda_log_group_name"></a> [receiver\_lambda\_log\_group\_name](#output\_receiver\_lambda\_log\_group\_name) | CloudWatch log group containing Splunk webhook receiver Lambda logs. |
+| <a name="output_saved_search_name"></a> [saved\_search\_name](#output\_saved\_search\_name) | Splunk saved search alert name. |
+| <a name="output_splunk_webhook_url"></a> [splunk\_webhook\_url](#output\_splunk\_webhook\_url) | Full Splunk webhook URL, including the shared path token. |
+| <a name="output_worker_lambda_function_arn"></a> [worker\_lambda\_function\_arn](#output\_worker\_lambda\_function\_arn) | GitHub App redelivery worker Lambda ARN. |
+| <a name="output_worker_lambda_log_group_name"></a> [worker\_lambda\_log\_group\_name](#output\_worker\_lambda\_log\_group\_name) | CloudWatch log group containing GitHub App redelivery worker Lambda logs. |
 <!-- END_TF_DOCS -->

--- a/modules/integrations/teleport/README.md
+++ b/modules/integrations/teleport/README.md
@@ -1,3 +1,24 @@
+# Teleport EKS Access
+
+This module configures Teleport access into Forge EKS clusters.
+
+## Why This Module Exists
+
+Forge runners are ephemeral, so most troubleshooting uses logs. When live access is necessary, Teleport provides an audited path into Kubernetes instead of unmanaged SSH or shared kubeconfigs.
+
+## What It Manages
+
+- A Teleport IAM role and EKS access policy.
+- An `aws-auth` Kubernetes ConfigMap entry for Teleport.
+- Per-tenant Kubernetes RBAC through the tenant submodule.
+- Outputs for Teleport role, tenant groups, cluster name, and account ID.
+
+## Operational Notes
+
+- Teleport is a break-glass/debugging path, not the normal operations interface.
+- Access should map to identity groups and tickets outside this module.
+- RBAC changes affect live cluster access, so test with least privilege.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -12,7 +33,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 3.2.0 |
 
 ## Modules

--- a/modules/integrations/teleport/tenant/README.md
+++ b/modules/integrations/teleport/tenant/README.md
@@ -1,3 +1,23 @@
+# Teleport Tenant RBAC
+
+This module creates the Kubernetes RBAC objects that let Teleport users inspect a specific tenant namespace.
+
+## Why This Module Exists
+
+Tenant-scoped live debugging should not imply cluster-wide access. This module grants the impersonation and pod permissions needed for a tenant namespace while preserving the namespace boundary.
+
+## What It Manages
+
+- ClusterRole and ClusterRoleBinding for impersonation.
+- Namespace RoleBinding for pod access.
+- Bindings scoped by the tenant namespace input.
+
+## Operational Notes
+
+- Use this only with the parent Teleport module and the organization access process.
+- Keep namespace names aligned with Forge tenant names.
+- Expand permissions deliberately; this is an audited human-access path.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/platform/arc_deployment/README.md
+++ b/modules/platform/arc_deployment/README.md
@@ -1,3 +1,24 @@
+# ARC Deployment Wrapper
+
+This module maps tenant runner configuration into the core ARC module.
+
+## Why This Module Exists
+
+Forge tenant configuration is written once, then expanded into platform modules. This wrapper is the tenant-facing ARC adapter: it translates runner specs, labels, images, resource limits, ECR access, and cluster migration flags into the lower-level Kubernetes resources.
+
+## What It Manages
+
+- A call into `modules/core/arc` for the tenant.
+- ARC controller settings derived from the tenant prefix and namespace.
+- Scale set definitions for each configured Kubernetes runner pool.
+- Runner IAM policy attachments and ECR registry wiring.
+
+## Operational Notes
+
+- This is the module to inspect when a tenant config value does not appear in the generated ARC resources.
+- The wrapper does not create the EKS cluster; it targets an existing cluster by name.
+- A tenant with no ARC runner specs will not create ARC scale sets.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/platform/ec2_deployment/README.md
+++ b/modules/platform/ec2_deployment/README.md
@@ -1,3 +1,25 @@
+# EC2 Runner Deployment
+
+This module deploys Forge EC2 runner pools using the upstream `terraform-aws-github-runner` multi-runner module.
+
+## Why This Module Exists
+
+The EC2 lane gives a GitHub Actions job a full VM or dedicated host. Forge uses it for workloads that need VM-level control, custom AMIs, macOS/Windows, larger hardware, or stronger isolation than a normal pod can provide.
+
+## What It Manages
+
+- The upstream multi-runner control plane for webhook, scale-up, scale-down, and ephemeral runner registration.
+- Per-runner-pool label matching, AMI selection, instance types, warm pool schedules, and capacity type.
+- KMS key material, Lambda egress security group, runner tags policy, and logging hooks.
+- Supporting modules that update runner tags and runner AMI SSM parameters.
+
+## Operational Notes
+
+- Every EC2 runner is ephemeral; the instance is expected to register for one job and then be reaped.
+- Label sets are the API contract with tenant workflows, so exact matching matters.
+- Cold starts can take minutes; use warm pools only where latency justifies the idle cost.
+- Subnet IP capacity and EC2 capacity errors are expected operational signals, not unusual exceptions.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -12,7 +34,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
 
 ## Modules

--- a/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/README.md
+++ b/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/README.md
@@ -1,3 +1,24 @@
+# EC2 Runner AMI SSM Updater
+
+This module schedules a Lambda that records the currently selected runner AMIs in SSM Parameter Store.
+
+## Why This Module Exists
+
+Forge runner AMIs are updated as images are rebuilt and tested. This helper keeps a discoverable SSM record of the AMI mapping used by EC2 runner pools, which makes operations and downstream lookups less dependent on Terraform state inspection.
+
+## What It Manages
+
+- A Lambda function built from the local updater code.
+- An EventBridge schedule that invokes the updater.
+- CloudWatch logs and IAM permissions for reading AMI metadata and writing SSM parameters.
+- The runner AMI map passed from the EC2 deployment module.
+
+## Operational Notes
+
+- Use the log group when an expected AMI value is not reflected in SSM.
+- The updater is metadata plumbing; it does not build AMIs or change a runner pool by itself.
+- Keep the schedule aligned with image-release cadence and operational visibility needs.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/platform/ec2_deployment/ec2_update_runner_tags/README.md
+++ b/modules/platform/ec2_deployment/ec2_update_runner_tags/README.md
@@ -1,3 +1,24 @@
+# EC2 Runner Tag Updater
+
+This module deploys a Lambda that enriches EC2 runner instances with job and workflow metadata.
+
+## Why This Module Exists
+
+Ephemeral runners disappear quickly, so tags have to be applied while a job is active. Forge uses those tags for cost allocation, troubleshooting, and Splunk dimensions that let operators connect a GitHub job back to AWS resources.
+
+## What It Manages
+
+- A Lambda function built from the tag updater code.
+- EventBridge rule and permissions for invocation from runner events.
+- IAM permissions to describe and tag EC2 instances.
+- CloudWatch logging for update attempts and failures.
+
+## Operational Notes
+
+- Missing tags usually point to event-shape, EventBridge, or EC2 permission problems.
+- Tags are part of the observability and cost model; avoid changing keys without updating dashboards and field extractions.
+- This module complements, rather than replaces, the base runner tags configured on the EC2 deployment.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/platform/forge_runners/README.md
+++ b/modules/platform/forge_runners/README.md
@@ -1,3 +1,26 @@
+# Forge Runners Tenant Stack
+
+This is the umbrella tenant module for Forge GitHub Actions runners.
+
+## Why This Module Exists
+
+Forge is a multi-tenant CI platform built around ephemeral runners, short-lived identity, and centralized operations. This module composes the tenant stack: EC2 runners, ARC runners, GitHub App settings, runner group reconciliation, trust validation, log archival, webhook relay, and self-healing support utilities.
+
+## What It Manages
+
+- EC2 runner deployment and ARC runner deployment.
+- GitHub App secret material in SSM Parameter Store.
+- IAM policies that let runners assume tenant-approved roles and pull allowed ECR images.
+- Runner group registration, trust validation, global lock, job log archival, webhook relay, and DLQ redrive helpers.
+- AppRegistry application metadata for the tenant deployment.
+
+## Operational Notes
+
+- This is the best starting point when onboarding or debugging a tenant because it shows how the platform pieces compose.
+- The tenant `deployment_config` defines the GitHub App, runner group, repository selection, and IAM bridge.
+- The EC2 and ARC lanes can both be enabled for the same tenant; workflows choose by labels.
+- Changing GitHub App or runner-group settings can affect job routing immediately.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -16,7 +39,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |

--- a/modules/platform/forge_runners/forge_trust_validator/README.md
+++ b/modules/platform/forge_runners/forge_trust_validator/README.md
@@ -1,3 +1,25 @@
+# Forge Trust Validator
+
+This module proactively validates tenant IAM trust relationships used by Forge runners.
+
+## Why This Module Exists
+
+Most runner AWS-auth failures happen at the ownership boundary between Forge and the tenant account. The validator turns those failures into scheduled checks by testing whether Forge runner roles can assume tenant roles and tag sessions before a real workflow depends on them.
+
+## What It Manages
+
+- A preparer Lambda that injects temporary validation trust.
+- An SQS delay queue used to wait for IAM propagation.
+- A validator Lambda that tests `sts:AssumeRole` and session tagging.
+- CloudWatch schedules, log groups, IAM policies, and cleanup permissions.
+
+## Operational Notes
+
+- The delay is intentional because IAM trust changes are eventually consistent.
+- Cleanup is load-bearing: temporary trust must be removed even when validation fails.
+- A green `AssumeRole` check is not enough if `sts:TagSession` is missing.
+- Use this module when tenant role access is added or changed.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +32,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/platform/forge_runners/github_actions_job_logs/README.md
+++ b/modules/platform/forge_runners/github_actions_job_logs/README.md
@@ -118,6 +118,12 @@ Then re-run Terraform apply so the updated `source_code_hash` triggers deploymen
 ## License
 See parent repository license.
 
+## Forge Context
+
+Forge relies on ephemeral runners, so the runner is often gone by the time someone needs to debug or audit a job. This module preserves the job log and the workflow job event as durable, KMS-encrypted S3 objects and gives the platform a queue-backed retry path for GitHub API or ingestion failures.
+
+The EventBridge -> dispatcher -> SQS -> archiver shape is intentional. It provides backpressure, retry, and DLQ handling so a temporary GitHub or network issue does not permanently drop audit evidence.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -130,7 +136,7 @@ See parent repository license.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/platform/forge_runners/github_app_runner_group/README.md
+++ b/modules/platform/forge_runners/github_app_runner_group/README.md
@@ -1,3 +1,24 @@
+# GitHub App Runner Group Registration
+
+This module keeps the GitHub App installation and runner group aligned with the tenant repository selection.
+
+## Why This Module Exists
+
+Runner groups are the GitHub-side boundary that keeps one tenant job from consuming another tenant runner. Forge reconciles that mapping automatically so onboarding repositories does not require manual GitHub UI work.
+
+## What It Manages
+
+- A scheduled Lambda for runner group registration/reconciliation.
+- CloudWatch logs and EventBridge schedule.
+- IAM permissions and GitHub App configuration needed by the Lambda.
+- Inputs for GHES/GitHub URL, organization, runner group, and repository selection.
+
+## Operational Notes
+
+- If jobs stay queued even though runners exist, check labels and runner-group registration together.
+- `repository_selection` must match the GitHub App installation policy: `all` or `selected`.
+- This module changes GitHub-side routing, so treat failures as tenant-impacting.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/platform/forge_runners/github_global_lock/README.md
+++ b/modules/platform/forge_runners/github_global_lock/README.md
@@ -1,3 +1,24 @@
+# GitHub Global Lock
+
+This module provides a DynamoDB-backed distributed lock for workflows that must not run concurrently.
+
+## Why This Module Exists
+
+Some CI/CD operations are safe only when serialized across repositories or workflow runs. Forge gives tenants a shared lock primitive and a janitor that clears stale locks when the owning run has already completed.
+
+## What It Manages
+
+- A DynamoDB lock table and policy.
+- A cleanup Lambda with scheduled EventBridge invocation.
+- GitHub App access used to inspect workflow-run status.
+- An output policy ARN that runner roles can attach for lock access.
+
+## Operational Notes
+
+- The cleanup Lambda is the self-healing path for abandoned locks.
+- DynamoDB TTL is a backstop; workflows should still release locks explicitly.
+- Changing lock key conventions requires workflow and cleanup logic to stay in sync.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 

--- a/modules/platform/forge_runners/github_webhook_relay/README.md
+++ b/modules/platform/forge_runners/github_webhook_relay/README.md
@@ -1,3 +1,24 @@
+# GitHub Webhook Relay Source Secret
+
+This module prepares the source-side secret and optional relay source for forwarding GitHub webhook events across accounts.
+
+## Why This Module Exists
+
+Forge integrations often need GitHub workflow events in an account that is not the original runner account. The relay pattern preserves webhook validation at the edge, stores the secret in AWS, and forwards normalized events through EventBridge.
+
+## What It Manages
+
+- A generated webhook relay secret stored in Secrets Manager with KMS encryption.
+- A reader role that can expose the source secret to an approved destination account.
+- Optional composition of the `github_webhook_relay_source` module.
+- Outputs for the secret ARN, reader role ARN, and region.
+
+## Operational Notes
+
+- The relay secret protects the public webhook ingress path; rotate intentionally.
+- Cross-account readers should be limited to the destination receiver account and role.
+- This module is source-side plumbing; destination receivers are configured in the integrations modules.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -11,7 +32,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 
 ## Modules

--- a/modules/platform/forge_runners/redrive_deadletter/README.md
+++ b/modules/platform/forge_runners/redrive_deadletter/README.md
@@ -1,3 +1,24 @@
+# Dead-Letter Redrive
+
+This module deploys a scheduled Lambda that redrives failed SQS messages for Forge support pipelines.
+
+## Why This Module Exists
+
+Forge favors self-healing queues over manual replay. When transient failures push messages into a dead-letter queue, this module gives the platform a controlled retry loop so short outages do not permanently drop work.
+
+## What It Manages
+
+- A redrive Lambda function.
+- An EventBridge schedule for periodic redrive attempts.
+- CloudWatch logs and IAM permissions to read DLQs and send messages back to source queues.
+- An input map of queue relationships to redrive.
+
+## Operational Notes
+
+- Use this for queues where replay is safe and idempotent.
+- Do not redrive poison messages forever without alerting; repeated failures indicate a real bug or bad event shape.
+- Keep the SQS map updated when adding new Forge queues.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -10,7 +31,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
 
 ## Modules
 


### PR DESCRIPTION
## Description

Adds human-readable module documentation before the existing terraform-docs sections across the Forge Terraform modules. The new preambles explain what each module does, why it exists in the Forge architecture, what it manages, and operational notes for readers.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- Ran `git diff --check`
- Verified Terraform module READMEs preserved their `BEGIN_TF_DOCS` / `END_TF_DOCS` generated sections.