### PR TITLE
chore: document accepted code scanning exceptions

### DIFF
--- a/.docker/forge-github-app-register/app.py
+++ b/.docker/forge-github-app-register/app.py
@@ -32,12 +32,17 @@ def oauth_callback():
     if not code:
         return "Missing 'code' parameter", 400
 
+    # Local-only GitHub App registration helper; code is a GitHub API path segment.
+    # lgtm[py/path-injection]
     url = f'{GITHUB_API}/app-manifests/{code}/conversions'
     headers = {'Accept': 'application/vnd.github.v3+json'}
     resp = requests.post(url, headers=headers)
 
     if resp.status_code != 201:
-        return f'Error converting manifest: {resp.status_code} {resp.text}', 500
+        # Local-only helper; upstream error text is returned only to the local operator.
+        # lgtm[py/reflective-xss]
+        error = f'Error converting manifest: {resp.status_code} {resp.text}'
+        return error, 500
 
     data = resp.json()
 

--- a/modules/infra/cloud_formation/main.tf
+++ b/modules/infra/cloud_formation/main.tf
@@ -54,6 +54,13 @@ resource "aws_iam_role" "cloudformation_execution_role" {
 }
 
 data "aws_iam_policy_document" "execution_role_policy" {
+  #checkov:skip=CKV2_AWS_40:CloudFormation StackSet execution role intentionally needs broad IAM permissions to deploy tenant-managed stacks.
+  #checkov:skip=CKV_AWS_107:CloudFormation StackSet execution role intentionally needs broad permissions to deploy tenant-managed stacks.
+  #checkov:skip=CKV_AWS_108:CloudFormation StackSet execution role intentionally needs broad permissions to deploy tenant-managed stacks.
+  #checkov:skip=CKV_AWS_109:CloudFormation StackSet execution role intentionally needs broad permissions to deploy tenant-managed stacks.
+  #checkov:skip=CKV_AWS_110:CloudFormation StackSet execution role intentionally needs broad permissions to deploy tenant-managed stacks.
+  #checkov:skip=CKV_AWS_111:CloudFormation StackSet execution role intentionally needs broad permissions to deploy tenant-managed stacks.
+  #checkov:skip=CKV_AWS_356:CloudFormation StackSet execution role intentionally needs wildcard resources to deploy tenant-managed stacks.
   statement {
     effect = "Allow"
     actions = [

--- a/modules/infra/eks/eks.tf
+++ b/modules/infra/eks/eks.tf
@@ -1,4 +1,5 @@
 module "ebs_csi_irsa_role" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version = "6.6.1"
 
@@ -16,6 +17,7 @@ module "ebs_csi_irsa_role" {
 }
 
 module "eks" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/eks/aws"
   version = "21.24.0"
 

--- a/modules/infra/eks/nodes.tf
+++ b/modules/infra/eks/nodes.tf
@@ -8,6 +8,7 @@ data "aws_ami" "eks_default" {
   }
 }
 module "self_managed_node_group" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
   version = "21.24.0"
 

--- a/modules/infra/storage/main.tf
+++ b/modules/infra/storage/main.tf
@@ -2,6 +2,7 @@
 # Long-term storage (i.e. release builds and SBOMs we need to retain long-term
 # for stability and auditing purposes).
 resource "aws_s3_bucket" "s3_long_term" {
+  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
   bucket = "${data.aws_caller_identity.current.account_id}-long-term-storage"
   tags   = local.all_security_tags
 }
@@ -47,6 +48,7 @@ resource "aws_s3_bucket_public_access_block" "s3_long_term" {
 # Short-term storage (i.e. temporary/feature-branch builds, core dumps, and
 # other artifacts we aren't obligated to retain long-term).
 resource "aws_s3_bucket" "s3_short_term" {
+  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
   bucket = "${data.aws_caller_identity.current.account_id}-short-term-storage"
   tags   = local.all_security_tags
 }

--- a/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/lambda.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/lambda.tf
@@ -6,6 +6,7 @@ resource "aws_cloudwatch_log_group" "webex" {
 }
 
 module "webex" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/secrets.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/secrets.tf
@@ -31,6 +31,7 @@ resource "aws_kms_alias" "webex_alias" {
 }
 
 resource "aws_secretsmanager_secret" "cicd_secrets" {
+  #checkov:skip=CKV2_AWS_57:Secret value is operator-managed for this integration; automatic rotation is not available here.
   for_each = {
     for key, val in local.secrets : val.name => val
   }

--- a/modules/integrations/github_webhook_relay_source/lambda.tf
+++ b/modules/integrations/github_webhook_relay_source/lambda.tf
@@ -1,4 +1,5 @@
 module "validate_signature_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/integrations/github_webhook_relay_source/main.tf
+++ b/modules/integrations/github_webhook_relay_source/main.tf
@@ -29,6 +29,7 @@ resource "aws_apigatewayv2_integration" "lambda" {
 }
 
 resource "aws_apigatewayv2_route" "post_hook" {
+  #checkov:skip=CKV_AWS_309:Public GitHub webhook route validates the HMAC signature in the Lambda integration.
   api_id    = aws_apigatewayv2_api.webhook.id
   route_key = "POST /webhook"
   target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"

--- a/modules/integrations/splunk_aws_billing/billing_per_resource.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 module "cur_per_resource" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 module "cur_per_resource_process" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/integrations/splunk_aws_billing/billing_per_service.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_service.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 module "cur_per_service" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/integrations/splunk_aws_billing/s3.tf
+++ b/modules/integrations/splunk_aws_billing/s3.tf
@@ -1,4 +1,5 @@
 resource "aws_s3_bucket" "aws_billing_report" {
+  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
   bucket = "${data.aws_caller_identity.current.account_id}-aws-billing-report"
   tags   = local.all_security_tags
 }

--- a/modules/integrations/splunk_cloud_data_manager/cloudwatch.tf
+++ b/modules/integrations/splunk_cloud_data_manager/cloudwatch.tf
@@ -58,6 +58,7 @@ module "splunk_cloudwatch" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_cloudwatch_iam_region" {
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
   count = var.cloudwatch_log_groups_config.enabled ? 1 : 0
   name  = module.splunk_cloudwatch[0].splunk_integration_name
 
@@ -77,6 +78,7 @@ resource "aws_cloudformation_stack" "cf_splunk_cloudwatch_iam_region" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_cloudwatch_region" {
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
   for_each = var.cloudwatch_log_groups_config.enabled ? toset(setsubtract(var.cloudwatch_log_groups_config.regions, [var.aws_region])) : []
   provider = aws.by_region[each.value]
   name     = module.splunk_cloudwatch[0].splunk_integration_name

--- a/modules/integrations/splunk_cloud_data_manager/custom_cloudwatch.tf
+++ b/modules/integrations/splunk_cloud_data_manager/custom_cloudwatch.tf
@@ -69,6 +69,7 @@ module "splunk_custom_cloudwatch" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_custom_cloudwatch_iam_region" {
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
   count = var.custom_cloudwatch_log_groups_config.enabled ? 1 : 0
   name  = module.splunk_custom_cloudwatch[0].splunk_integration_name
 
@@ -88,6 +89,7 @@ resource "aws_cloudformation_stack" "cf_splunk_custom_cloudwatch_iam_region" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_custom_cloudwatch_region" {
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
   for_each = var.custom_cloudwatch_log_groups_config.enabled ? toset(setsubtract(local.custom_log_group_regions, [var.aws_region])) : []
   provider = aws.by_region[each.key]
   name     = module.splunk_custom_cloudwatch[0].splunk_integration_name

--- a/modules/integrations/splunk_cloud_data_manager/sec_meta.tf
+++ b/modules/integrations/splunk_cloud_data_manager/sec_meta.tf
@@ -64,6 +64,7 @@ module "splunk_security_metadata" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_security_metadata_iam_region" {
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
   count = var.security_metadata_config.enabled ? 1 : 0
   name  = module.splunk_security_metadata[0].splunk_integration_name
 
@@ -83,6 +84,7 @@ resource "aws_cloudformation_stack" "cf_splunk_security_metadata_iam_region" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_security_metadata_region" {
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
   for_each = var.security_metadata_config.enabled ? toset(setsubtract(var.security_metadata_config.regions, [var.aws_region])) : []
   provider = aws.by_region[each.value]
   name     = module.splunk_security_metadata[0].splunk_integration_name

--- a/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/main.tf
+++ b/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/main.tf
@@ -1,4 +1,5 @@
 module "splunk_dm_metadata_ec2inst_pattern_tags_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 module "splunk_s3_runner_logs_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
@@ -1,4 +1,5 @@
 resource "aws_s3_bucket" "firehose_backup" {
+  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
   bucket = "splunk-s3-runner-logs-failed-${data.aws_caller_identity.current.account_id}-${var.aws_region}"
   tags   = var.tags
 }

--- a/modules/integrations/splunk_o11y_aws_integration/cf.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/cf.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudformation_stack" "splunk_integration" {
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
   name = "splunk-integration"
 
   parameters = {

--- a/modules/integrations/splunk_secrets/main.tf
+++ b/modules/integrations/splunk_secrets/main.tf
@@ -99,6 +99,7 @@ resource "aws_kms_alias" "regional_alias" {
 
 # Actual object containing the secret.
 resource "aws_secretsmanager_secret" "cicd_secrets" {
+  #checkov:skip=CKV2_AWS_57:Secret value is operator-managed for this integration; automatic rotation is not available here.
   for_each = {
     for key, val in local.secrets : val.name => val
   }

--- a/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/main.tf
+++ b/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/main.tf
@@ -1,4 +1,5 @@
 module "ec2_update_runner_ssm_ami_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/platform/ec2_deployment/ec2_update_runner_tags/main.tf
+++ b/modules/platform/ec2_deployment/ec2_update_runner_tags/main.tf
@@ -1,4 +1,5 @@
 module "ec2_update_runner_tags_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -34,6 +34,7 @@ data "external" "download_lambdas" {
 
 
 module "runners" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source = "git::https://github.com/github-aws-runners/terraform-aws-github-runner.git//modules/multi-runner?ref=v7.8.0"
 
   aws_region = var.aws_region

--- a/modules/platform/ec2_deployment/security_group.tf
+++ b/modules/platform/ec2_deployment/security_group.tf
@@ -1,5 +1,6 @@
 # Allow the lambda to egress to any destination via any protocol.
 resource "aws_security_group" "gh_runner_lambda_egress" {
+  #checkov:skip=CKV2_AWS_5:Security group is attached through the terraform-aws-github-runner lambda_security_group_ids module input.
   name   = "${var.runner_configs.prefix}-gh-runner-lambda-egress-all"
   vpc_id = var.network_configs.lambda_vpc_id
 

--- a/modules/platform/forge_runners/forge_trust_validator/main.tf
+++ b/modules/platform/forge_runners/forge_trust_validator/main.tf
@@ -5,6 +5,7 @@ locals {
 }
 
 module "forge_trust_preparer_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 
@@ -42,6 +43,7 @@ module "forge_trust_preparer_lambda" {
 }
 
 module "forge_trust_validator_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/platform/forge_runners/github_actions_job_logs/job_log_archiver.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/job_log_archiver.tf
@@ -4,6 +4,7 @@ locals {
 }
 
 module "job_log_archiver" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/platform/forge_runners/github_actions_job_logs/job_log_dispatcher.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/job_log_dispatcher.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 module "job_log_dispatcher" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/platform/forge_runners/github_actions_job_logs/s3.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/s3.tf
@@ -1,4 +1,5 @@
 resource "aws_s3_bucket" "gh_logs" {
+  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
   bucket = "${var.prefix}-forge-gh-logs-${data.aws_caller_identity.current.account_id}"
   tags   = var.tags
 }

--- a/modules/platform/forge_runners/github_app_runner_group/main.tf
+++ b/modules/platform/forge_runners/github_app_runner_group/main.tf
@@ -1,4 +1,5 @@
 module "register_github_app_runner_group_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/platform/forge_runners/github_global_lock/main.tf
+++ b/modules/platform/forge_runners/github_global_lock/main.tf
@@ -77,6 +77,7 @@ resource "aws_iam_policy" "dynamodb_policy" {
 
 ## GitHub Clean Global Lock Lambda
 module "clean_global_lock_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 

--- a/modules/platform/forge_runners/github_webhook_relay/main.tf
+++ b/modules/platform/forge_runners/github_webhook_relay/main.tf
@@ -38,6 +38,7 @@ resource "aws_kms_alias" "github_webhook_relay" {
 }
 
 resource "aws_secretsmanager_secret" "github_webhook_relay" {
+  #checkov:skip=CKV2_AWS_57:Secret value is managed by Terraform for this integration; automatic rotation is not available here.
 
   name        = "${var.secret_prefix}/webhook_relay"
   description = "GitHub webhook relay endpoint + secret"

--- a/modules/platform/forge_runners/redrive_deadletter/main.tf
+++ b/modules/platform/forge_runners/redrive_deadletter/main.tf
@@ -1,4 +1,5 @@
 module "redrive_deadletter_lambda" {
+  #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
   source  = "terraform-aws-modules/lambda/aws"
   version = "8.8.0"
 


### PR DESCRIPTION
## Description

Documents accepted code-scanning exceptions that were reviewed as false positives or accepted-risk findings. Adds scoped inline CodeQL and Checkov suppressions for local-only helper code, Terraform module-source policy exceptions, Splunk-managed CloudFormation stacks, S3 replication policy exceptions, and operator/application-managed secrets.

Also reflects the GitHub-side dismissals for those reviewed alerts. The stuck-workflow dispatcher changes are intentionally left out of this PR.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Code scanning triage / accepted-risk documentation

## Testing

- Ran `terraform fmt` on touched Terraform files.
- Ran `git diff --check`.
- Ran targeted Checkov:
  - `checkov -d modules --skip-download -c CKV_TF_1 --quiet`
  - `checkov -d modules --skip-download -c CKV_AWS_124,CKV_AWS_144,CKV2_AWS_57 --quiet`
- Commit pre-commit hooks passed except `tofu-validate` and `terraform_validate`, which were skipped because they hung locally after multiple attempts.
