### PR TITLE
fix: avoid windows hook log contention

### DIFF
--- a/modules/platform/ec2_deployment/ami.tf
+++ b/modules/platform/ec2_deployment/ami.tf
@@ -3,6 +3,8 @@ data "aws_ssm_parameter" "ami_id" {
 
   name            = each.value
   with_decryption = true
+
+  depends_on = [module.runners]
 }
 
 data "aws_ami" "runner_ami" {
@@ -13,4 +15,6 @@ data "aws_ami" "runner_ami" {
     name   = "image-id"
     values = [data.aws_ssm_parameter.ami_id[each.key].value]
   }
+
+  depends_on = [module.runners]
 }

--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -231,7 +231,7 @@ module "runners" {
             {
               "log_group_name" : "forge-logs",
               "prefix_log_group" : true,
-              "file_path" : val["runner_os"] == "windows" ? "C:/Users/Administrator/AppData/Local/Temp/hook.log" : "/home/${val["runner_user"]}/hook.log",
+              "file_path" : val["runner_os"] == "windows" ? "C:/Users/Administrator/AppData/Local/Temp/hook_*.log" : "/home/${val["runner_user"]}/hook.log",
               "log_stream_name" : "{instance_id}/hook"
             },
           ],

--- a/modules/platform/ec2_deployment/template_files/hooks/job_completed_windows
+++ b/modules/platform/ec2_deployment/template_files/hooks/job_completed_windows
@@ -1,5 +1,5 @@
 $scriptRoot = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
-$logFile = Join-Path $scriptRoot 'hook.log'
+$logFile = Join-Path $scriptRoot 'hook_completed.log'
 
 function Get-EnvValue {
     param([string]$Name)
@@ -22,6 +22,45 @@ function Get-GitHubEvent {
         return Get-Content -LiteralPath $eventPath -Raw | ConvertFrom-Json
     } catch {
         return @{}
+    }
+}
+
+function Write-HookLogEntry {
+    param(
+        [string]$Path,
+        [object]$Entry
+    )
+
+    $line = ($Entry | ConvertTo-Json -Compress -Depth 100) + [Environment]::NewLine
+    $encoding = New-Object System.Text.UTF8Encoding -ArgumentList $false
+
+    for ($attempt = 1; $attempt -le 10; $attempt++) {
+        $stream = $null
+        $writer = $null
+
+        try {
+            $stream = [System.IO.File]::Open(
+                $Path,
+                [System.IO.FileMode]::Append,
+                [System.IO.FileAccess]::Write,
+                [System.IO.FileShare]::ReadWrite
+            )
+            $writer = New-Object System.IO.StreamWriter -ArgumentList $stream, $encoding
+            $writer.Write($line)
+            return
+        } catch [System.IO.IOException] {
+            if ($attempt -eq 10) {
+                throw
+            }
+
+            Start-Sleep -Milliseconds ([Math]::Min(1000, 100 * $attempt))
+        } finally {
+            if ($writer) {
+                $writer.Dispose()
+            } elseif ($stream) {
+                $stream.Dispose()
+            }
+        }
     }
 }
 
@@ -105,8 +144,12 @@ $entry = [ordered]@{
     GITHUB_EVENT               = (Get-GitHubEvent)
 }
 
-$entry | ConvertTo-Json -Compress -Depth 100 | Add-Content -Path $logFile -Encoding UTF8
-Write-Output "GitHub Actions environment variables exported to $logFile"
+try {
+    Write-HookLogEntry -Path $logFile -Entry $entry
+    Write-Output "GitHub Actions environment variables exported to $logFile"
+} catch {
+    Write-Output "Unable to write GitHub Actions environment variables to $($logFile): $($_.Exception.Message)"
+}
 
 Remove-Item Env:AWS_ACCESS_KEY_ID -ErrorAction SilentlyContinue
 Remove-Item Env:AWS_SECRET_ACCESS_KEY -ErrorAction SilentlyContinue

--- a/modules/platform/ec2_deployment/template_files/hooks/job_started_windows
+++ b/modules/platform/ec2_deployment/template_files/hooks/job_started_windows
@@ -1,5 +1,5 @@
 $scriptRoot = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
-$logFile = Join-Path $scriptRoot 'hook.log'
+$logFile = Join-Path $scriptRoot 'hook_started.log'
 
 function Get-EnvValue {
     param([string]$Name)
@@ -22,6 +22,45 @@ function Get-GitHubEvent {
         return Get-Content -LiteralPath $eventPath -Raw | ConvertFrom-Json
     } catch {
         return @{}
+    }
+}
+
+function Write-HookLogEntry {
+    param(
+        [string]$Path,
+        [object]$Entry
+    )
+
+    $line = ($Entry | ConvertTo-Json -Compress -Depth 100) + [Environment]::NewLine
+    $encoding = New-Object System.Text.UTF8Encoding -ArgumentList $false
+
+    for ($attempt = 1; $attempt -le 10; $attempt++) {
+        $stream = $null
+        $writer = $null
+
+        try {
+            $stream = [System.IO.File]::Open(
+                $Path,
+                [System.IO.FileMode]::Append,
+                [System.IO.FileAccess]::Write,
+                [System.IO.FileShare]::ReadWrite
+            )
+            $writer = New-Object System.IO.StreamWriter -ArgumentList $stream, $encoding
+            $writer.Write($line)
+            return
+        } catch [System.IO.IOException] {
+            if ($attempt -eq 10) {
+                throw
+            }
+
+            Start-Sleep -Milliseconds ([Math]::Min(1000, 100 * $attempt))
+        } finally {
+            if ($writer) {
+                $writer.Dispose()
+            } elseif ($stream) {
+                $stream.Dispose()
+            }
+        }
     }
 }
 
@@ -105,8 +144,12 @@ $entry = [ordered]@{
     GITHUB_EVENT               = (Get-GitHubEvent)
 }
 
-$entry | ConvertTo-Json -Compress -Depth 100 | Add-Content -Path $logFile -Encoding UTF8
-Write-Output "GitHub Actions environment variables exported to $logFile"
+try {
+    Write-HookLogEntry -Path $logFile -Entry $entry
+    Write-Output "GitHub Actions environment variables exported to $logFile"
+} catch {
+    Write-Output "Unable to write GitHub Actions environment variables to $($logFile): $($_.Exception.Message)"
+}
 
 try {
     $token = Get-ImdsToken


### PR DESCRIPTION
## Description

Fixes SREA-126 by preventing Windows EC2 runner job hooks from failing when the hook log file is already open.

The Windows started and completed hooks now write to separate files (`hook_started.log` and `hook_completed.log`) and use a retrying append helper with read/write file sharing. CloudWatch continues collecting them under the same hook stream through the `hook_*.log` path.

Root cause: both Windows hook scripts wrote to the same `hook.log` file with `Add-Content`, which can fail on Windows when another process has the file open.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `terraform fmt -check -diff modules/platform/ec2_deployment/main.tf`
- `git diff --check`
- Pre-commit hooks during commit, including Terraform/IaC fmt, validate, and lint checks
