### PR TITLE
feat: add Splunk OpenCost EKS integration

### DIFF
--- a/examples/deployments/splunk-deployment/release_versions.yml
+++ b/examples/deployments/splunk-deployment/release_versions.yml
@@ -33,6 +33,11 @@ spec:
         repo: git@github.com:cisco-open/forge.git
         module_path: modules/integrations/splunk_otel_eks
         ref: main
+      splunk_opencost_eks:
+        local_path: ../forge
+        repo: git@github.com:cisco-open/forge.git
+        module_path: modules/integrations/splunk_opencost_eks
+        ref: main
       splunk_secrets:
         local_path: ../forge
         repo: git@github.com:cisco-open/forge.git

--- a/examples/deployments/splunk-deployment/terragrunt/_global_settings/splunk_opencost_eks.hcl
+++ b/examples/deployments/splunk-deployment/terragrunt/_global_settings/splunk_opencost_eks.hcl
@@ -1,0 +1,44 @@
+locals {
+  # Global settings.
+  global_data  = read_terragrunt_config(find_in_parent_folders("_global_settings/_global.hcl"))
+  team_name    = local.global_data.locals.team_name
+  product_name = local.global_data.locals.product_name
+  project_name = local.global_data.locals.project_name
+
+  # Environment settings.
+  env_data            = read_terragrunt_config(find_in_parent_folders("_environment_wide_settings/_environment.hcl"))
+  default_aws_profile = local.env_data.locals.default_aws_profile
+
+  # Region settings.
+  region_data = read_terragrunt_config(find_in_parent_folders("_region_wide_settings/_region.hcl"))
+  region      = local.region_data.locals.region_aws
+
+  default_tags = {
+    ApplicationName   = local.project_name
+    ResourceOwner     = local.team_name
+    ProductFamilyName = local.product_name
+    IntendedPublic    = "No"
+    LastRevalidatedBy = "Terraform"
+    LastRevalidatedAt = "2025-05-15"
+  }
+
+  opencost_settings_data = read_terragrunt_config(find_in_parent_folders("splunk_opencost_eks/config.hcl"))
+}
+
+dependencies {
+  paths = [
+    find_in_parent_folders("splunk_otel_eks")
+  ]
+}
+
+inputs = {
+  # Core environment.
+  aws_profile = local.default_aws_profile
+  aws_region  = local.region
+
+  # OpenCost EKS configuration.
+  cluster_name = local.opencost_settings_data.locals.cluster_name
+
+  # Misc.
+  default_tags = local.default_tags
+}

--- a/examples/deployments/splunk-deployment/terragrunt/_global_settings/splunk_otel_eks.hcl
+++ b/examples/deployments/splunk-deployment/terragrunt/_global_settings/splunk_otel_eks.hcl
@@ -54,8 +54,9 @@ inputs = {
   aws_region  = local.region
 
   # Splunk OTel EKS Configuration
-  cluster_name          = local.eks_settings_data.locals.cluster_name
-  splunk_otel_collector = local.eks_settings_data.locals.splunk_otel_collector
+  cluster_name                     = local.eks_settings_data.locals.cluster_name
+  splunk_otel_collector            = local.eks_settings_data.locals.splunk_otel_collector
+  prometheus_autodiscovery_enabled = true
 
   # Misc
   tags         = local.tags

--- a/examples/deployments/splunk-deployment/terragrunt/environments/prod/regions/eu-west-1/splunk_opencost_eks/config.hcl
+++ b/examples/deployments/splunk-deployment/terragrunt/environments/prod/regions/eu-west-1/splunk_opencost_eks/config.hcl
@@ -1,0 +1,4 @@
+locals {
+  config       = yamldecode(file("config.yml"))
+  cluster_name = local.config.cluster_name
+}

--- a/examples/deployments/splunk-deployment/terragrunt/environments/prod/regions/eu-west-1/splunk_opencost_eks/config.yml
+++ b/examples/deployments/splunk-deployment/terragrunt/environments/prod/regions/eu-west-1/splunk_opencost_eks/config.yml
@@ -1,0 +1,2 @@
+---
+cluster_name: forge-euw1-prod

--- a/examples/deployments/splunk-deployment/terragrunt/environments/prod/regions/eu-west-1/splunk_opencost_eks/terragrunt.hcl
+++ b/examples/deployments/splunk-deployment/terragrunt/environments/prod/regions/eu-west-1/splunk_opencost_eks/terragrunt.hcl
@@ -1,0 +1,63 @@
+# Root module (used for path resolution and remote state).
+include "root" {
+  path = find_in_parent_folders()
+}
+
+# Global settings.
+include "global" {
+  path   = find_in_parent_folders("_global_settings/_global.hcl")
+  expose = true
+}
+
+# Environment-wide settings.
+include "env" {
+  path   = find_in_parent_folders("_environment_wide_settings/_environment.hcl")
+  expose = true
+}
+
+# Module global settings.
+include "mod_global" {
+  path   = find_in_parent_folders("_global_settings/${basename(get_terragrunt_dir())}.hcl")
+  expose = true
+}
+
+# Version of module to use.
+locals {
+  module_name = basename(get_terragrunt_dir())
+  project     = include.global.locals.project_name
+  env         = include.env.locals.env
+
+  release_version_env     = get_env("RELEASE_VERSION_PATH", "")
+  release_version_file    = length(trimspace(local.release_version_env)) > 0 ? local.release_version_env : "${get_repo_root()}/release_versions.yml"
+  release_version_content = file(local.release_version_file)
+  release_version         = yamldecode(local.release_version_content)
+
+  use_local_repos = local.release_version["metadata"]["use_local_repos"]
+  module_root     = local.release_version["spec"]["iac"]["modules"][local.module_name]
+  git_prefix      = "git::file://"
+
+  module_base    = local.use_local_repos ? "${local.git_prefix}${get_repo_root()}/${local.module_root["local_path"]}" : local.module_root["repo"]
+  module_version = local.module_root["ref"]
+  module_ref     = local.use_local_repos ? "${local.module_base}//${local.module_root["module_path"]}" : "${local.module_base}//${local.module_root["module_path"]}?ref=${local.module_version}"
+}
+
+# Construct the terraform.source attribute using the source_base.
+terraform {
+  source = local.module_ref
+}
+
+# Remote state storage/locks.
+remote_state {
+  backend = include.env.locals.remote_state_config.backend
+
+  config = {
+    bucket              = include.env.locals.remote_state_config.config.bucket
+    key                 = "${path_relative_to_include("root")}/terraform.tfstate"
+    region              = include.env.locals.remote_state_config.config.region
+    encrypt             = include.env.locals.remote_state_config.config.encrypt
+    dynamodb_table      = include.env.locals.remote_state_config.config.dynamodb_table
+    profile             = include.env.locals.remote_state_config.config.profile
+    s3_bucket_tags      = include.env.locals.remote_state_config.config.s3_bucket_tags
+    dynamodb_table_tags = include.env.locals.remote_state_config.config.dynamodb_table_tags
+  }
+}

--- a/examples/templates/splunk/splunk_opencost_eks/config.yml
+++ b/examples/templates/splunk/splunk_opencost_eks/config.yml
@@ -1,0 +1,2 @@
+---
+cluster_name: <CLUSTER_NAME>  # e.g., forge-euw1-prod

--- a/modules/integrations/splunk_opencost_eks/README.md
+++ b/modules/integrations/splunk_opencost_eks/README.md
@@ -1,0 +1,39 @@
+# Splunk OpenCost for EKS
+
+This module installs OpenCost and a minimal Prometheus release on an EKS cluster.
+
+OpenCost exposes Prometheus-format cost metrics on `/metrics`. The existing `splunk_otel_eks` module should scrape those metrics through the static pod and service annotations configured here.
+
+## What It Manages
+
+- `helm_release.managed_prometheus`
+- `helm_release.opencost`
+- EKS cluster data lookups for Helm authentication
+
+## Fixed Defaults
+
+- OpenCost namespace: `opencost`
+- OpenCost service account: `opencost`
+- OpenCost chart: `opencost/opencost` version `2.5.20`
+- Prometheus namespace: `prometheus-system`
+- Prometheus chart: `prometheus-community/prometheus` version `29.14.0`
+- OpenCost metrics endpoint: `http://opencost.opencost.svc.cluster.local:9003/metrics`
+
+## Example
+
+```hcl
+module "splunk_opencost_eks" {
+  source = "../../../modules/integrations/splunk_opencost_eks"
+
+  aws_profile = "forge-prod"
+  aws_region  = "eu-west-1"
+  cluster_name = "forge-euw1-prod"
+
+  default_tags = {
+    ApplicationName = "forge"
+    ResourceOwner   = "forge"
+  }
+}
+```
+
+Enable Prometheus autodiscovery in `splunk_otel_eks` so the Splunk collector scrapes the OpenCost annotations.

--- a/modules/integrations/splunk_opencost_eks/backend.tf
+++ b/modules/integrations/splunk_opencost_eks/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  # Intentionally empty. Will be filled by Terragrunt.
+  backend "s3" {}
+}

--- a/modules/integrations/splunk_opencost_eks/data.tf
+++ b/modules/integrations/splunk_opencost_eks/data.tf
@@ -1,0 +1,7 @@
+data "aws_eks_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = var.cluster_name
+}

--- a/modules/integrations/splunk_opencost_eks/main.tf
+++ b/modules/integrations/splunk_opencost_eks/main.tf
@@ -44,7 +44,7 @@ resource "helm_release" "opencost" {
   name             = "opencost"
   repository       = "https://opencost.github.io/opencost-helm-chart"
   chart            = "opencost"
-  version          = "2.5.20"
+  version          = "2.5.25"
   namespace        = "opencost"
   create_namespace = true
 

--- a/modules/integrations/splunk_opencost_eks/main.tf
+++ b/modules/integrations/splunk_opencost_eks/main.tf
@@ -124,26 +124,32 @@ resource "helm_release" "opencost" {
     {
       name  = "podAnnotations.prometheus\\.io/scrape"
       value = "true"
+      type  = "string"
     },
     {
       name  = "podAnnotations.prometheus\\.io/path"
       value = "/metrics"
+      type  = "string"
     },
     {
       name  = "podAnnotations.prometheus\\.io/port"
       value = "9003"
+      type  = "string"
     },
     {
       name  = "service.annotations.prometheus\\.io/scrape"
       value = "true"
+      type  = "string"
     },
     {
       name  = "service.annotations.prometheus\\.io/path"
       value = "/metrics"
+      type  = "string"
     },
     {
       name  = "service.annotations.prometheus\\.io/port"
       value = "9003"
+      type  = "string"
     }
   ]
 

--- a/modules/integrations/splunk_opencost_eks/main.tf
+++ b/modules/integrations/splunk_opencost_eks/main.tf
@@ -1,0 +1,158 @@
+resource "helm_release" "managed_prometheus" {
+  name             = "prometheus"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus"
+  version          = "29.14.0"
+  namespace        = "prometheus-system"
+  create_namespace = true
+
+  set = [
+    {
+      name  = "alertmanager.enabled"
+      value = false
+    },
+    {
+      name  = "kube-state-metrics.enabled"
+      value = false
+    },
+    {
+      name  = "prometheus-node-exporter.enabled"
+      value = false
+    },
+    {
+      name  = "prometheus-pushgateway.enabled"
+      value = false
+    },
+    {
+      name  = "server.persistentVolume.enabled"
+      value = false
+    },
+    {
+      name  = "server.service.servicePort"
+      value = 80
+    }
+  ]
+
+  atomic          = true
+  cleanup_on_fail = true
+  timeout         = 1200
+  wait            = true
+
+}
+
+resource "helm_release" "opencost" {
+  name             = "opencost"
+  repository       = "https://opencost.github.io/opencost-helm-chart"
+  chart            = "opencost"
+  version          = "2.5.20"
+  namespace        = "opencost"
+  create_namespace = true
+
+  set = [
+    {
+      name  = "fullnameOverride"
+      value = "opencost"
+    },
+    {
+      name  = "serviceAccount.create"
+      value = true
+    },
+    {
+      name  = "serviceAccount.name"
+      value = "opencost"
+    },
+    {
+      name  = "opencost.cloudIntegrationSecret"
+      value = ""
+    },
+    {
+      name  = "opencost.cloudCost.enabled"
+      value = false
+    },
+    {
+      name  = "opencost.exporter.apiPort"
+      value = 9003
+    },
+    {
+      name  = "opencost.exporter.defaultClusterId"
+      value = var.cluster_name
+    },
+    {
+      name  = "opencost.metrics.kubeStateMetrics.emitKsmV1Metrics"
+      value = false
+    },
+    {
+      name  = "opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly"
+      value = false
+    },
+    {
+      name  = "opencost.prometheus.external.enabled"
+      value = false
+    },
+    {
+      name  = "opencost.prometheus.external.url"
+      value = ""
+    },
+    {
+      name  = "opencost.prometheus.internal.enabled"
+      value = true
+    },
+    {
+      name  = "opencost.prometheus.internal.namespaceName"
+      value = "prometheus-system"
+    },
+    {
+      name  = "opencost.prometheus.internal.serviceName"
+      value = "prometheus-server"
+    },
+    {
+      name  = "opencost.prometheus.internal.port"
+      value = 80
+    },
+    {
+      name  = "opencost.prometheus.internal.path"
+      value = ""
+    },
+    {
+      name  = "opencost.prometheus.internal.scheme"
+      value = "http"
+    },
+    {
+      name  = "opencost.ui.enabled"
+      value = false
+    },
+    {
+      name  = "podAnnotations.prometheus\\.io/scrape"
+      value = "true"
+    },
+    {
+      name  = "podAnnotations.prometheus\\.io/path"
+      value = "/metrics"
+    },
+    {
+      name  = "podAnnotations.prometheus\\.io/port"
+      value = "9003"
+    },
+    {
+      name  = "service.annotations.prometheus\\.io/scrape"
+      value = "true"
+    },
+    {
+      name  = "service.annotations.prometheus\\.io/path"
+      value = "/metrics"
+    },
+    {
+      name  = "service.annotations.prometheus\\.io/port"
+      value = "9003"
+    }
+  ]
+
+  atomic          = true
+  cleanup_on_fail = true
+  timeout         = 1200
+  wait            = true
+
+  depends_on = [
+    helm_release.managed_prometheus,
+  ]
+}

--- a/modules/integrations/splunk_opencost_eks/outputs.tf
+++ b/modules/integrations/splunk_opencost_eks/outputs.tf
@@ -1,0 +1,35 @@
+output "namespace" {
+  value = "opencost"
+}
+
+output "release_name" {
+  value = "opencost"
+}
+
+output "service_name" {
+  value = "opencost"
+}
+
+output "service_account_name" {
+  value = "opencost"
+}
+
+output "metrics_endpoint" {
+  value = "http://opencost.opencost.svc.cluster.local:9003/metrics"
+}
+
+output "metrics_host" {
+  value = "opencost.opencost.svc.cluster.local"
+}
+
+output "metrics_port" {
+  value = 9003
+}
+
+output "metrics_path" {
+  value = "/metrics"
+}
+
+output "prometheus_endpoint" {
+  value = "http://prometheus-server.prometheus-system.svc.cluster.local:80"
+}

--- a/modules/integrations/splunk_opencost_eks/providers.tf
+++ b/modules/integrations/splunk_opencost_eks/providers.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+
+  # Required, as per security guidelines.
+  default_tags {
+    tags = var.default_tags
+  }
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}

--- a/modules/integrations/splunk_opencost_eks/variables.tf
+++ b/modules/integrations/splunk_opencost_eks/variables.tf
@@ -1,0 +1,22 @@
+variable "aws_profile" {
+  type        = string
+  description = "AWS profile to use."
+  default     = null
+}
+
+variable "aws_region" {
+  type        = string
+  description = "Default AWS region."
+  default     = null
+}
+
+variable "default_tags" {
+  type        = map(string)
+  description = "A map of tags to apply to resources."
+  default     = {}
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The EKS cluster name and OpenCost default cluster ID."
+}

--- a/modules/integrations/splunk_opencost_eks/versions.tf
+++ b/modules/integrations/splunk_opencost_eks/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.47"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 3.0.0"
+    }
+  }
+
+  # OpenTofu version.
+  required_version = "~> 1.11"
+}

--- a/modules/integrations/splunk_otel_eks/README.md
+++ b/modules/integrations/splunk_otel_eks/README.md
@@ -28,13 +28,15 @@ Forge sends AWS metrics through the Splunk Observability integration, but Kubern
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.47 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 3.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.52.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 3.2.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
 
 ## Modules
 
@@ -49,6 +51,7 @@ No modules.
 | [aws_iam_role.splunk_otel_ec2_describe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.splunk_otel_ec2_describe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.splunk_otel_collector](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [time_sleep.wait_for_pod_identity_propagation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_iam_openid_connect_provider.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
@@ -65,6 +68,7 @@ No modules.
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | Default AWS region. | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the EKS cluster | `string` | n/a | yes |
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
+| <a name="input_prometheus_autodiscovery_enabled"></a> [prometheus\_autodiscovery\_enabled](#input\_prometheus\_autodiscovery\_enabled) | Enable Splunk OTel annotation-based Prometheus autodiscovery for pods and services such as OpenCost. | `bool` | `false` | no |
 | <a name="input_splunk_otel_collector"></a> [splunk\_otel\_collector](#input\_splunk\_otel\_collector) | Configuration for the Splunk OpenTelemetry Collector | <pre>object({<br/>    splunk_platform_endpoint        = string<br/>    splunk_platform_index           = string<br/>    gateway                         = bool<br/>    environment                     = string<br/>    discovery                       = bool<br/>    splunk_observability_realm      = string<br/>    splunk_observability_ingest_url = string<br/>    splunk_observability_api_url    = string<br/>    splunk_observability_profiling  = bool<br/>  })</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
 

--- a/modules/integrations/splunk_otel_eks/otel.tf
+++ b/modules/integrations/splunk_otel_eks/otel.tf
@@ -81,6 +81,10 @@ resource "helm_release" "splunk_otel_collector" {
       value = var.splunk_otel_collector.discovery
     },
     {
+      name  = "autodetect.prometheus"
+      value = var.prometheus_autodiscovery_enabled
+    },
+    {
       name  = "tolerations[0].operator"
       value = "Exists"
     }

--- a/modules/integrations/splunk_otel_eks/variables.tf
+++ b/modules/integrations/splunk_otel_eks/variables.tf
@@ -28,6 +28,12 @@ variable "splunk_otel_collector" {
   })
 }
 
+variable "prometheus_autodiscovery_enabled" {
+  type        = bool
+  description = "Enable Splunk OTel annotation-based Prometheus autodiscovery for pods and services such as OpenCost."
+  default     = false
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map of tags to apply to resources."


### PR DESCRIPTION
## Description

Adds a `splunk_opencost_eks` integration module that installs OpenCost and a minimal Prometheus release on EKS with static Prometheus scrape annotations for Splunk OTel discovery.

Also adds the Splunk deployment Terragrunt example/template, registers the module in the Splunk deployment release map, and enables Prometheus autodiscovery in `splunk_otel_eks`.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: _________

## Testing

- `tofu fmt -check -recursive modules/integrations/splunk_opencost_eks modules/integrations/splunk_otel_eks`
- `terragrunt hcl fmt --check` for the touched Splunk Terragrunt files
- `terragrunt hcl validate` for `splunk_opencost_eks` and `splunk_otel_eks`
- Pre-commit hooks during commit, including YAML lint, Terragrunt fmt, Tofu fmt/validate, Terraform fmt/lint/validate, and Gitleaks
