### PR TITLE
fix: break ec2 runner ami destroy cycle

### DIFF
--- a/modules/platform/ec2_deployment/ami.tf
+++ b/modules/platform/ec2_deployment/ami.tf
@@ -1,20 +1,16 @@
 data "aws_ssm_parameter" "ami_id" {
-  for_each = {
-    for runner_key, runner in module.runners.runners_map :
-    runner_key => split("parameter", runner.launch_template_ami_id)[1]
-  }
+  for_each = local.runner_ami_ssm_parameter_names
 
   name            = each.value
   with_decryption = true
-  depends_on      = [module.runners]
 }
 
 data "aws_ami" "runner_ami" {
-  for_each    = { for runner_key, runner in module.runners.runners_map : runner_key => runner.launch_template_ami_id }
+  for_each    = var.runner_configs.runner_specs
   most_recent = false
+
   filter {
     name   = "image-id"
     values = [data.aws_ssm_parameter.ami_id[each.key].value]
   }
-  depends_on = [module.runners]
 }

--- a/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami.tf
+++ b/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami.tf
@@ -1,3 +1,19 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+locals {
+  runner_ami_ssm_parameter_names = {
+    for key in keys(var.runner_configs.runner_specs) :
+    key => "/github-action-runners/${var.runner_configs.prefix}/${key}/runners/config/ami_id"
+  }
+
+  runner_ami_ssm_parameter_arns = {
+    for key, name in local.runner_ami_ssm_parameter_names :
+    key => "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${name}"
+  }
+}
+
 module "ec2_update_runner_ssm_ami" {
   source = "./ec2_update_runner_ssm_ami"
 
@@ -13,8 +29,8 @@ module "ec2_update_runner_ssm_ami" {
   runner_ami_map = {
     for key in keys(var.runner_configs.runner_specs) :
     key => {
-      resource_ssm_id = replace(module.runners.runners_map[key].launch_template_ami_id, "resolve:ssm:", "")
-      ssm_id          = split("parameter", module.runners.runners_map[key].launch_template_ami_id)[1]
+      resource_ssm_id = local.runner_ami_ssm_parameter_arns[key]
+      ssm_id          = local.runner_ami_ssm_parameter_names[key]
       ami_filter      = var.runner_configs.runner_specs[key].ami_filter
       ami_owners      = var.runner_configs.runner_specs[key].ami_owners
     }


### PR DESCRIPTION
## Description

Fixes EC2 runner destroy cycles when deleting a runner type.

The AMI lookup now reads the module-managed AMI ID from the deterministic SSM parameter path built from `runner_configs.prefix` and each `runner_specs` key, for example:

`/github-action-runners/sfcntls-usw2-sl/large-dp-test/runners/config/ami_id`

This removes the dependency on `module.runners.runners_map` and the explicit `depends_on = [module.runners]` from the AMI data sources, which was causing Terraform to keep the AMI lookup inside the same destroy graph as the removed runner module instance.

The SSM AMI updater now uses the same derived parameter name and ARN, so its Lambda policy and environment map stay aligned with the runner module's SSM layout without depending on runner module outputs.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: _________

## Testing

- `tofu -chdir=/private/tmp/forge-fix-ec2-runner-ami-cycle/modules/platform/ec2_deployment validate`
- Commit hooks passed, including Terraform/IaC fmt and validation, Terraform validate, Terraform linter, security checks, and related repository checks.
