### PR TITLE
docs: add forge operations skeleton

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,3 +14,4 @@ Forge is a platform for secure, ephemeral GitHub Actions runners on AWS with mul
 - [Tenant Usage Guide](tenant-usage/index.md)
 - [Secrets Reference](./configurations/secrets.md)
 - [Module Dependency Guide](./configurations/dependency.md)
+- [Forge Operations Patterns](./operations-patterns/README.md)

--- a/docs/operations-patterns/README.md
+++ b/docs/operations-patterns/README.md
@@ -1,0 +1,100 @@
+# Forge Operations Patterns
+
+This folder is a portable operations skeleton for maintaining Forge with the
+same discipline used by the surrounding operations repositories, without
+copying private company adapters, credential flows, or deployment-specific
+implementation details.
+
+It is intentionally Markdown-only. Treat it as a shareable playbook and
+template kit, not as runnable automation.
+
+## What This Captures
+
+The source repositories share a few durable patterns:
+
+- Every repository has a small quality gate that runs on pull requests and
+  pushes.
+- Operational work is split into entry workflows, reusable workflow contracts,
+  and local task actions.
+- Risky execution is separated from dry-run validation and guarded by protected
+  environments.
+- Dynamic infrastructure or tenant work is discovered from the repository
+  structure before execution instead of being hardcoded in one static matrix.
+- Scheduled maintenance jobs are treated as first-class workflows with
+  concurrency controls and human-readable summaries.
+- Review readiness is standardized with simple PR templates, validation
+  evidence, and explicit risk notes.
+- Agent or automation work is constrained by scope, local validation, and
+  non-destructive defaults.
+
+## Folder Map
+
+| Path                      | Purpose                                                       |
+| ------------------------- | ------------------------------------------------------------- |
+| `automation-blueprint.md` | Map of the automation families that keep Forge low-touch.     |
+| `repo-structure.md`       | Recommended repository layout and ownership boundaries.       |
+| `pipeline-patterns.md`    | Reusable pipeline shapes extracted from the repos.            |
+| `day-2-operations.md`     | Operating rhythm for day-to-day Forge maintenance.            |
+| `adapter-contracts.md`    | Inputs, outputs, and behavior for local workflow adapters.    |
+| `catalog-schemas.md`      | Example schemas for automation and repository catalogs.       |
+| `script-interfaces.md`    | Stable local script arguments, outputs, and exit codes.       |
+| `workflow-summaries.md`   | Example summaries for operators and reviewers.                |
+| `rollback-examples.md`    | Rollback shapes for each automation family.                   |
+| `required-checks.md`      | Stable final-check naming for branch protection.              |
+| `ownership-matrix.md`     | Owner, backup, reviewer, and escalation template.             |
+| `reference-skeleton/`     | Concrete repo folder tree for a Forge operations repo.        |
+| `playbooks/`              | Focused runbooks for recurring maintainer workflows.          |
+| `templates/`              | Fill-in documents for PRs, incidents, reviews, and repo maps. |
+| `examples/`               | Copyable example snippets for each automation family.         |
+
+## What Was Excluded
+
+The scan found implementation details that should not be copied into this
+portable skeleton:
+
+- Company-owned GitHub actions and repository owners.
+- Private registry images, numeric identifiers, and bot identities.
+- Organization-specific login or credential bootstrap commands.
+- Internal compliance, ticketing, chat, and observability system names.
+- Deployment-tool installation flows and environment-specific adapters.
+
+Those details can be reattached later behind local adapters, but the shared
+pattern should stay platform-neutral.
+
+## Adoption Checklist
+
+1. Pick the Forge area: tenant lifecycle, runner images, integrations,
+   examples, documentation, or release management.
+1. Fill `templates/repo-map.md` for the area before changing files.
+1. Fill `templates/automation-catalog.md` when the change touches image baking,
+   repository management, scheduled jobs, or dependency automation.
+1. Check `adapter-contracts.md` before adding or changing local adapters.
+1. Check `script-interfaces.md` before adding scripts used by workflows.
+1. Select the matching playbook from `playbooks/`.
+1. Record the validation commands and outputs in `templates/change-record.md`.
+1. Use `templates/pr-description.md` for reviewer-facing scope, risk, and
+   rollback notes.
+
+## Automation Families
+
+Use these skeletons for the operational work that makes Forge maintainable:
+
+| Automation                                           | Playbook                                 | Example                                        |
+| ---------------------------------------------------- | ---------------------------------------- | ---------------------------------------------- |
+| Bake and test runner images                          | `playbooks/image-bake-and-test.md`       | `examples/image-factory-workflow.md`           |
+| Build and smoke-check containers                     | `playbooks/container-build-and-check.md` | `examples/container-factory-workflow.md`       |
+| Manage IaC repositories                              | `playbooks/iac-repository-operations.md` | `examples/iac-operations-workflow.md`          |
+| Create and govern repositories from a catalog        | `playbooks/repository-factory.md`        | `examples/repository-factory-catalog.md`       |
+| Run cron-style scheduled maintenance jobs            | `playbooks/scheduled-jobs.md`            | `examples/scheduled-job-workflow.md`           |
+| Run Custodian-style policy hygiene jobs              | `playbooks/policy-hygiene-jobs.md`       | `examples/policy-hygiene-job.md`               |
+| Run Renovate-style dependency automation             | `playbooks/dependency-automation.md`     | `examples/dependency-automation-config.md`     |
+| Orchestrate migrations and active/inactive rotations | `playbooks/migration-orchestration.md`   | `examples/migration-orchestration-workflow.md` |
+
+## Design Rule
+
+Keep the pattern generic and adapter-driven:
+
+- The pattern describes what must happen.
+- The local adapter decides how credentials, environments, runners, and
+  deployment engines are wired.
+- The PR explains which adapter was used and what validation proved.

--- a/docs/operations-patterns/adapter-contracts.md
+++ b/docs/operations-patterns/adapter-contracts.md
@@ -1,0 +1,177 @@
+# Adapter Contracts
+
+Adapters isolate local implementation details from the reusable workflow shape.
+Each adapter should have a small, stable interface so workflows stay readable
+and private wiring can change without rewriting every automation.
+
+## Common Rules
+
+- Inputs and outputs must be documented in `action.yml`.
+- Adapters should not print sensitive values.
+- Adapters should fail fast when required environment or secrets are missing.
+- Adapters should emit only stable outputs needed by later steps.
+- Adapters should be testable with a dry-run or validation mode.
+
+## `auth-adapter`
+
+Purpose: prepare access for read-only and mutating operations.
+
+```yaml
+name: auth-adapter
+description: Prepare local credentials for Forge operations.
+inputs:
+  environment:
+    description: Target environment name.
+    required: true
+  mode:
+    description: read-only or write.
+    required: true
+outputs:
+  identity:
+    description: Redacted identity label for summaries.
+    value: ${{ steps.auth.outputs.identity }}
+runs:
+  using: composite
+  steps:
+    - id: auth
+      shell: bash
+      run: ./scripts/adapter-auth.sh "${{ inputs.environment }}" "${{ inputs.mode }}"
+```
+
+Expected behavior:
+
+- `mode=read-only` cannot mutate remote state.
+- `mode=write` fails unless the workflow environment approved the job.
+- Output `identity` is safe to publish in a summary.
+
+## `deployment-adapter`
+
+Purpose: run dry-run and apply operations against one discovered unit.
+
+```yaml
+name: deployment-adapter
+description: Run declared-state operations for one unit.
+inputs:
+  command:
+    description: dry-run or apply.
+    required: true
+  path:
+    description: Unit path.
+    required: true
+  summary-file:
+    description: Markdown summary output path.
+    required: false
+    default: deployment-summary.md
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        ./scripts/run-deployment.sh \
+          --command "${{ inputs.command }}" \
+          --path "${{ inputs.path }}" \
+          --summary-file "${{ inputs.summary-file }}"
+```
+
+Expected behavior:
+
+- `dry-run` exits nonzero on validation errors.
+- `apply` exits nonzero on partial apply or unknown final state.
+- Summary includes changed, unchanged, failed, and skipped resources.
+
+## `registry-adapter`
+
+Purpose: authenticate to the local image registry without exposing registry
+details in reusable examples.
+
+```yaml
+name: registry-adapter
+description: Prepare registry access for build or publish jobs.
+inputs:
+  mode:
+    description: pull, push, or both.
+    required: true
+outputs:
+  registry:
+    description: Redacted registry label.
+    value: ${{ steps.registry.outputs.registry }}
+runs:
+  using: composite
+  steps:
+    - id: registry
+      shell: bash
+      run: ./scripts/adapter-registry.sh "${{ inputs.mode }}"
+```
+
+Expected behavior:
+
+- Pull-only mode cannot push.
+- Push mode requires an approved publish environment.
+- Output must not include tokens.
+
+## `notification-adapter`
+
+Purpose: publish summaries to the local notification or request system.
+
+```yaml
+name: notification-adapter
+description: Publish a sanitized operation summary.
+inputs:
+  summary-file:
+    required: true
+  severity:
+    required: false
+    default: info
+  title:
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        ./scripts/publish-summary.sh \
+          --title "${{ inputs.title }}" \
+          --severity "${{ inputs.severity }}" \
+          --summary-file "${{ inputs.summary-file }}"
+```
+
+Expected behavior:
+
+- Fails if the summary contains blocked sensitive patterns.
+- Links back to workflow run or commit.
+- Does not publish raw logs by default.
+
+## `workflow-toggle-adapter`
+
+Purpose: disable or enable competing automations during controlled migrations.
+
+```yaml
+name: workflow-toggle-adapter
+description: Toggle selected workflows during migrations.
+inputs:
+  state:
+    description: enabled or disabled.
+    required: true
+  reason:
+    description: Human-readable maintenance reason.
+    required: true
+  workflow-group:
+    description: Named workflow group to toggle.
+    required: false
+    default: migration-sensitive
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        ./scripts/toggle-workflows.sh \
+          --state "${{ inputs.state }}" \
+          --reason "${{ inputs.reason }}" \
+          --workflow-group "${{ inputs.workflow-group }}"
+```
+
+Expected behavior:
+
+- Disable is idempotent.
+- Enable always runs in a final `always()` cleanup job.
+- Summary lists each workflow touched.

--- a/docs/operations-patterns/automation-blueprint.md
+++ b/docs/operations-patterns/automation-blueprint.md
@@ -1,0 +1,78 @@
+# Forge Automation Blueprint
+
+This page turns the observed operations repositories into a portable automation
+map. It describes the shape of each automation family without copying private
+actions, credentials, registry paths, or organization names.
+
+## Automation Map
+
+| Family                | Purpose                                                                            | Typical Triggers                       | Core Contract                                                                                     | Evidence                                                                |
+| --------------------- | ---------------------------------------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Image factory         | Bake runner images, test them, and publish only verified candidates.               | Pull request, push, manual dispatch.   | Compute version, decide matrix, bake image, collect test matrix, smoke test, aggregate PR status. | Image identifiers, build logs, smoke test result, final validation job. |
+| Container factory     | Build support containers and verify the produced image can start.                  | Pull request, push, manual dispatch.   | Build image, tag/version, scan or lint, smoke-check with expected command.                        | Image tag, digest, check output.                                        |
+| IaC operations        | Dry-run on PRs and apply from protected paths.                                     | Pull request, protected push, dispatch | Discover units, group by dependency layer, dry-run or apply per unit, aggregate status.           | Changed paths, dry-run summary, apply summary, final validation job.    |
+| Repository factory    | Create repositories and apply branch protections, teams, metadata, and webhooks.   | Catalog change, manual dispatch.       | Validate catalog, dry-run changes, apply approved state, verify resulting settings.               | Catalog diff, dry-run summary, applied repository list, drift check.    |
+| Scheduled jobs        | Run recurring hygiene without a human starting each job.                           | Schedule plus manual dispatch.         | Acquire lock, run scoped task, emit summary, fail loudly on partial state.                        | Summary artifact, changed resources, skipped resources.                 |
+| Policy hygiene        | Enforce platform policy and report drift.                                          | Schedule plus manual dispatch.         | Load policy set, run read-only scan or approved remediation, publish findings.                    | Findings summary, exemptions, remediation result.                       |
+| Dependency automation | Keep dependencies current with controlled PRs and post-update validation.          | Schedule plus manual dispatch.         | Load dependency config, authenticate through an adapter, open PRs, run validation.                | Dependency PRs, update log, failed lookup list.                         |
+| Migration flow        | Move tenants or workloads between active and inactive states without hand driving. | Manual dispatch.                       | Discover active state, disable competing jobs, execute phased migration, re-enable normal jobs.   | Phase summary, tenant matrix, rollback checkpoint.                      |
+
+## Common Contract
+
+Every automation family should answer the same questions:
+
+- What is the source of truth?
+- What is discovered at runtime?
+- Which step is read-only validation?
+- Which step can mutate state?
+- What approval gate protects mutation?
+- What final status check should branch protection depend on?
+- What evidence is left for the next maintainer?
+
+## Adapter Boundary
+
+Keep private implementation behind local adapters:
+
+- Authentication.
+- Registry login.
+- Environment selection.
+- Deployment engine setup.
+- Notification or request-system updates.
+- Secret retrieval.
+
+The portable skeleton should name the adapter purpose, not the private command.
+
+## PR Status Pattern
+
+For large automations, require one stable final status:
+
+1. Discover work.
+1. Run conditional or matrix jobs.
+1. Run a final `validate` job with `always()`.
+1. Fail `validate` when any required job failed or was cancelled.
+1. Make branch protection depend on `validate`, not dynamic matrix job names.
+
+## Summary Pattern
+
+Every scheduled, migration, image, and repository automation should publish a
+human-readable summary:
+
+- Inputs used.
+- Targets discovered.
+- Targets changed.
+- Targets skipped.
+- Failures and retry guidance.
+- Rollback or resume point.
+
+## Example Templates
+
+Concrete snippets live under `examples/`:
+
+- `examples/image-factory-workflow.md`
+- `examples/container-factory-workflow.md`
+- `examples/iac-operations-workflow.md`
+- `examples/repository-factory-catalog.md`
+- `examples/scheduled-job-workflow.md`
+- `examples/policy-hygiene-job.md`
+- `examples/dependency-automation-config.md`
+- `examples/migration-orchestration-workflow.md`

--- a/docs/operations-patterns/catalog-schemas.md
+++ b/docs/operations-patterns/catalog-schemas.md
@@ -1,0 +1,181 @@
+# Catalog Schemas
+
+Catalog schemas make the skeleton enforceable. They prevent malformed
+repository, image, schedule, and ownership config from reaching workflow logic.
+
+## Validation Command Pattern
+
+```bash
+./scripts/validate-catalog.sh \
+  --schema schemas/repositories.schema.json \
+  --catalog config/repositories.yaml
+```
+
+The validator should exit nonzero when:
+
+- required fields are missing
+- unknown fields are present
+- required checks are empty for a protected repository
+- mutating automations lack an owner
+- schedules lack manual dispatch support
+
+## Repository Catalog Schema Example
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["metadata", "repositories"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": ["default_branch", "default_visibility"],
+      "properties": {
+        "default_branch": { "type": "string" },
+        "default_visibility": {
+          "type": "string",
+          "enum": ["private", "internal", "public"]
+        },
+        "template_repository": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "repositories": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "description", "teams", "branch_protection"],
+        "properties": {
+          "name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
+          "description": { "type": "string", "minLength": 10 },
+          "visibility": { "type": "string" },
+          "template": { "type": "string" },
+          "topics": { "type": "array", "items": { "type": "string" } },
+          "teams": {
+            "type": "object",
+            "properties": {
+              "readers": { "type": "array", "items": { "type": "string" } },
+              "writers": { "type": "array", "items": { "type": "string" } },
+              "maintainers": { "type": "array", "items": { "type": "string" } },
+              "admins": { "type": "array", "items": { "type": "string" } }
+            },
+            "additionalProperties": false
+          },
+          "branch_protection": {
+            "type": "object",
+            "required": ["required_checks", "required_reviews"],
+            "properties": {
+              "required_checks": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string" }
+              },
+              "required_reviews": { "type": "integer", "minimum": 1 }
+            },
+            "additionalProperties": true
+          },
+          "rulesets": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "webhooks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "url", "events", "active", "secret_ref"],
+              "properties": {
+                "name": { "type": "string" },
+                "url": { "type": "string" },
+                "events": { "type": "array", "items": { "type": "string" } },
+                "active": { "type": "boolean" },
+                "secret_ref": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## Automation Catalog Schema Example
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["automations"],
+  "properties": {
+    "automations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "family", "owner", "source_of_truth", "final_check"],
+        "properties": {
+          "name": { "type": "string" },
+          "family": {
+            "type": "string",
+            "enum": [
+              "image-factory",
+              "container-factory",
+              "iac-operations",
+              "repository-factory",
+              "scheduled-job",
+              "policy-hygiene",
+              "dependency-automation",
+              "migration"
+            ]
+          },
+          "owner": { "type": "string" },
+          "source_of_truth": { "type": "string" },
+          "manual_dispatch": { "type": "boolean" },
+          "schedule": { "type": ["string", "null"] },
+          "final_check": { "type": "string" },
+          "mutates_state": { "type": "boolean" },
+          "approval_environment": { "type": ["string", "null"] }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}
+```
+
+## Image Catalog Schema Example
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["images"],
+  "properties": {
+    "images": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["family", "path", "architectures", "smoke_test"],
+        "properties": {
+          "family": { "type": "string" },
+          "path": { "type": "string" },
+          "versions": { "type": "array", "items": { "type": "string" } },
+          "architectures": { "type": "array", "items": { "type": "string" } },
+          "smoke_test": { "type": "string" },
+          "downstream_consumers": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}
+```

--- a/docs/operations-patterns/day-2-operations.md
+++ b/docs/operations-patterns/day-2-operations.md
@@ -1,0 +1,73 @@
+# Day-2 Operations Loop
+
+This is the steady-state maintenance loop for Forge. It keeps urgent support,
+planned changes, dependency updates, and platform hygiene in one operating
+model.
+
+## Daily
+
+- Check failed CI or scheduled maintenance workflows.
+- Triage tenant-facing incidents with the latest workflow logs and config diff.
+- Review open pull requests for stuck checks, stale review comments, and missing
+  validation evidence.
+- Confirm no emergency change bypassed the documented rollback path.
+
+## Weekly
+
+- Review dependency update PRs and group them by risk.
+- Check runner image, container, and example workflow drift.
+- Review image bake and smoke-test results for recent tool or base updates.
+- Confirm repository factory changes were applied through catalog review instead
+  of manual settings drift.
+- Verify dashboards, alerts, and runbooks still match current event fields.
+- Review newly added tenants or workloads for config consistency.
+- Close the loop on incident action items.
+
+## Monthly
+
+- Audit branch protection and required checks against current workflow names.
+- Review scheduled jobs for stale credentials, disabled workflows, or silent
+  failures.
+- Review policy hygiene findings and expired exemptions.
+- Refresh generated documentation and confirm human-written docs still explain
+  the current behavior.
+- Review cost, capacity, and queue-time signals for runner pools.
+- Test at least one full tenant lifecycle in a non-production environment.
+
+## Change Flow
+
+1. Define the requested outcome and impacted area.
+1. Fill `templates/repo-map.md` if the area is unfamiliar.
+1. Choose the matching playbook.
+1. Make the smallest scoped change.
+1. Run the repo-local quality gate.
+1. Run a dry-run or smoke test for the impacted area.
+1. Fill `templates/change-record.md`.
+1. Open the PR with scope, validation, risk, and rollback.
+1. Watch the required checks after push.
+
+## Incident Flow
+
+1. Capture symptom, time window, workflow, and impacted tenant or component.
+1. Identify the exact failing step or missing signal.
+1. Reproduce locally when possible.
+1. Patch the smallest failing contract.
+1. Verify with local commands and a rerun.
+1. Record root cause and prevention in `templates/incident-log.md`.
+
+## Release Flow
+
+1. Confirm merged changes since the last release.
+1. Confirm generated docs and examples match the release state.
+1. Run release validation or consume the candidate artifact in a smoke test.
+1. Publish release metadata.
+1. Watch post-release scheduled jobs and dependency automation.
+
+## Exit Criteria For Maintenance Work
+
+- The changed files match the requested scope.
+- The source of truth is clear.
+- Validation evidence is recorded.
+- Rollback is documented.
+- Any private adapter or environment-specific dependency is named in the PR, not
+  hidden in a generic playbook.

--- a/docs/operations-patterns/examples/README.md
+++ b/docs/operations-patterns/examples/README.md
@@ -1,0 +1,30 @@
+# Operations Template Examples
+
+These examples are copyable starting points. They show the structure of the
+automation without private runner labels, registry hosts, credential commands,
+organization names, or secret paths.
+
+## Examples
+
+| Example                               | Use For                                                               |
+| ------------------------------------- | --------------------------------------------------------------------- |
+| `image-factory-workflow.md`           | Baking runner images, testing them, and exposing one stable PR check. |
+| `container-factory-workflow.md`       | Building and smoke-checking operational containers.                   |
+| `iac-operations-workflow.md`          | Dry-running changes on PRs and applying from protected paths.         |
+| `repository-factory-catalog.md`       | Creating repositories and applying governance from a catalog.         |
+| `scheduled-job-workflow.md`           | Cron-style maintenance jobs with manual dispatch and summaries.       |
+| `policy-hygiene-job.md`               | Custodian-style read-only scan and gated remediation jobs.            |
+| `dependency-automation-config.md`     | Renovate-style dependency automation with validation.                 |
+| `migration-orchestration-workflow.md` | Multi-phase active/inactive migration workflows.                      |
+
+## Placeholder Convention
+
+- Replace `<runner-label>` with the runner class used by the repo.
+- Replace `<auth-adapter>` with the local authentication action or script.
+- Replace `<registry-adapter>` with the local registry login action or script.
+- Replace `<deployment-adapter>` with the local dry-run/apply action.
+- Replace `<notification-adapter>` with the local summary, ticket, or chat
+  adapter.
+- Replace `<catalog-path>` with the repository catalog path.
+
+Keep the private adapter implementation outside these examples.

--- a/docs/operations-patterns/examples/container-factory-workflow.md
+++ b/docs/operations-patterns/examples/container-factory-workflow.md
@@ -1,0 +1,90 @@
+# Example: Container Factory Workflow
+
+Use this for helper containers that Forge automation depends on, such as runner
+containers, quality-tool containers, or maintenance containers.
+
+```yaml
+name: Container Factory
+
+on:
+  pull_request:
+    paths:
+      - "containers/<container-name>/**"
+      - ".github/workflows/container-factory.yml"
+  push:
+    branches: [main]
+    paths:
+      - "containers/<container-name>/**"
+      - ".github/workflows/container-factory.yml"
+  workflow_dispatch:
+    inputs:
+      publish:
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: <runner-label>
+    outputs:
+      image_ref: ${{ steps.meta.outputs.image_ref }}
+      image_digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<registry-adapter>
+      - id: meta
+        shell: bash
+        run: |
+          image_ref="<registry>/<namespace>/<container-name>:${GITHUB_SHA::12}"
+          echo "image_ref=${image_ref}" >> "$GITHUB_OUTPUT"
+      - id: build
+        shell: bash
+        run: |
+          docker build \
+            --file containers/<container-name>/Dockerfile \
+            --tag "${{ steps.meta.outputs.image_ref }}" \
+            containers/<container-name>
+          digest="$(docker image inspect "${{ steps.meta.outputs.image_ref }}" --format '{{index .RepoDigests 0}}' || true)"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+  check-image:
+    needs: build
+    runs-on: <runner-label>
+    steps:
+      - name: Smoke check produced image
+        shell: bash
+        run: |
+          docker run --rm "${{ needs.build.outputs.image_ref }}" --version
+
+  publish:
+    needs: [build, check-image]
+    if: github.event_name == 'workflow_dispatch' && inputs.publish == true
+    runs-on: <runner-label>
+    environment: container-publish
+    steps:
+      - uses: ./.github/actions/<registry-adapter>
+      - name: Push image
+        shell: bash
+        run: docker push "${{ needs.build.outputs.image_ref }}"
+
+  validate:
+    needs: [build, check-image]
+    if: always()
+    runs-on: <runner-label>
+    steps:
+      - shell: bash
+        run: |
+          test "${{ needs.build.result }}" = "success"
+          test "${{ needs.check-image.result }}" = "success"
+```
+
+## Replace Before Use
+
+- `<registry>`
+- `<namespace>`
+- `<container-name>`
+- `<registry-adapter>`
+- smoke command
+- publish environment

--- a/docs/operations-patterns/examples/dependency-automation-config.md
+++ b/docs/operations-patterns/examples/dependency-automation-config.md
@@ -1,0 +1,86 @@
+# Example: Dependency Automation Config
+
+Use this for Renovate-style dependency automation. Keep the private package
+access behind an adapter and keep the update behavior in declared config.
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "UTC",
+  "schedule": ["before 6am on monday"],
+  "dependencyDashboard": true,
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group image updates",
+      "matchDatasources": ["docker"],
+      "groupName": "container-images"
+    },
+    {
+      "description": "Automerge low-risk patch updates after checks pass",
+      "matchUpdateTypes": ["patch"],
+      "automerge": false
+    }
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "./scripts/update-generated-docs.sh",
+      "pre-commit run --files {{packageFile}}"
+    ],
+    "fileFilters": ["**/*.md", "**/*.yaml", "**/*.yml", "**/*.json"]
+  }
+}
+```
+
+## Workflow Wrapper Example
+
+```yaml
+name: Dependency Automation
+
+on:
+  schedule:
+    - cron: "11 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: <runner-label>
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<auth-adapter>
+      - uses: ./.github/actions/<package-source-adapter>
+      - name: Run dependency automation
+        shell: bash
+        run: |
+          ./scripts/run-dependency-bot.sh \
+            --config renovate.json \
+            --summary-file dependency-summary.md
+      - run: cat dependency-summary.md >> "$GITHUB_STEP_SUMMARY"
+```
+
+## Required Summary Fields
+
+- update PRs opened or updated
+- failed package lookups
+- skipped managers
+- generated files changed
+- validation commands run
+
+## Replace Before Use
+
+- schedule
+- package managers
+- post-upgrade tasks
+- private package source adapter
+- dependency bot command

--- a/docs/operations-patterns/examples/iac-operations-workflow.md
+++ b/docs/operations-patterns/examples/iac-operations-workflow.md
@@ -1,0 +1,112 @@
+# Example: IaC Operations Workflow
+
+Use this shape for a repository that stores declared operational state. Pull
+requests run dry-run validation. Protected branch or manual dispatch runs apply
+behind an approval gate.
+
+```yaml
+name: IaC Operations
+
+on:
+  pull_request:
+    paths:
+      - "environments/**"
+      - "modules/**"
+      - ".github/workflows/iac-operations.yml"
+  push:
+    branches: [main]
+    paths:
+      - "environments/**"
+      - "modules/**"
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        type: choice
+        options: [dev, stage, prod]
+        default: dev
+      run_apply:
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: iac-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: <runner-label>
+    outputs:
+      units: ${{ steps.discover.outputs.units }}
+      has_units: ${{ steps.discover.outputs.has_units }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - id: discover
+        shell: bash
+        run: |
+          # Replace with repo-specific unit discovery.
+          find environments -name unit.yaml -print \
+            | jq -R '{"path": ., "name": (. | split("/")[-2]), "layer": 0}' \
+            | jq -s -c . > units.json
+          echo "units=$(cat units.json)" >> "$GITHUB_OUTPUT"
+          echo "has_units=$(jq 'length > 0' units.json)" >> "$GITHUB_OUTPUT"
+
+  dry-run:
+    needs: discover
+    if: needs.discover.outputs.has_units == 'true'
+    runs-on: <runner-label>
+    strategy:
+      fail-fast: false
+      matrix:
+        unit: ${{ fromJSON(needs.discover.outputs.units) }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<auth-adapter>
+      - uses: ./.github/actions/<deployment-adapter>
+        with:
+          command: dry-run
+          path: ${{ matrix.unit.path }}
+
+  apply:
+    needs: [discover, dry-run]
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_apply == true)
+    runs-on: <runner-label>
+    environment: iac-apply-${{ inputs.target_environment || 'prod' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        unit: ${{ fromJSON(needs.discover.outputs.units) }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<auth-adapter>
+      - uses: ./.github/actions/<deployment-adapter>
+        with:
+          command: apply
+          path: ${{ matrix.unit.path }}
+
+  validate:
+    needs: [discover, dry-run, apply]
+    if: always()
+    runs-on: <runner-label>
+    steps:
+      - shell: bash
+        run: |
+          test "${{ needs.discover.result }}" = "success"
+          if [ "${{ needs.discover.outputs.has_units }}" = "true" ]; then
+            test "${{ needs.dry-run.result }}" = "success"
+          fi
+          if [ "${{ needs.apply.result }}" != "skipped" ]; then
+            test "${{ needs.apply.result }}" = "success"
+          fi
+```
+
+## Replace Before Use
+
+- unit discovery logic
+- `<auth-adapter>`
+- `<deployment-adapter>`
+- environment names
+- branch protection check name

--- a/docs/operations-patterns/examples/image-factory-workflow.md
+++ b/docs/operations-patterns/examples/image-factory-workflow.md
@@ -1,0 +1,166 @@
+# Example: Image Factory Workflow
+
+Use this shape for a runner base-image repository. It mirrors the important
+operational pattern: compute version, decide the matrix, bake images, test the
+candidate image, optionally build a downstream image, and expose one stable
+validation job.
+
+```yaml
+name: Runner Image Factory
+
+on:
+  pull_request:
+    paths:
+      - "images/**"
+      - "ansible/**"
+      - ".github/workflows/image-factory.yml"
+  push:
+    branches: [main]
+    paths:
+      - "images/**"
+      - "ansible/**"
+      - ".github/workflows/image-factory.yml"
+  workflow_dispatch:
+    inputs:
+      image_family:
+        description: "Image family to build, or all"
+        type: choice
+        options: [all, linux, macos, windows]
+        default: all
+      publish:
+        description: "Publish image after tests"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: image-factory-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  compute-version:
+    runs-on: <runner-label>
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - id: version
+        shell: bash
+        run: |
+          version="$(date -u +%Y%m%d)-${GITHUB_SHA::8}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+  determine-matrix:
+    runs-on: <runner-label>
+    outputs:
+      image_matrix: ${{ steps.matrix.outputs.image_matrix }}
+      has_images: ${{ steps.matrix.outputs.has_images }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - id: matrix
+        shell: bash
+        run: |
+          # Replace with repository-specific discovery.
+          cat > image-matrix.json <<'JSON'
+          [
+            {"family":"linux","version":"24.04","arch":"amd64","path":"images/linux/24.04"},
+            {"family":"linux","version":"24.04","arch":"arm64","path":"images/linux/24.04"},
+            {"family":"windows","version":"2025","arch":"amd64","path":"images/windows/2025"}
+          ]
+          JSON
+          echo "image_matrix=$(jq -c . image-matrix.json)" >> "$GITHUB_OUTPUT"
+          echo "has_images=true" >> "$GITHUB_OUTPUT"
+
+  bake-image:
+    needs: [compute-version, determine-matrix]
+    if: needs.determine-matrix.outputs.has_images == 'true'
+    runs-on: <runner-label>
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.determine-matrix.outputs.image_matrix) }}
+    outputs:
+      # In real workflows, collect candidate identifiers in a follow-up job.
+      built: "true"
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<auth-adapter>
+      - name: Bake image
+        shell: bash
+        env:
+          IMAGE_PATH: ${{ matrix.image.path }}
+          IMAGE_VERSION: ${{ needs.compute-version.outputs.version }}
+        run: |
+          ./scripts/bake-image.sh "$IMAGE_PATH" "$IMAGE_VERSION"
+
+  collect-test-matrix:
+    needs: [determine-matrix, bake-image]
+    if: always() && needs.bake-image.result == 'success'
+    runs-on: <runner-label>
+    outputs:
+      test_matrix: ${{ steps.collect.outputs.test_matrix }}
+    steps:
+      - id: collect
+        shell: bash
+        run: |
+          # Replace with the image identifiers emitted by bake-image.
+          cat > test-matrix.json <<'JSON'
+          [
+            {"image_id":"<candidate-image-id>","family":"linux","arch":"amd64"}
+          ]
+          JSON
+          echo "test_matrix=$(jq -c . test-matrix.json)" >> "$GITHUB_OUTPUT"
+
+  test-image:
+    needs: [collect-test-matrix]
+    runs-on: <runner-label>
+    strategy:
+      fail-fast: false
+      matrix:
+        candidate: ${{ fromJSON(needs.collect-test-matrix.outputs.test_matrix) }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<auth-adapter>
+      - name: Run smoke test
+        shell: bash
+        run: |
+          ./scripts/test-runner-image.sh "${{ matrix.candidate.image_id }}"
+
+  publish-image:
+    needs: [test-image]
+    if: github.event_name != 'pull_request' && inputs.publish == true
+    runs-on: <runner-label>
+    environment: image-publish
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<auth-adapter>
+      - name: Publish candidate
+        shell: bash
+        run: ./scripts/publish-image.sh
+
+  validate:
+    needs: [determine-matrix, bake-image, collect-test-matrix, test-image]
+    if: always()
+    runs-on: <runner-label>
+    steps:
+      - name: Validate required jobs
+        shell: bash
+        run: |
+          test "${{ needs.determine-matrix.result }}" = "success"
+          test "${{ needs.bake-image.result }}" = "success"
+          test "${{ needs.collect-test-matrix.result }}" = "success"
+          test "${{ needs.test-image.result }}" = "success"
+```
+
+## Replace Before Use
+
+- `./scripts/bake-image.sh`
+- `./scripts/test-runner-image.sh`
+- `./scripts/publish-image.sh`
+- `<auth-adapter>`
+- `<runner-label>`
+- image discovery logic
+- candidate image identifier collection

--- a/docs/operations-patterns/examples/migration-orchestration-workflow.md
+++ b/docs/operations-patterns/examples/migration-orchestration-workflow.md
@@ -1,0 +1,138 @@
+# Example: Migration Orchestration Workflow
+
+Use this when Forge needs a repeatable active/inactive migration with explicit
+phases and checkpoints.
+
+```yaml
+name: Runtime Migration
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        options: [dev, stage, prod]
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: runtime-migration-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  discovery:
+    runs-on: <runner-label>
+    outputs:
+      active_target: ${{ steps.discover.outputs.active_target }}
+      inactive_target: ${{ steps.discover.outputs.inactive_target }}
+      workloads: ${{ steps.discover.outputs.workloads }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - id: discover
+        shell: bash
+        run: |
+          ./scripts/discover-runtime-state.sh \
+            --environment "${{ inputs.environment }}" \
+            --output runtime-state.json
+          echo "active_target=$(jq -r .active runtime-state.json)" >> "$GITHUB_OUTPUT"
+          echo "inactive_target=$(jq -r .inactive runtime-state.json)" >> "$GITHUB_OUTPUT"
+          echo "workloads=$(jq -c .workloads runtime-state.json)" >> "$GITHUB_OUTPUT"
+
+  disable-workflows:
+    needs: discovery
+    runs-on: <runner-label>
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<workflow-toggle-adapter>
+        with:
+          state: disabled
+          reason: runtime-migration
+
+  recreate-inactive:
+    needs: [discovery, disable-workflows]
+    runs-on: <runner-label>
+    environment: migration-${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<deployment-adapter>
+        with:
+          command: recreate
+          target: ${{ needs.discovery.outputs.inactive_target }}
+
+  move-to-inactive:
+    needs: [discovery, recreate-inactive]
+    runs-on: <runner-label>
+    strategy:
+      fail-fast: false
+      matrix:
+        workload: ${{ fromJSON(needs.discovery.outputs.workloads) }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<migration-adapter>
+        with:
+          workload: ${{ matrix.workload.name }}
+          target: ${{ needs.discovery.outputs.inactive_target }}
+
+  recreate-active:
+    needs: [discovery, move-to-inactive]
+    runs-on: <runner-label>
+    environment: migration-${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<deployment-adapter>
+        with:
+          command: recreate
+          target: ${{ needs.discovery.outputs.active_target }}
+
+  move-to-active:
+    needs: [discovery, recreate-active]
+    runs-on: <runner-label>
+    strategy:
+      fail-fast: false
+      matrix:
+        workload: ${{ fromJSON(needs.discovery.outputs.workloads) }}
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<migration-adapter>
+        with:
+          workload: ${{ matrix.workload.name }}
+          target: ${{ needs.discovery.outputs.active_target }}
+
+  enable-workflows:
+    needs: [move-to-active]
+    if: always()
+    runs-on: <runner-label>
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<workflow-toggle-adapter>
+        with:
+          state: enabled
+          reason: runtime-migration-complete
+
+  validate:
+    needs:
+      - discovery
+      - disable-workflows
+      - recreate-inactive
+      - move-to-inactive
+      - recreate-active
+      - move-to-active
+      - enable-workflows
+    if: always()
+    runs-on: <runner-label>
+    steps:
+      - shell: bash
+        run: |
+          test "${{ needs.enable-workflows.result }}" = "success"
+          test "${{ needs.move-to-active.result }}" = "success"
+```
+
+## Replace Before Use
+
+- runtime discovery script
+- workflow toggle adapter
+- deployment adapter
+- migration adapter
+- approval environment
+- resume logic if partial retries are required

--- a/docs/operations-patterns/examples/policy-hygiene-job.md
+++ b/docs/operations-patterns/examples/policy-hygiene-job.md
@@ -1,0 +1,95 @@
+# Example: Policy Hygiene Job
+
+Use this for Custodian-style policy scans or remediations. The default path is
+read-only. Remediation must be explicit and protected.
+
+```yaml
+name: Policy Hygiene
+
+on:
+  schedule:
+    - cron: "43 4 * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        type: choice
+        options: [scan, remediate]
+        default: scan
+      policy_set:
+        type: string
+        default: "policies/default"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: policy-hygiene-${{ inputs.policy_set || 'default' }}
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    runs-on: <runner-label>
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<auth-adapter>
+      - name: Run policy scan
+        shell: bash
+        run: |
+          ./scripts/policy-hygiene.sh \
+            --mode scan \
+            --policy-set "${{ inputs.policy_set || 'policies/default' }}" \
+            --summary-file policy-summary.md
+      - run: cat policy-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+  remediate:
+    needs: scan
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'remediate'
+    runs-on: <runner-label>
+    environment: policy-remediation
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<auth-adapter>
+      - name: Run approved remediation
+        shell: bash
+        run: |
+          ./scripts/policy-hygiene.sh \
+            --mode remediate \
+            --policy-set "${{ inputs.policy_set }}" \
+            --summary-file remediation-summary.md
+      - run: cat remediation-summary.md >> "$GITHUB_STEP_SUMMARY"
+```
+
+## Policy Set Example
+
+```yaml
+policies:
+  - name: missing-owner-tag
+    mode: scan
+    severity: medium
+    resource: "<resource-kind>"
+    filters:
+      - field: "tags.owner"
+        op: missing
+    remediation:
+      enabled: false
+      action: "notify-owner"
+
+  - name: expired-temporary-resource
+    mode: scan
+    severity: high
+    resource: "<resource-kind>"
+    filters:
+      - field: "tags.expires_at"
+        op: before_today
+    remediation:
+      enabled: true
+      action: "delete-after-approval"
+```
+
+## Replace Before Use
+
+- policy engine command
+- policy schema
+- remediation approval environment
+- resource kinds
+- notification adapter

--- a/docs/operations-patterns/examples/repository-factory-catalog.md
+++ b/docs/operations-patterns/examples/repository-factory-catalog.md
@@ -1,0 +1,78 @@
+# Example: Repository Factory Catalog
+
+Use a catalog like this when repositories should be created and governed from
+declared state instead of manual settings.
+
+```yaml
+metadata:
+  template_repository: "<template-repo>"
+  default_visibility: "private"
+  default_branch: "main"
+  default_topics:
+    - forge
+    - operations
+
+repositories:
+  - name: "forge-runner-images"
+    description: "Builds and tests Forge runner images."
+    visibility: "private"
+    template: "<template-repo>"
+    topics:
+      - runner-images
+      - automation
+    teams:
+      readers:
+        - "<team-readers>"
+      writers:
+        - "<team-writers>"
+      maintainers:
+        - "<team-maintainers>"
+      admins:
+        - "<team-admins>"
+    branch_protection:
+      required_reviews: 1
+      dismiss_stale_reviews: true
+      require_signed_commits: true
+      required_checks:
+        - "run-pre-commit"
+        - "validate"
+    rulesets:
+      commit_message:
+        pattern: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w-]+\\))?(!)?: .+"
+      pull_request:
+        required_approving_review_count: 1
+    webhooks:
+      - name: "workflow-events"
+        url: "<webhook-url>"
+        events:
+          - workflow_job
+          - workflow_run
+        active: true
+        secret_ref: "<secret-reference>"
+    metadata:
+      owner: "<owning-team>"
+      purpose: "image-factory"
+      lifecycle: "active"
+```
+
+## Expected Automation
+
+The repository factory should translate this catalog into:
+
+- repository creation from template
+- topics and metadata
+- team permissions
+- default branch
+- branch protection
+- repository rulesets
+- required status checks
+- webhook registration
+- vulnerability or security settings where available
+
+## Review Checklist
+
+- Required checks are stable job names.
+- `secret_ref` points to a secret source and is not a secret value.
+- Template use is explicit.
+- Team access is least privilege.
+- Catalog diff is the only source of truth.

--- a/docs/operations-patterns/examples/scheduled-job-workflow.md
+++ b/docs/operations-patterns/examples/scheduled-job-workflow.md
@@ -1,0 +1,77 @@
+# Example: Scheduled Maintenance Job
+
+Use this for cron-style Forge operations such as stale PR labeling, report
+publication, drift inventory, or periodic smoke tests.
+
+```yaml
+name: Scheduled Maintenance
+
+on:
+  schedule:
+    - cron: "17 6 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+      target:
+        type: string
+        default: "all"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: scheduled-maintenance
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: <runner-label>
+    steps:
+      - uses: actions/checkout@<pinned-version>
+      - uses: ./.github/actions/<auth-adapter>
+      - name: Run maintenance task
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run || 'true' }}
+          TARGET: ${{ inputs.target || 'all' }}
+        run: |
+          ./scripts/maintenance-task.sh \
+            --target "$TARGET" \
+            --dry-run "$DRY_RUN" \
+            --summary-file maintenance-summary.md
+      - name: Publish summary
+        shell: bash
+        run: |
+          cat maintenance-summary.md >> "$GITHUB_STEP_SUMMARY"
+```
+
+## Required Summary Fields
+
+```markdown
+# Scheduled Maintenance Summary
+
+- Mode:
+- Target:
+- Started:
+- Completed:
+- Changed:
+- Skipped:
+- Failed:
+
+## Failed Targets
+
+| Target | Reason | Next Step |
+| --- | --- | --- |
+```
+
+## Replace Before Use
+
+- cron schedule
+- permissions
+- `<auth-adapter>`
+- `./scripts/maintenance-task.sh`
+- summary fields

--- a/docs/operations-patterns/ownership-matrix.md
+++ b/docs/operations-patterns/ownership-matrix.md
@@ -1,0 +1,51 @@
+# Ownership Matrix
+
+Operations automation stays smooth only when each family has a clear owner,
+backup, escalation route, and review expectation.
+
+## Ownership Table
+
+| Automation Family     | Primary Owner | Backup Owner | Reviewers        | Escalation     | Review Cadence  |
+| --------------------- | ------------- | ------------ | ---------------- | -------------- | --------------- |
+| Image factory         | `<owner>`     | `<backup>`   | `<review-group>` | `<escalation>` | weekly          |
+| Container factory     | `<owner>`     | `<backup>`   | `<review-group>` | `<escalation>` | weekly          |
+| IaC operations        | `<owner>`     | `<backup>`   | `<review-group>` | `<escalation>` | weekly          |
+| Repository factory    | `<owner>`     | `<backup>`   | `<review-group>` | `<escalation>` | monthly         |
+| Scheduled jobs        | `<owner>`     | `<backup>`   | `<review-group>` | `<escalation>` | monthly         |
+| Policy hygiene        | `<owner>`     | `<backup>`   | `<review-group>` | `<escalation>` | monthly         |
+| Dependency automation | `<owner>`     | `<backup>`   | `<review-group>` | `<escalation>` | weekly          |
+| Migration flow        | `<owner>`     | `<backup>`   | `<review-group>` | `<escalation>` | before each use |
+
+## Ownership Config Example
+
+```yaml
+automations:
+  - name: image-factory
+    family: image-factory
+    owner: "<owner>"
+    backup: "<backup>"
+    reviewers:
+      - "<review-group>"
+    escalation: "<escalation>"
+    review_cadence: weekly
+    required_summary: true
+
+  - name: repository-factory
+    family: repository-factory
+    owner: "<owner>"
+    backup: "<backup>"
+    reviewers:
+      - "<review-group>"
+    escalation: "<escalation>"
+    review_cadence: monthly
+    required_summary: true
+```
+
+## Review Expectations
+
+- Owners review source-of-truth catalog changes.
+- Backups can approve urgent rollback changes.
+- Reviewers check validation evidence and summary output.
+- Escalation contacts own blocked applies, broken schedules, and failed
+  remediations.
+- Any automation without a current owner should run in read-only mode only.

--- a/docs/operations-patterns/pipeline-patterns.md
+++ b/docs/operations-patterns/pipeline-patterns.md
@@ -1,0 +1,171 @@
+# Pipeline Pattern Catalog
+
+These patterns describe the pipeline logic observed across the operations
+repositories in a platform-neutral form.
+
+## Three-Layer Workflow Model
+
+| Layer              | Responsibility                                                       | Review Questions                                               |
+| ------------------ | -------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Entry workflow     | Defines triggers, permissions, concurrency, and high-level inputs.   | Does this run only when intended? Are permissions minimal?     |
+| Reusable workflow  | Defines the reusable execution contract and orchestration order.     | Are inputs explicit? Are dry-run and apply modes separated?    |
+| Local task adapter | Performs one local task such as build, validate, publish, or deploy. | Can it be tested locally? Does it hide private wiring cleanly? |
+
+## Quality Gate
+
+Use for every repository.
+
+- Trigger on pull requests and pushes to protected branches.
+- Run repo-local formatting, linting, policy, and secret-scan hooks.
+- Keep permissions read-only unless the check must comment on the PR.
+- Require maintainers to include validation evidence in the PR.
+
+Anti-pattern: adding a second untracked quality path that bypasses the local
+hooks.
+
+## Workflow Change Safety
+
+Use when editing automation files.
+
+- Keep trigger changes isolated and easy to review.
+- Review `permissions`, `concurrency`, `paths`, and manual inputs together.
+- Pin third-party actions or document the version policy.
+- Validate workflow syntax and the repo-local hooks before pushing.
+
+Anti-pattern: changing workflow behavior while also refactoring unrelated
+repository code.
+
+## Discovery To Matrix
+
+Use when the repository structure determines what must run.
+
+- Discover target paths from the checked-out tree.
+- Convert discovered paths into a structured matrix.
+- Include useful metadata in each matrix entry, such as environment, region,
+  tenant, component, or path.
+- Use `fail-fast: false` for independent matrix entries so one failure does not
+  hide the rest of the impact.
+
+Anti-pattern: hardcoding all targets in workflow YAML when the repo already
+contains the source of truth.
+
+## Dry-Run And Apply Split
+
+Use for infrastructure, migrations, and any operation that changes remote
+state.
+
+- Pull requests run dry-run validation only.
+- Protected branches can run apply after review.
+- Manual dispatch can force a scoped operation with explicit inputs.
+- Apply jobs require a protected environment or equivalent approval gate.
+
+Anti-pattern: allowing pull request workflows to modify persistent state.
+
+## Migration Orchestration
+
+Use when a change must move tenants, workloads, or environments between states.
+
+- Disable competing scheduled workflows before migration.
+- Discover current active and inactive targets.
+- Execute destroy, recreate, migrate, and scale phases as separate jobs.
+- Re-enable normal workflows after successful completion.
+- Keep the migration state visible through summaries.
+
+Anti-pattern: a single opaque job that performs every phase without resumable
+boundaries.
+
+## Scheduled Maintenance
+
+Use for dependency updates, drift scans, stale PR hygiene, docs publication, and
+periodic smoke tests.
+
+- Pair `schedule` with `workflow_dispatch`.
+- Add concurrency so overlapping runs cannot race.
+- Emit a summary artifact or page when the result is useful to humans.
+- Keep write permissions limited to the target artifact.
+
+Anti-pattern: scheduled jobs that mutate repositories without clear ownership
+or audit output.
+
+## Release And Version Handling
+
+Use when publishing shared actions, images, modules, or docs.
+
+- Make the release trigger explicit.
+- Derive version type from branch, label, input, or commit convention.
+- Build first, publish second, validate third.
+- Store release notes and generated metadata in predictable locations.
+
+Anti-pattern: publishing a new artifact without a validation job that consumes
+it.
+
+## Image Factory
+
+Use when baking runner images.
+
+- Compute version before building.
+- Support a build matrix by image family, operating system, version, and
+  architecture.
+- Allow intentional skip flags for expensive matrix entries.
+- Collect successfully built images into a smoke-test matrix.
+- Test the candidate image before publishing or handing it to downstream
+  consumers.
+
+Anti-pattern: treating a successful bake as proof that the image can run jobs.
+
+## Repository Factory
+
+Use when repository settings should be governed as declared state.
+
+- Store repository entries in a catalog.
+- Derive repository creation, team access, metadata, webhooks, branch
+  protection, and required checks from the catalog.
+- Dry-run catalog changes before applying them.
+- Keep manual follow-ups explicit in the PR.
+
+Anti-pattern: creating a repository by hand and backfilling catalog state later.
+
+## Dependency Automation
+
+Use when a bot keeps versions, lockfiles, images, and generated docs current.
+
+- Run on a schedule and support manual dispatch.
+- Keep manager config in the repo.
+- Use local adapters for private package access.
+- Group updates so reviewers can keep up.
+- Publish failed lookups and unsupported updates.
+
+Anti-pattern: treating a dependency scan with lookup failures as a clean run.
+
+## PR Validation Aggregator
+
+Use when a workflow has many conditional jobs.
+
+- Add a final job that depends on all relevant jobs.
+- Run it with `always()`.
+- Fail when any required dependency failed or was cancelled.
+- Use it as the required status check instead of requiring every matrix job by
+  name.
+
+Anti-pattern: branch protection depending on dynamic matrix job names.
+
+## Report Or Page Publishing
+
+Use when operations output is useful beyond the raw workflow logs.
+
+- Gather structured data from source repos or workflow artifacts.
+- Generate one compact landing page plus separate detailed pages.
+- Deploy from a dedicated job with only the permissions it needs.
+- Keep the generated output reproducible from repository state.
+
+Anti-pattern: hiding operational status in private workflow logs only.
+
+## Portable Controls
+
+- Minimal permissions by default.
+- Explicit concurrency groups.
+- Manual dispatch for dangerous operations.
+- Protected environments for apply or publish.
+- Local adapters for private integrations.
+- Structured summaries for human review.
+- No secrets in logs, docs, examples, or templates.

--- a/docs/operations-patterns/playbooks/bootstrap-and-quality.md
+++ b/docs/operations-patterns/playbooks/bootstrap-and-quality.md
@@ -1,0 +1,40 @@
+# Playbook: Bootstrap And Quality Gate
+
+## Goal
+
+Start Forge work from a known local baseline and pass the repository quality
+gate before review.
+
+## Use When
+
+- Starting work in a repo or unfamiliar area.
+- Preparing a PR.
+- Reproducing a failing quality check.
+
+## Inputs
+
+- Repository path.
+- Target branch.
+- Current changed files.
+
+## Checklist
+
+1. Confirm the current branch and worktree status.
+1. Identify existing local changes before editing.
+1. Install or refresh repo-local hooks if needed.
+1. Run the repository quality command.
+1. Fix failures in the smallest possible patch.
+1. Rerun the same command until it passes.
+1. Record the command and result in the change record.
+
+## Definition Of Done
+
+- The quality gate passes or the remaining blocker is documented.
+- Existing unrelated local changes were not reverted or staged accidentally.
+- The PR notes include validation evidence.
+
+## Common Failures
+
+- Running checks from the wrong directory.
+- Fixing generated files by hand.
+- Staging unrelated local edits.

--- a/docs/operations-patterns/playbooks/ci-failure-triage.md
+++ b/docs/operations-patterns/playbooks/ci-failure-triage.md
@@ -1,0 +1,40 @@
+# Playbook: CI Failure Triage
+
+## Goal
+
+Move from a failing check to a targeted fix with a short evidence trail.
+
+## Use When
+
+- A PR check fails.
+- A scheduled workflow fails.
+- A workflow rerun fails differently from the original failure.
+
+## Inputs
+
+- Failing workflow name.
+- Failing job and step.
+- Relevant log excerpt.
+- Changed files in the PR or recent commit.
+
+## Checklist
+
+1. Capture the exact failing job, step, and error.
+1. Check whether the failure is from the changed files or shared tooling.
+1. Reproduce locally with the closest equivalent command.
+1. Patch the smallest root cause.
+1. Rerun the local command.
+1. Push or rerun CI only after local evidence is collected.
+1. Record symptom, cause, fix, and validation.
+
+## Definition Of Done
+
+- The failing check passes or the blocker is clearly external.
+- The fix explains why the failure happened.
+- The PR includes validation and residual risk.
+
+## Common Failures
+
+- Rerunning CI repeatedly without local reproduction.
+- Fixing an earlier failure after the check moved to a new failing step.
+- Treating a workflow contract mismatch as a transient error.

--- a/docs/operations-patterns/playbooks/container-build-and-check.md
+++ b/docs/operations-patterns/playbooks/container-build-and-check.md
@@ -1,0 +1,50 @@
+# Playbook: Container Build And Check
+
+## Goal
+
+Build operational containers, tag them consistently, and verify that each image
+can start before it is used by Forge automation.
+
+## Use When
+
+- Updating a runner container.
+- Updating a tool container used by workflows.
+- Rebuilding a quality or operations helper image.
+
+## Inputs
+
+- Container context path.
+- Versioning rule.
+- Target registry placeholder.
+- Expected startup or smoke-test command.
+- Optional security scan policy.
+
+## Skeleton
+
+1. Derive image version from branch, tag, input, or commit convention.
+1. Build the image from the expected context.
+1. Tag with version and immutable digest.
+1. Run local smoke checks against the produced image.
+1. Publish only after smoke checks pass.
+1. Emit tag, digest, and check output in the workflow summary.
+
+## Review Checklist
+
+- Build context is scoped to the intended container.
+- Secrets are not baked into the image.
+- The check-image step uses the image that was just built.
+- Tags are deterministic and traceable to source.
+- Published digest is available for consumers.
+
+## Definition Of Done
+
+- Build succeeded.
+- Smoke check succeeded.
+- Digest or immutable reference is recorded.
+- Consumers know which tag or digest to update.
+
+## Common Failures
+
+- Testing a stale image instead of the image from the current build.
+- Using mutable tags as the only deployment reference.
+- Hiding registry authentication inside shared docs.

--- a/docs/operations-patterns/playbooks/dependency-automation.md
+++ b/docs/operations-patterns/playbooks/dependency-automation.md
@@ -1,0 +1,53 @@
+# Playbook: Dependency Automation
+
+## Goal
+
+Keep dependencies current through scheduled automation while preserving control
+over validation, grouping, and private package access. This is the skeleton for
+Renovate-style dependency automation.
+
+## Use When
+
+- Managing dependency update bots.
+- Adding or changing dependency managers.
+- Debugging failed dependency lookups.
+- Grouping update PRs by risk.
+
+## Inputs
+
+- Dependency config.
+- Repository list.
+- Schedule.
+- Authentication adapter for private package sources.
+- Post-update validation commands.
+
+## Skeleton
+
+1. Run on schedule and manual dispatch.
+1. Load dependency manager config from the repo.
+1. Prepare private package access through a local adapter.
+1. Run dependency discovery.
+1. Open or update PRs.
+1. Run post-update validation for supported change types.
+1. Publish lookup failures and skipped updates.
+
+## Review Checklist
+
+- Dependency grouping matches reviewer capacity.
+- Private package access is handled by an adapter, not copied into docs.
+- Generated docs or lockfiles are updated when dependencies change.
+- Failed lookups are visible.
+- The bot does not bypass required checks.
+
+## Definition Of Done
+
+- Update PRs include validation.
+- Failed dependency lookups are triaged.
+- Config changes are tested with a dry-run where available.
+- Reviewers know which update groups are low or high risk.
+
+## Common Failures
+
+- Treating no-result lookups as successful scans.
+- Adding diagnostics that leak credentials or private paths.
+- Letting dependency PRs pile up without grouping.

--- a/docs/operations-patterns/playbooks/iac-repository-operations.md
+++ b/docs/operations-patterns/playbooks/iac-repository-operations.md
@@ -1,0 +1,52 @@
+# Playbook: IaC Repository Operations
+
+## Goal
+
+Manage infrastructure repositories with predictable dry-run, apply, and
+promotion behavior.
+
+## Use When
+
+- Updating environment configuration.
+- Adding a new module or operational stack.
+- Changing shared release versions.
+- Adjusting promotion or regression coverage.
+
+## Inputs
+
+- Target environment.
+- Changed paths.
+- Module or stack dependency order.
+- Dry-run command.
+- Apply command protected by approval.
+
+## Skeleton
+
+1. Pull changed paths from the PR or dispatch input.
+1. Discover affected units from repository structure.
+1. Group units by dependency layer.
+1. Run dry-run validation for pull requests.
+1. Run apply only from protected branch or manual approval.
+1. Aggregate all layer results into one final validation job.
+1. Record dry-run or apply summaries per unit.
+
+## Review Checklist
+
+- New units are included in the reusable workflow path.
+- Regression and promotion use the same reusable contract.
+- Apply requires a protected environment or equivalent approval.
+- Discovery excludes generated cache directories.
+- Layers preserve dependency order.
+- Final status does not depend on dynamic matrix names.
+
+## Definition Of Done
+
+- Pull requests dry-run all impacted units.
+- Promotion applies the same units through the same contract.
+- The PR includes changed units, validation commands, and rollback.
+
+## Common Failures
+
+- Adding a new stack that is never dry-run or applied.
+- Patching only one caller while another caller uses the same reusable workflow.
+- Treating generated units as static YAML entries.

--- a/docs/operations-patterns/playbooks/image-bake-and-test.md
+++ b/docs/operations-patterns/playbooks/image-bake-and-test.md
@@ -1,0 +1,56 @@
+# Playbook: Image Bake And Test
+
+## Goal
+
+Bake runner images in a repeatable matrix, test the produced images, and expose
+one stable PR validation result.
+
+## Use When
+
+- Updating base operating system images.
+- Adding or removing runner tools.
+- Changing hardening, bootstrap, or runtime configuration.
+- Promoting an image candidate into downstream runner builds.
+
+## Inputs
+
+- Image family list.
+- Operating system, version, and architecture matrix.
+- Versioning rule.
+- Optional skip flags for expensive matrix entries.
+- Smoke test commands.
+- Downstream image or runner build that consumes the base image.
+
+## Skeleton
+
+1. Compute image version.
+1. Parse skip flags from PR title, commit message, or manual input.
+1. Build each requested image family and architecture.
+1. Collect only successfully built images into a test matrix.
+1. Smoke-test each image with a minimal runner workload.
+1. Optionally build a downstream image from the candidate base image.
+1. Run one final PR validation job that evaluates all required jobs.
+1. Publish image identifiers and smoke-test summaries.
+
+## Review Checklist
+
+- Build matrix matches the changed image files.
+- Skip flags cannot hide required security or release validation.
+- Smoke tests prove the runner can boot and execute a basic job.
+- Downstream consumers are tested when a base image changes.
+- Final validation is stable enough for branch protection.
+- Image identifiers are recorded without exposing private registry details.
+
+## Definition Of Done
+
+- Candidate image builds completed or intentional skips are documented.
+- Smoke tests passed for each required candidate.
+- Downstream consumer test passed when applicable.
+- PR includes build matrix, skipped entries, image identifiers, and rollback.
+
+## Common Failures
+
+- Publishing an image that was built but never boot-tested.
+- Using dynamic matrix job names as required checks.
+- Letting skip flags bypass all meaningful validation.
+- Losing the image identifier needed for downstream testing.

--- a/docs/operations-patterns/playbooks/migration-orchestration.md
+++ b/docs/operations-patterns/playbooks/migration-orchestration.md
@@ -1,0 +1,56 @@
+# Playbook: Migration Orchestration
+
+## Goal
+
+Move workloads through a multi-phase migration with clear checkpoints and
+rollback points.
+
+## Use When
+
+- Rebuilding active and inactive clusters.
+- Moving tenants between active states.
+- Recreating shared runtime infrastructure.
+- Coordinating maintenance that must temporarily disable normal workflows.
+
+## Inputs
+
+- Active and inactive target names.
+- Tenant or workload matrix.
+- Disable and enable workflow controls.
+- Phase order.
+- Rollback checkpoint.
+
+## Skeleton
+
+1. Discover active and inactive state.
+1. Disable competing scheduled or promotion workflows.
+1. Destroy or drain inactive target.
+1. Recreate inactive target.
+1. Move workloads to inactive target.
+1. Destroy or drain old active target.
+1. Recreate active target.
+1. Move workloads back to active target.
+1. Scale down inactive target.
+1. Re-enable normal workflows.
+1. Publish phase summary and rollback notes.
+
+## Review Checklist
+
+- Discovery reflects current state before phase one.
+- Every phase has a dependency on the previous phase.
+- Workload matrix is visible.
+- Competing automations are disabled only for the maintenance window.
+- Rollback or resume point is clear after each phase.
+
+## Definition Of Done
+
+- All phases completed or stopped at a documented checkpoint.
+- Normal workflows are re-enabled.
+- Summary shows workload movement and final state.
+- Any follow-up is tracked.
+
+## Common Failures
+
+- Running migration while normal automation is still active.
+- Hiding all phases inside one opaque job.
+- Lacking a clear resume point after partial failure.

--- a/docs/operations-patterns/playbooks/policy-hygiene-jobs.md
+++ b/docs/operations-patterns/playbooks/policy-hygiene-jobs.md
@@ -1,0 +1,51 @@
+# Playbook: Policy Hygiene Jobs
+
+## Goal
+
+Run recurring policy checks or remediations that keep the Forge environment
+clean without requiring manual scans. This is the skeleton for Custodian-style
+jobs, regardless of which policy engine runs behind the local adapter.
+
+## Use When
+
+- Checking resource drift against policy.
+- Enforcing retention, tagging, ownership, or lifecycle rules.
+- Producing hygiene reports for operators.
+
+## Inputs
+
+- Policy set.
+- Target scope.
+- Read-only versus remediation mode.
+- Exemption list.
+- Summary destination.
+
+## Skeleton
+
+1. Load the policy set from the repository.
+1. Resolve target scope from input or schedule.
+1. Run read-only scan by default.
+1. Run remediation only when explicitly approved.
+1. Publish findings with severity, owner, and resource placeholder.
+1. Track exemptions and expiration dates.
+
+## Review Checklist
+
+- Default mode is read-only.
+- Remediation is gated and reversible.
+- Exemptions are explicit and reviewed.
+- Findings include enough context for the owner to act.
+- The policy job has a manual rerun path.
+
+## Definition Of Done
+
+- Findings are visible.
+- Remediations are auditable.
+- Exemptions are not permanent by accident.
+- Operators can rerun the job without editing workflow code.
+
+## Common Failures
+
+- Treating policy scan failures as noise.
+- Applying remediation without an approval gate.
+- Publishing findings without owners or next steps.

--- a/docs/operations-patterns/playbooks/pr-readiness.md
+++ b/docs/operations-patterns/playbooks/pr-readiness.md
@@ -1,0 +1,39 @@
+# Playbook: PR Readiness
+
+## Goal
+
+Prepare a PR that reviewers can approve without reconstructing the whole
+investigation.
+
+## Use When
+
+- Before opening a PR.
+- Before requesting review after new commits.
+- When replacing a weak PR description.
+
+## Inputs
+
+- Final diff.
+- Validation commands and outputs.
+- Known risk and rollback path.
+
+## Checklist
+
+1. Confirm the changed files match the request.
+1. Summarize the problem in one or two sentences.
+1. List the actual behavior change.
+1. Include validation commands and results.
+1. Call out risk, impact, and rollback.
+1. Mention anything intentionally not changed.
+
+## Definition Of Done
+
+- The PR body has scope, validation, risk, and rollback.
+- No unverified validation claims are included.
+- Reviewers can tell what changed and why.
+
+## Common Failures
+
+- Filling a PR template with generic wording.
+- Claiming tests passed when they were not run.
+- Hiding unrelated changes in a broad summary.

--- a/docs/operations-patterns/playbooks/repository-factory.md
+++ b/docs/operations-patterns/playbooks/repository-factory.md
@@ -1,0 +1,71 @@
+# Playbook: Repository Factory
+
+## Goal
+
+Create and maintain repositories from a catalog so repository settings are
+reviewed, repeatable, and recoverable.
+
+## Use When
+
+- Creating a new Forge operations repository.
+- Updating team access.
+- Changing branch protection or required checks.
+- Adding repository metadata, topics, autolinks, or webhooks.
+- Creating a new repository from a template.
+
+## Inputs
+
+- Repository catalog entry.
+- Template repository placeholder.
+- Team access model.
+- Required checks.
+- Branch protection and ruleset policy.
+- Webhook or integration contract.
+
+## Skeleton
+
+1. Add or update one catalog entry.
+1. Validate catalog schema.
+1. Dry-run repository changes.
+1. Review planned changes for create, update, access, protection, and webhook
+   resources.
+1. Apply only after review.
+1. Verify repository settings after apply.
+1. Record follow-up work that cannot be safely automated.
+
+## Catalog Fields
+
+| Field             | Purpose                                                    |
+| ----------------- | ---------------------------------------------------------- |
+| `name`            | Repository name.                                           |
+| `description`     | Reviewer-readable purpose.                                 |
+| `visibility`      | Public, private, or internal visibility policy.            |
+| `template`        | Optional source template.                                  |
+| `topics`          | Search and ownership tags.                                 |
+| `teams`           | Readers, writers, maintainers, and administrators.         |
+| `required_checks` | Stable required status checks.                             |
+| `rulesets`        | Pull request, signature, commit-message, and branch rules. |
+| `webhooks`        | Event relay contracts.                                     |
+| `metadata`        | Custom fields used for inventory and reporting.            |
+
+## Review Checklist
+
+- Required checks match stable workflow job names.
+- Repository creation cannot accidentally destroy existing repositories.
+- Team access follows least privilege.
+- Webhook secrets are referenced, never committed.
+- Template use is intentional and documented.
+- Manual follow-ups are tracked.
+
+## Definition Of Done
+
+- Catalog diff clearly describes the repository change.
+- Dry-run shows only intended changes.
+- Applied repository settings match the catalog.
+- Follow-up access or secret steps are recorded.
+
+## Common Failures
+
+- Managing repository settings by hand after the catalog exists.
+- Requiring dynamic workflow matrix jobs in branch protection.
+- Hiding one-off access grants outside the catalog.

--- a/docs/operations-patterns/playbooks/safe-automation-boundaries.md
+++ b/docs/operations-patterns/playbooks/safe-automation-boundaries.md
@@ -1,0 +1,40 @@
+# Playbook: Safe Automation Boundaries
+
+## Goal
+
+Keep automation and agent-driven edits scoped, reversible, and easy to audit.
+
+## Use When
+
+- Asking an agent to edit the repo.
+- Building a new maintenance automation.
+- Running a bulk change across multiple files.
+
+## Inputs
+
+- User request.
+- Target files or folders.
+- Existing local changes.
+- Allowed side effects.
+
+## Checklist
+
+1. State the intended scope before editing.
+1. Read existing files and follow local patterns.
+1. Preserve unrelated local changes.
+1. Avoid destructive git operations unless explicitly requested.
+1. Prefer additive docs or templates before runnable automation.
+1. Validate only the changed surface.
+1. Report what changed and what was left untouched.
+
+## Definition Of Done
+
+- The change set is scoped to the request.
+- No unrelated files were modified.
+- The audit trail names the commands or checks that mattered.
+
+## Common Failures
+
+- Broad refactors during a targeted maintenance request.
+- Creating a parallel flow instead of adapting the existing one.
+- Reverting user work while cleaning up.

--- a/docs/operations-patterns/playbooks/scheduled-jobs.md
+++ b/docs/operations-patterns/playbooks/scheduled-jobs.md
@@ -1,0 +1,52 @@
+# Playbook: Scheduled Jobs
+
+## Goal
+
+Run recurring operational hygiene with clear ownership, locking, and summaries.
+This is the skeleton for cron-style jobs that operate Forge without requiring a
+human to press a button each time.
+
+## Use When
+
+- Tagging or labeling stale pull requests.
+- Publishing generated reports or pages.
+- Running periodic smoke tests.
+- Checking inactive resources or stale state.
+
+## Inputs
+
+- Schedule.
+- Manual dispatch inputs.
+- Target scope.
+- Lock or concurrency key.
+- Summary output format.
+
+## Skeleton
+
+1. Pair schedule with manual dispatch.
+1. Acquire a workflow-level concurrency lock.
+1. Load targets from the source of truth.
+1. Run the smallest scoped job.
+1. Emit changed, skipped, and failed targets.
+1. Fail when automation cannot prove the final state.
+
+## Review Checklist
+
+- Schedule cadence matches operational need.
+- Manual dispatch can run the same logic on demand.
+- Permissions are minimal.
+- The job cannot overlap with itself.
+- Summary tells maintainers what happened without opening every log line.
+
+## Definition Of Done
+
+- Job runs on schedule and on demand.
+- Summary is readable.
+- Failures are actionable.
+- Mutating behavior is documented and scoped.
+
+## Common Failures
+
+- Scheduled jobs that silently skip work.
+- Jobs that overlap and race on the same resources.
+- No manual dispatch path for urgent reruns.

--- a/docs/operations-patterns/playbooks/security-hygiene.md
+++ b/docs/operations-patterns/playbooks/security-hygiene.md
@@ -1,0 +1,39 @@
+# Playbook: Security Hygiene
+
+## Goal
+
+Prevent secrets, credentials, private endpoints, and sensitive operational
+details from entering docs, examples, logs, or commits.
+
+## Use When
+
+- Editing configuration.
+- Adding examples.
+- Copying log samples.
+- Writing incident or PR notes.
+
+## Inputs
+
+- Changed files.
+- Any copied logs, payloads, screenshots, or config samples.
+
+## Checklist
+
+1. Search the diff for tokens, keys, private endpoints, and internal identifiers.
+1. Keep secret retrieval in local adapters instead of generic playbooks.
+1. Replace real identities with placeholders in examples.
+1. Run the repo-local secret scan.
+1. Review PR text for copied sensitive values.
+1. Document any redaction assumptions.
+
+## Definition Of Done
+
+- No sensitive values appear in committed files or PR text.
+- Security hooks pass or a false positive is documented.
+- Examples remain useful with placeholders.
+
+## Common Failures
+
+- Copying real workflow logs into documentation.
+- Leaving internal identifiers in shareable templates.
+- Disabling a scan instead of fixing the finding.

--- a/docs/operations-patterns/playbooks/workflow-change-safety.md
+++ b/docs/operations-patterns/playbooks/workflow-change-safety.md
@@ -1,0 +1,39 @@
+# Playbook: Workflow Change Safety
+
+## Goal
+
+Change automation behavior without surprising reviewers or breaking protected
+paths.
+
+## Use When
+
+- Editing workflow triggers.
+- Adding or removing workflow jobs.
+- Changing permissions, concurrency, environments, or reusable workflow inputs.
+
+## Inputs
+
+- Target workflow files.
+- Expected behavior before and after the change.
+- Required checks for protected branches.
+
+## Checklist
+
+1. Identify the workflow entry point and any reusable workflow it calls.
+1. Review trigger, path filter, permissions, concurrency, and environment gates.
+1. Keep private credential setup inside local adapters.
+1. Validate workflow syntax and repository hooks.
+1. Explain the behavior change in the PR.
+1. Confirm branch protection still points at stable required checks.
+
+## Definition Of Done
+
+- The workflow diff is minimal and reviewable.
+- The validation path is documented.
+- Apply, publish, or destructive steps remain behind explicit gates.
+
+## Common Failures
+
+- Making a workflow reusable but forgetting to document its inputs.
+- Requiring dynamic matrix job names in branch protection.
+- Adding broad write permissions for a single commenting or publishing step.

--- a/docs/operations-patterns/playbooks/workload-onboarding.md
+++ b/docs/operations-patterns/playbooks/workload-onboarding.md
@@ -1,0 +1,42 @@
+# Playbook: Workload Onboarding
+
+## Goal
+
+Add or update a tenant, workload, or integration through a repeatable reviewable
+process.
+
+## Use When
+
+- A team requests new Forge capacity.
+- An existing workload needs a new runner class or integration.
+- A config was removed and must be restored.
+
+## Inputs
+
+- Request record or issue.
+- Target environment and ownership.
+- Required runner type, access model, and observability needs.
+- Existing baseline configuration to compare against.
+
+## Checklist
+
+1. Read the request and extract requirements.
+1. Confirm the target path and naming convention.
+1. Compare with a known-good baseline.
+1. Add only the required config fields.
+1. Validate syntax and structure.
+1. Run dry-run validation for the impacted path.
+1. Record expected access, logging, and rollback behavior.
+
+## Definition Of Done
+
+- The request maps to explicit config changes.
+- New files match the repository path convention.
+- Validation shows the intended impact only.
+- The PR names owner, scope, risk, and rollback.
+
+## Common Failures
+
+- Inferring requirements from memory instead of the request record.
+- Mixing onboarding with unrelated cleanup.
+- Copying secret material into tracked files.

--- a/docs/operations-patterns/reference-skeleton/README.md
+++ b/docs/operations-patterns/reference-skeleton/README.md
@@ -1,0 +1,127 @@
+# Reference Operations Repo Skeleton
+
+This is the concrete folder layout to copy when creating a Forge operations
+repository. It shows where each automation family should live and what each
+file is expected to own.
+
+## Folder Tree
+
+```text
+forge-ops-example/
+  .github/
+    actions/
+      auth-adapter/
+        action.yml
+      deployment-adapter/
+        action.yml
+      registry-adapter/
+        action.yml
+      notification-adapter/
+        action.yml
+      workflow-toggle-adapter/
+        action.yml
+    workflows/
+      pre-commit.yml
+      image-factory.yml
+      container-factory.yml
+      iac-operations.yml
+      repository-factory.yml
+      scheduled-maintenance.yml
+      policy-hygiene.yml
+      dependency-automation.yml
+      runtime-migration.yml
+    PULL_REQUEST_TEMPLATE.md
+  config/
+    automations.yaml
+    repositories.yaml
+    images.yaml
+    containers.yaml
+    schedules.yaml
+    policies.yaml
+    dependencies.json
+    ownership.yaml
+  docs/
+    runbooks/
+      image-factory.md
+      repository-factory.md
+      dependency-automation.md
+      incident-response.md
+    summaries/
+      image-factory-summary.md
+      policy-hygiene-summary.md
+      migration-summary.md
+  scripts/
+    bake-image.sh
+    test-runner-image.sh
+    publish-image.sh
+    build-container.sh
+    check-container.sh
+    discover-units.sh
+    run-deployment.sh
+    validate-repository-catalog.sh
+    run-repository-factory.sh
+    scheduled-maintenance.sh
+    policy-hygiene.sh
+    run-dependency-bot.sh
+    discover-runtime-state.sh
+    migrate-workload.sh
+  schemas/
+    automations.schema.json
+    repositories.schema.json
+    images.schema.json
+    schedules.schema.json
+    ownership.schema.json
+  README.md
+  CONTRIBUTING.md
+```
+
+## File Ownership
+
+| File Or Folder               | Owns                                                                                      | Does Not Own                         |
+| ---------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------ |
+| `.github/workflows/`         | Triggers, permissions, concurrency, environments, final validation jobs.                  | Long operational logic.              |
+| `.github/actions/*-adapter/` | Local access, registry, deployment, notification, and workflow toggle plumbing.           | Generic pattern documentation.       |
+| `config/`                    | Declared source of truth for images, repos, schedules, policies, dependencies, ownership. | Secrets or generated runtime output. |
+| `scripts/`                   | Local task implementation with stable arguments and exit codes.                           | Workflow trigger policy.             |
+| `schemas/`                   | Validation contracts for config files.                                                    | Live environment state.              |
+| `docs/runbooks/`             | Human operating guidance.                                                                 | Generated summaries.                 |
+| `docs/summaries/`            | Example or generated summary shapes.                                                      | Source of truth configuration.       |
+
+## Minimum Viable Repository
+
+For a small Forge operations repo, start with:
+
+- `.github/workflows/pre-commit.yml`
+- `.github/workflows/scheduled-maintenance.yml`
+- `.github/actions/auth-adapter/action.yml`
+- `config/automations.yaml`
+- `config/ownership.yaml`
+- `scripts/scheduled-maintenance.sh`
+- `schemas/automations.schema.json`
+- `README.md`
+- `CONTRIBUTING.md`
+
+Add image, container, repository, dependency, and migration workflows only when
+the repo owns those automation families.
+
+## Golden Path
+
+1. Add declared state under `config/`.
+1. Validate declared state with a schema under `schemas/`.
+1. Implement the smallest local task under `scripts/`.
+1. Wrap local access or environment setup in `.github/actions/*-adapter/`.
+1. Add a workflow that calls the adapter and script.
+1. Add one stable final validation job.
+1. Document owner, rollback, and summary output.
+
+## Naming Conventions
+
+| Item                 | Convention                                             |
+| -------------------- | ------------------------------------------------------ |
+| Final validation job | `validate`                                             |
+| Read-only job        | `dry-run`, `scan`, or `check`                          |
+| Mutating job         | `apply`, `publish`, `remediate`, or `migrate`          |
+| Adapter action       | `<purpose>-adapter`                                    |
+| Config file          | plural noun, for example `images.yaml`                 |
+| Schema file          | matching config name, for example `images.schema.json` |
+| Summary file         | `<automation>-summary.md`                              |

--- a/docs/operations-patterns/repo-structure.md
+++ b/docs/operations-patterns/repo-structure.md
@@ -1,0 +1,70 @@
+# Repository Structure Pattern
+
+Forge maintenance is smoother when each repository keeps a predictable boundary
+between documentation, examples, modules, scripts, and automation contracts.
+
+## Recommended Shape
+
+```text
+repo/
+  .github/
+    workflows/
+    actions/
+    PULL_REQUEST_TEMPLATE.md
+  docs/
+    operations-patterns/
+    configurations/
+    tenant-usage/
+  examples/
+  modules/
+  scripts/
+  CHANGELOG.md
+  CONTRIBUTING.md
+  README.md
+```
+
+## Ownership Boundaries
+
+| Area                 | Owns                                                                | Should Not Own                                                       |
+| -------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `.github/workflows/` | Trigger policy, permissions, reusable workflow calls, review gates. | Long shell scripts or environment-specific credential bootstrapping. |
+| `.github/actions/`   | Local task adapters used by workflows.                              | Shared process documentation.                                        |
+| `docs/`              | Operator and tenant-facing guidance.                                | Generated runtime state.                                             |
+| `examples/`          | Minimal consumable deployments and tests.                           | Production-only configuration.                                       |
+| `modules/`           | Reusable Forge building blocks.                                     | Tenant-specific secrets or local state.                              |
+| `scripts/`           | Local maintenance helpers with clear inputs and outputs.            | Hidden CI-only business logic.                                       |
+| `config/`            | Catalogs for repositories, schedules, policies, or dependency bots. | Secrets or generated runtime output.                                 |
+
+## Maintenance Inventory
+
+Create or update this table for every Forge maintenance area.
+
+| Area                      | Source of Truth                  | Change Trigger                        | Validation                              | Rollback                           |
+| ------------------------- | -------------------------------- | ------------------------------------- | --------------------------------------- | ---------------------------------- |
+| Tenant configuration      | Repository config files          | Request, drift, or migration          | Parse config and dry-run impacted paths | Revert config change               |
+| Runner image or container | Build recipe and version file    | Dependency, security, or feature need | Build and smoke test                    | Revert version and image reference |
+| Integration               | Module config and alert contract | Alert gap or downstream field change  | Unit check, dry-run, sample payload     | Revert module/config change        |
+| Documentation             | `docs/` and examples             | User confusion or release change      | Link check and reviewer read-through    | Revert doc patch                   |
+| Release                   | Changelog and version metadata   | Approved merge or scheduled release   | Tags, generated notes, CI status        | Revert tag or release metadata     |
+
+## Bootstrap Rules
+
+1. Start from a clean branch unless intentionally carrying local work.
+1. Confirm the repo-local quality gate before making broad edits.
+1. Keep generated docs separate from human-written operator guidance.
+1. Put environment-specific details in configuration, not in shared playbooks.
+1. Keep private adapters behind local workflow actions or scripts.
+
+## Repository Readiness Checklist
+
+- `README.md` explains purpose, personas, and quick start.
+- `CONTRIBUTING.md` explains local validation and PR expectations.
+- `.github/PULL_REQUEST_TEMPLATE.md` asks for scope, type, testing, risk, and
+  rollback.
+- A quality workflow runs on pull requests and pushes.
+- Expensive or destructive workflows can be manually dispatched and are guarded
+  by environments.
+- Repository, image, scheduled, and dependency automations have a documented
+  source of truth.
+- Generated outputs are documented as generated and not hand-edited.
+- Secret handling is documented without exposing real secret names or values.

--- a/docs/operations-patterns/required-checks.md
+++ b/docs/operations-patterns/required-checks.md
@@ -1,0 +1,49 @@
+# Required Check Naming
+
+Branch protection should depend on stable final checks, not dynamic matrix job
+names. This keeps required checks predictable even when matrix entries change.
+
+## Recommended Checks
+
+| Automation            | Required Check                  | Why                                                             |
+| --------------------- | ------------------------------- | --------------------------------------------------------------- |
+| Quality gate          | `run-pre-commit`                | Stable baseline quality check.                                  |
+| Image factory         | `validate`                      | Aggregates build, test, downstream, and skipped matrix entries. |
+| Container factory     | `validate`                      | Confirms build and check-image completed.                       |
+| IaC operations        | `validate`                      | Confirms discovery and dry-run jobs completed.                  |
+| Repository factory    | `validate`                      | Confirms catalog validation and dry-run completed.              |
+| Dependency automation | `validate` or repo quality gate | Confirms generated changes pass validation.                     |
+| Migration             | no PR required check by default | Usually manual dispatch, summarized separately.                 |
+
+## Rules
+
+- Use one final `validate` job per complex workflow.
+- Run `validate` with `if: always()`.
+- Make `validate` inspect all required dependencies.
+- Do not require matrix job names in branch protection.
+- Do not require jobs that only run on protected branch apply.
+- Keep the quality gate required for every repository.
+
+## Example Validate Job
+
+```yaml
+validate:
+  needs: [discover, dry-run]
+  if: always()
+  runs-on: <runner-label>
+  steps:
+    - shell: bash
+      run: |
+        test "${{ needs.discover.result }}" = "success"
+        test "${{ needs.dry-run.result }}" = "success"
+```
+
+## Status Check Inventory
+
+Track required checks in the repository catalog:
+
+```yaml
+required_checks:
+  - "run-pre-commit"
+  - "validate"
+```

--- a/docs/operations-patterns/rollback-examples.md
+++ b/docs/operations-patterns/rollback-examples.md
@@ -1,0 +1,81 @@
+# Rollback Examples
+
+Every automation family needs a rollback shape before it is used in production.
+
+## Image Rollback
+
+Use when a newly baked image fails after publication.
+
+1. Stop promotion of the candidate image.
+1. Repoint consumers to the previous known-good image identifier.
+1. Open a fix PR against the image recipe.
+1. Re-run image factory with smoke tests.
+1. Publish a replacement only after downstream consumer validation.
+
+Rollback record:
+
+```markdown
+## Image Rollback
+
+- Bad candidate:
+- Previous known-good:
+- Consumers reverted:
+- Validation after revert:
+- Follow-up PR:
+```
+
+## Container Rollback
+
+1. Repoint workflow or config to the previous immutable image digest.
+1. Re-run the check-image job.
+1. Disable scheduled use of the bad tag if needed.
+1. Open a fix PR.
+
+## Repository Catalog Rollback
+
+1. Revert the catalog entry change.
+1. Dry-run repository factory.
+1. Confirm the dry-run restores intended settings only.
+1. Apply through the protected path.
+1. Verify branch protection and required checks.
+
+Do not delete repositories automatically unless the deletion was explicitly
+approved and documented.
+
+## Declared-State Apply Rollback
+
+1. Identify the unit path and last successful run.
+1. Revert the declared-state change.
+1. Run dry-run for the unit.
+1. Apply through the protected path.
+1. Confirm runtime state matches the previous intended state.
+
+## Scheduled Job Rollback
+
+1. Disable the schedule or set dry-run mode.
+1. Revert the job config or target selector.
+1. Manually dispatch the job in dry-run mode.
+1. Re-enable the schedule after the summary is clean.
+
+## Policy Remediation Rollback
+
+1. Stop additional remediation runs.
+1. Identify remediated resources from the summary.
+1. Restore only resources that were changed by the remediation run.
+1. Add or update exemption if the policy was too broad.
+1. Re-run scan mode.
+
+## Dependency Update Rollback
+
+1. Revert the dependency PR or restore the previous lockfile.
+1. Re-run generated docs or lockfile checks.
+1. Pause or reconfigure the update rule if the package source is unstable.
+1. Reopen the update with a smaller group if needed.
+
+## Migration Rollback
+
+1. Stop at the latest successful checkpoint.
+1. Confirm workflows are disabled if migration state is split.
+1. Move workloads back to the last known-good target.
+1. Re-enable workflows only after workload health is verified.
+1. Record the checkpoint and failed phase.

--- a/docs/operations-patterns/script-interfaces.md
+++ b/docs/operations-patterns/script-interfaces.md
@@ -1,0 +1,129 @@
+# Script Interfaces
+
+Workflow examples call local scripts. Those scripts need stable arguments,
+outputs, and exit codes so maintainers can run the same tasks locally and in
+automation.
+
+## Common Rules
+
+- Every script supports `--help`.
+- Every script uses `set -euo pipefail` or equivalent strict behavior.
+- Every script accepts `--summary-file` when it produces human output.
+- Every mutating script supports a read-only mode where practical.
+- Exit code `0` means success.
+- Exit code `1` means validation or execution failure.
+- Exit code `2` means bad input or missing prerequisites.
+- Exit code `3` means partial state requiring human review.
+
+## `bake-image.sh`
+
+```text
+Usage:
+  bake-image.sh <image-path> <version> [--summary-file <path>]
+
+Outputs:
+  image-id=<candidate-image-id>
+  image-family=<family>
+  image-version=<version>
+```
+
+Summary must include:
+
+- image path
+- version
+- architecture
+- build duration
+- candidate image identifier
+- warnings
+
+## `test-runner-image.sh`
+
+```text
+Usage:
+  test-runner-image.sh <candidate-image-id> [--summary-file <path>]
+```
+
+The test should prove:
+
+- image boots or starts
+- runner bootstrap completes
+- a minimal command executes
+- logs are available
+
+## `run-deployment.sh`
+
+```text
+Usage:
+  run-deployment.sh --command <dry-run|apply> --path <unit-path> --summary-file <path>
+```
+
+Rules:
+
+- `dry-run` never changes remote state.
+- `apply` requires approval from the caller.
+- output includes changed, unchanged, skipped, and failed counts.
+
+## `run-repository-factory.sh`
+
+```text
+Usage:
+  run-repository-factory.sh --catalog <path> --mode <dry-run|apply> --summary-file <path>
+```
+
+Rules:
+
+- validates catalog before action
+- prevents accidental repository deletion by default
+- reports create, update, unchanged, and manual follow-up items
+
+## `scheduled-maintenance.sh`
+
+```text
+Usage:
+  scheduled-maintenance.sh --target <target> --dry-run <true|false> --summary-file <path>
+```
+
+Rules:
+
+- manual dispatch and scheduled runs call the same script
+- dry-run is the default
+- failures are listed with owner and next step
+
+## `policy-hygiene.sh`
+
+```text
+Usage:
+  policy-hygiene.sh --mode <scan|remediate> --policy-set <path> --summary-file <path>
+```
+
+Rules:
+
+- `scan` is read-only
+- `remediate` requires approval
+- exemptions include owner and expiration
+
+## `run-dependency-bot.sh`
+
+```text
+Usage:
+  run-dependency-bot.sh --config <path> --summary-file <path>
+```
+
+Rules:
+
+- failed lookups are reported as warnings or failures
+- generated file updates are visible
+- private package access stays behind an adapter
+
+## `migrate-workload.sh`
+
+```text
+Usage:
+  migrate-workload.sh --workload <name> --target <target> --summary-file <path>
+```
+
+Rules:
+
+- migration is idempotent
+- each workload emits a checkpoint
+- partial state exits with code `3`

--- a/docs/operations-patterns/templates/automation-catalog.md
+++ b/docs/operations-patterns/templates/automation-catalog.md
@@ -1,0 +1,48 @@
+# Automation Catalog
+
+## Automation
+
+- Name:
+- Family:
+- Owner:
+- Source of truth:
+- Manual dispatch available:
+- Schedule:
+
+## Contract
+
+| Contract Item             | Value |
+| ------------------------- | ----- |
+| Entry workflow            |       |
+| Reusable workflow         |       |
+| Local adapter             |       |
+| Read-only validation step |       |
+| Mutating step             |       |
+| Approval gate             |       |
+| Final required check      |       |
+| Summary artifact          |       |
+
+## Runtime Discovery
+
+| Discovered Item | Source | Used By |
+| --------------- | ------ | ------- |
+|                 |        |         |
+
+## Validation
+
+| Scenario         | Validation |
+| ---------------- | ---------- |
+| Pull request     |            |
+| Protected branch |            |
+| Manual dispatch  |            |
+| Rollback         |            |
+
+## Private Adapter Placeholders
+
+| Adapter Purpose         | Placeholder              |
+| ----------------------- | ------------------------ |
+| Authentication          | `<auth-adapter>`         |
+| Registry login          | `<registry-adapter>`     |
+| Secret retrieval        | `<secret-adapter>`       |
+| Notification            | `<notification-adapter>` |
+| Deployment engine setup | `<deployment-adapter>`   |

--- a/docs/operations-patterns/templates/change-record.md
+++ b/docs/operations-patterns/templates/change-record.md
@@ -1,0 +1,34 @@
+# Change Record
+
+## Summary
+
+- Requested outcome:
+- Impacted area:
+- Branch:
+- Related issue or request:
+
+## Files Changed
+
+| File | Reason |
+| ---- | ------ |
+|      |        |
+
+## Validation
+
+| Command or Check | Result | Notes |
+| ---------------- | ------ | ----- |
+|                  |        |       |
+
+## Risk
+
+- User impact:
+- Operational impact:
+- Security impact:
+- Rollback:
+
+## Follow-Up
+
+- [ ] Documentation updated.
+- [ ] Required checks passed.
+- [ ] Reviewer questions answered.
+- [ ] Follow-up issue created if needed.

--- a/docs/operations-patterns/templates/image-build-matrix.md
+++ b/docs/operations-patterns/templates/image-build-matrix.md
@@ -1,0 +1,25 @@
+# Image Build Matrix
+
+## Version
+
+- Version source:
+- Release candidate:
+- Commit:
+
+## Matrix
+
+| Family | OS  | Version | Architecture | Build? | Test? | Skip Reason |
+| ------ | --- | ------- | ------------ | ------ | ----- | ----------- |
+|        |     |         |              |        |       |             |
+
+## Test Evidence
+
+| Image | Smoke Test | Result | Notes |
+| ----- | ---------- | ------ | ----- |
+|       |            |        |       |
+
+## Downstream Consumers
+
+| Consumer | Candidate Image | Result |
+| -------- | --------------- | ------ |
+|          |                 |        |

--- a/docs/operations-patterns/templates/incident-log.md
+++ b/docs/operations-patterns/templates/incident-log.md
@@ -1,0 +1,38 @@
+# Incident Log
+
+## Context
+
+- Time window:
+- Impacted tenant, workload, or component:
+- Detected by:
+- Severity:
+
+## Symptom
+
+Describe the externally visible failure.
+
+## Evidence
+
+| Source            | Observation |
+| ----------------- | ----------- |
+| Workflow logs     |             |
+| Application logs  |             |
+| Config diff       |             |
+| Metrics or alerts |             |
+
+## Root Cause
+
+State the smallest confirmed cause. Mark unknowns explicitly.
+
+## Fix
+
+- Patch:
+- Validation:
+- Deployed or merged at:
+
+## Prevention
+
+- [ ] Test or check added.
+- [ ] Runbook updated.
+- [ ] Alert or dashboard updated.
+- [ ] Follow-up owner assigned.

--- a/docs/operations-patterns/templates/operations-review.md
+++ b/docs/operations-patterns/templates/operations-review.md
@@ -1,0 +1,28 @@
+# Operations Review
+
+## Review Window
+
+- Start:
+- End:
+- Reviewer:
+
+## Health Snapshot
+
+| Area               | Status | Notes |
+| ------------------ | ------ | ----- |
+| Pull requests      |        |       |
+| Scheduled jobs     |        |       |
+| Runner capacity    |        |       |
+| Dependency updates |        |       |
+| Documentation      |        |       |
+| Incidents          |        |       |
+
+## Decisions Needed
+
+| Decision | Owner | Due Date |
+| -------- | ----- | -------- |
+|          |       |          |
+
+## Action Items
+
+- \[ \]

--- a/docs/operations-patterns/templates/pr-description.md
+++ b/docs/operations-patterns/templates/pr-description.md
@@ -1,0 +1,31 @@
+# Description
+
+Explain the problem and the change in reviewer-friendly language.
+
+## Type Of Change
+
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Refactor
+- [ ] Maintenance
+
+## Scope
+
+- Changed:
+- Not changed:
+
+## Validation
+
+| Check | Result |
+| ----- | ------ |
+|       |        |
+
+## Risk And Rollback
+
+- Risk:
+- Rollback:
+
+## Notes For Reviewers
+
+-

--- a/docs/operations-patterns/templates/repo-map.md
+++ b/docs/operations-patterns/templates/repo-map.md
@@ -1,0 +1,43 @@
+# Repository Map
+
+## Purpose
+
+- Repository:
+- Main audience:
+- Main operational responsibility:
+
+## Important Paths
+
+| Path                 | Purpose                                       | Owner |
+| -------------------- | --------------------------------------------- | ----- |
+| `.github/workflows/` | Workflow entry points and reusable contracts. |       |
+| `.github/actions/`   | Local task adapters.                          |       |
+| `docs/`              | Human-facing documentation.                   |       |
+| `examples/`          | Example deployments and smoke tests.          |       |
+| `modules/`           | Reusable building blocks.                     |       |
+| `scripts/`           | Local helper commands.                        |       |
+
+## Critical Workflows
+
+| Workflow | Trigger | Required Check? | Purpose |
+| -------- | ------- | --------------- | ------- |
+|          |         |                 |         |
+
+## Local Validation
+
+| Area               | Command | Notes |
+| ------------------ | ------- | ----- |
+| Quality gate       |         |       |
+| Dry-run validation |         |       |
+| Smoke test         |         |       |
+
+## Operational Dependencies
+
+List dependencies by type without real secrets.
+
+| Type          | Placeholder       | Notes |
+| ------------- | ----------------- | ----- |
+| Secret source | `<secret-source>` |       |
+| Runner label  | `<runner-label>`  |       |
+| Environment   | `<environment>`   |       |
+| Registry      | `<registry>`      |       |

--- a/docs/operations-patterns/templates/repository-catalog-entry.md
+++ b/docs/operations-patterns/templates/repository-catalog-entry.md
@@ -1,0 +1,38 @@
+# Repository Catalog Entry
+
+## Repository
+
+- Name:
+- Description:
+- Visibility:
+- Template:
+- Topics:
+
+## Access
+
+| Role           | Teams Or Users |
+| -------------- | -------------- |
+| Readers        |                |
+| Writers        |                |
+| Maintainers    |                |
+| Administrators |                |
+
+## Governance
+
+| Setting                | Value |
+| ---------------------- | ----- |
+| Default branch         |       |
+| Required checks        |       |
+| Pull request approvals |       |
+| Commit message policy  |       |
+| Signature policy       |       |
+| Vulnerability alerts   |       |
+| Webhooks               |       |
+| Custom metadata        |       |
+
+## Validation
+
+- Catalog schema:
+- Dry-run:
+- Applied state:
+- Manual follow-up:

--- a/docs/operations-patterns/workflow-summaries.md
+++ b/docs/operations-patterns/workflow-summaries.md
@@ -1,0 +1,140 @@
+# Workflow Summary Examples
+
+Good summaries let operators understand a workflow without reading raw logs.
+Every automation family should write a sanitized Markdown summary.
+
+## Image Factory Summary
+
+```markdown
+# Image Factory Summary
+
+- Version: 20260626-a1b2c3d4
+- Trigger: pull_request
+- Final status: success
+
+## Build Matrix
+
+| Family | Version | Arch | Result | Candidate |
+| --- | --- | --- | --- | --- |
+| linux | 24.04 | amd64 | success | <candidate-image-id> |
+| linux | 24.04 | arm64 | skipped | skip flag |
+
+## Smoke Tests
+
+| Candidate | Test | Result |
+| --- | --- | --- |
+| <candidate-image-id> | boot-and-run-command | success |
+
+## Follow-Up
+
+- No follow-up required.
+```
+
+## Repository Factory Summary
+
+```markdown
+# Repository Factory Summary
+
+- Catalog: config/repositories.yaml
+- Mode: dry-run
+- Final status: success
+
+## Planned Changes
+
+| Repository | Action | Notes |
+| --- | --- | --- |
+| forge-runner-images | create | from template |
+| forge-ops-maintenance | update | required checks changed |
+
+## Manual Follow-Up
+
+| Repository | Follow-Up | Owner |
+| --- | --- | --- |
+| forge-runner-images | install app or secret placeholder | <owner> |
+```
+
+## Scheduled Maintenance Summary
+
+```markdown
+# Scheduled Maintenance Summary
+
+- Mode: dry-run
+- Target: all
+- Final status: warning
+
+## Results
+
+| Target | Action | Result | Next Step |
+| --- | --- | --- | --- |
+| stale-prs | label | success | none |
+| old-runs | cleanup | skipped | dry-run only |
+| report-page | publish | failed | rerun after permissions fix |
+```
+
+## Policy Hygiene Summary
+
+```markdown
+# Policy Hygiene Summary
+
+- Policy set: policies/default
+- Mode: scan
+- Final status: failed
+
+## Findings
+
+| Severity | Policy | Resource | Owner | Next Step |
+| --- | --- | --- | --- | --- |
+| high | expired-temporary-resource | <resource-id> | <owner> | approve remediation |
+| medium | missing-owner-tag | <resource-id> | unknown | assign owner |
+
+## Exemptions
+
+| Policy | Resource | Expires | Owner |
+| --- | --- | --- | --- |
+| missing-owner-tag | <resource-id> | 2026-07-31 | <owner> |
+```
+
+## Dependency Automation Summary
+
+```markdown
+# Dependency Automation Summary
+
+- Config: config/dependencies.json
+- Final status: warning
+
+## Updates
+
+| Group | PR | Result |
+| --- | --- | --- |
+| github-actions | <pr-link> | opened |
+| container-images | <pr-link> | updated |
+
+## Failed Lookups
+
+| Manager | Package | Reason |
+| --- | --- | --- |
+| image | <package> | private source unavailable |
+```
+
+## Migration Summary
+
+```markdown
+# Runtime Migration Summary
+
+- Environment: prod
+- Active target before: active-a
+- Inactive target before: inactive-b
+- Final status: success
+
+## Phases
+
+| Phase | Result | Checkpoint |
+| --- | --- | --- |
+| discovery | success | runtime-state.json |
+| disable-workflows | success | workflows-disabled |
+| recreate-inactive | success | inactive-ready |
+| move-to-inactive | success | workloads-on-inactive |
+| recreate-active | success | active-ready |
+| move-to-active | success | workloads-on-active |
+| enable-workflows | success | workflows-enabled |
+```


### PR DESCRIPTION
## Description

Adds a new `docs/operations-patterns/` documentation pack for maintaining Forge operations consistently across image baking, container builds, IaC workflows, repository factory/catalog management, scheduled jobs, policy hygiene, dependency automation, migrations, rollback, ownership, and required checks.

The docs include playbooks, copyable workflow/catalog examples, adapter contracts, script interfaces, schema examples, workflow summaries, rollback examples, and a reference operations repo skeleton. `docs/index.md` now links to the new operations patterns section.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `pre-commit run mdformat --files docs/index.md docs/operations-patterns/*.md docs/operations-patterns/playbooks/*.md docs/operations-patterns/templates/*.md docs/operations-patterns/examples/*.md docs/operations-patterns/reference-skeleton/*.md`
- `git diff --check -- docs/index.md docs/operations-patterns`
- Private/Cisco-specific term scan against `docs/operations-patterns`
- Commit hooks passed for the staged docs change