### PR TITLE
chore(deps): update Renovate-managed dependencies

### DIFF
--- a/.docker/pre-commit/Dockerfile
+++ b/.docker/pre-commit/Dockerfile
@@ -78,7 +78,7 @@ RUN set -eux; \
     chmod 755 /usr/local/bin/terraform-docs
 
 # renovate: datasource=github-releases depName=gruntwork-io/terragrunt registryUrl=https://github.com/
-ARG TERRAGRUNT_VERSION="1.0.8"
+ARG TERRAGRUNT_VERSION="1.1.0"
 ARG TERRAGRUNT_SRC="https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64"
 ARG TERRAGRUNT_ARTIFACT="terragrunt"
 RUN set -eux; \

--- a/.docker/pre-commit/Dockerfile
+++ b/.docker/pre-commit/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS build
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS build
 
 WORKDIR /opt/build
 
@@ -104,7 +104,7 @@ RUN set -eux; \
     unzip -o ${TOFU_ARTIFACT} -d /usr/local/bin/; \
     chmod 755 /usr/local/bin/tofu
 
-FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 AS final
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS final
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/.github/workflows/iac-policy.yml
+++ b/.github/workflows/iac-policy.yml
@@ -100,6 +100,6 @@ jobs:
       - name: Upload Checkov SARIF
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -54,6 +54,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Description

Updates Renovate-managed dependencies used by CI and pre-commit tooling:

- Updates the `ubuntu:24.04` image digest used by `.docker/pre-commit/Dockerfile`.
- Updates `gruntwork-io/terragrunt` from `1.0.8` to `1.1.0` in the pre-commit Docker image.
- Updates `github/codeql-action/upload-sarif` from `v4.36.2` to `v4.36.3` in the IaC policy and OSSF Scorecard workflows.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: dependency maintenance

## Testing

Not run locally. Changes are Renovate dependency updates for the pre-commit image and GitHub workflow actions.
