### PR TITLE
feat: add OpenCost O11y dashboard

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/README.md
@@ -4,12 +4,12 @@ This module creates the shared Splunk Observability dashboard group, dashboards,
 
 ## Why This Module Exists
 
-Forge operators need dashboards that connect capacity, cost, and health signals to concrete subsystems. This module builds the metrics-side views for EC2 runners, Kubernetes runners, Lambda, SQS, DynamoDB, EBS, billing, and platform impact.
+Forge operators need dashboards that connect capacity, cost, and health signals to concrete subsystems. This module builds the metrics-side views for EC2 runners, Kubernetes runners, Lambda, SQS, DynamoDB, EBS, billing, OpenCost, and platform impact.
 
 ## What It Manages
 
 - A Forge dashboard group in Splunk Observability.
-- Dashboard modules for EC2, Kubernetes, Lambda, SQS, DynamoDB, EBS, billing, and Forge impact.
+- Dashboard modules for EC2, Kubernetes, Lambda, SQS, DynamoDB, EBS, billing, OpenCost, and Forge impact.
 - Kubernetes detector modules and notification wiring.
 - Dynamic variables that let dashboards filter by tenant and environment.
 
@@ -44,6 +44,7 @@ Forge operators need dashboards that connect capacity, cost, and health signals 
 | <a name="module_dashboard_ebs"></a> [dashboard\_ebs](#module\_dashboard\_ebs) | ./dashboards/ebs | n/a |
 | <a name="module_dashboard_forge_impact"></a> [dashboard\_forge\_impact](#module\_dashboard\_forge\_impact) | ./dashboards/forge_impact | n/a |
 | <a name="module_dashboard_lambda"></a> [dashboard\_lambda](#module\_dashboard\_lambda) | ./dashboards/lambda | n/a |
+| <a name="module_dashboard_opencost"></a> [dashboard\_opencost](#module\_dashboard\_opencost) | ./dashboards/opencost | n/a |
 | <a name="module_dashboard_runner_ec2"></a> [dashboard\_runner\_ec2](#module\_dashboard\_runner\_ec2) | ./dashboards/runner_ec2 | n/a |
 | <a name="module_dashboard_runner_k8s"></a> [dashboard\_runner\_k8s](#module\_dashboard\_runner\_k8s) | ./dashboards/runner_k8s | n/a |
 | <a name="module_dashboard_sqs"></a> [dashboard\_sqs](#module\_dashboard\_sqs) | ./dashboards/sqs | n/a |

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
@@ -96,6 +96,17 @@ module "dashboard_forge_impact" {
 }
 
 # Cost and usage
+module "dashboard_opencost" {
+  source = "./dashboards/opencost"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  tenant_names    = var.dashboard_variables.runner_k8s.tenant_names
+  dashboard_group = signalfx_dashboard_group.forgecicd.id
+}
+
 module "dashboard_billing" {
   source = "./dashboards/billing"
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/README.md
@@ -1,0 +1,62 @@
+# Splunk Observability OpenCost Dashboard
+
+This module creates the OpenCost tenant cost dashboard.
+
+## Why This Module Exists
+
+Forge operators need a Kubernetes-side cost view for ARC tenant namespaces. This dashboard turns OpenCost CPU and memory allocation metrics into tenant-level hourly cost and monthly run-rate views.
+
+## What It Manages
+
+- Tenant hourly compute allocation cost.
+- Tenant monthly compute run rate.
+- CPU and memory cost trends by tenant namespace.
+- Top pods by compute allocation cost.
+- Dashboard parent relationship in the shared O11y group.
+
+## Operational Notes
+
+- Tenant scope uses the OpenCost `namespace` metric label and the Forge K8S tenant namespace list.
+- This estimates Kubernetes compute allocation cost from OpenCost metrics; it is not an AWS invoice or CUR-backed bill.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.11 |
+| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | < 10.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | < 10.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [signalfx_dashboard.opencost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/dashboard) | resource |
+| [signalfx_list_chart.tenant_hourly_compute_cost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.tenant_monthly_compute_run_rate](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_pod_compute_cost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_time_chart.tenant_compute_cost_trend](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.tenant_cpu_cost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.tenant_memory_cost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_dashboard_group"></a> [dashboard\_group](#input\_dashboard\_group) | Dashboard group name for organizing dashboards. | `string` | n/a | yes |
+| <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | Tenant namespaces used to scope OpenCost allocation metrics. | `list(string)` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
@@ -1,0 +1,272 @@
+locals {
+  opencost_tenant_namespace_filter = length(var.tenant_names) > 0 ? join(" or ", [
+    for namespace in sort(var.tenant_names) : "filter('namespace', '${namespace}')"
+  ]) : "filter('namespace', '*')"
+}
+
+resource "signalfx_list_chart" "tenant_hourly_compute_cost" {
+  name        = "Tenant hourly compute cost"
+  description = "Estimates current OpenCost CPU and memory allocation cost by tenant namespace."
+
+  program_text = <<-EOF
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+cpu_cost = (cpu_allocation * cpu_price).sum(by=['namespace'])
+
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+memory_cost = (memory_allocation * memory_price).sum(by=['namespace'])
+
+A = (cpu_cost + memory_cost).publish(label='A')
+EOF
+
+  sort_by = "-value"
+
+  hide_missing_values     = true
+  max_precision           = 4
+  secondary_visualization = "Sparkline"
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "namespace"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "sf_metric"
+  }
+
+  viz_options {
+    display_name = "USD/hour"
+    label        = "A"
+  }
+}
+
+resource "signalfx_list_chart" "tenant_monthly_compute_run_rate" {
+  name        = "Tenant monthly compute run rate"
+  description = "Projects current OpenCost CPU and memory allocation cost to a 730-hour month by tenant namespace."
+
+  program_text = <<-EOF
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+cpu_cost = (cpu_allocation * cpu_price).sum(by=['namespace'])
+
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+memory_cost = (memory_allocation * memory_price).sum(by=['namespace'])
+
+A = (cpu_cost + memory_cost).scale(730).publish(label='A')
+EOF
+
+  sort_by = "-value"
+
+  hide_missing_values     = true
+  max_precision           = 2
+  secondary_visualization = "Sparkline"
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "namespace"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "sf_metric"
+  }
+
+  viz_options {
+    display_name = "USD/month"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "tenant_compute_cost_trend" {
+  name        = "Tenant compute cost trend"
+  description = "Tracks OpenCost CPU and memory allocation cost by tenant namespace over time."
+
+  program_text = <<-EOF
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+cpu_cost = (cpu_allocation * cpu_price).sum(by=['namespace'])
+
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+memory_cost = (memory_allocation * memory_price).sum(by=['namespace'])
+
+A = (cpu_cost + memory_cost).publish(label='A')
+EOF
+
+  plot_type                 = "AreaChart"
+  axes_precision            = 4
+  on_chart_legend_dimension = "namespace"
+  unit_prefix               = "Metric"
+
+  axis_left {
+    label = "USD/hour"
+  }
+
+  histogram_options {
+    color_theme = "gold"
+  }
+
+  viz_options {
+    display_name = "USD/hour"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "tenant_cpu_cost" {
+  name        = "Tenant CPU cost"
+  description = "Tracks OpenCost CPU allocation cost by tenant namespace."
+
+  program_text = <<-EOF
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+A = (cpu_allocation * cpu_price).sum(by=['namespace']).publish(label='A')
+EOF
+
+  plot_type                 = "AreaChart"
+  axes_precision            = 4
+  on_chart_legend_dimension = "namespace"
+  unit_prefix               = "Metric"
+
+  axis_left {
+    label = "USD/hour"
+  }
+
+  histogram_options {
+    color_theme = "gold"
+  }
+
+  viz_options {
+    display_name = "CPU USD/hour"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "tenant_memory_cost" {
+  name        = "Tenant memory cost"
+  description = "Tracks OpenCost memory allocation cost by tenant namespace."
+
+  program_text = <<-EOF
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+A = (memory_allocation * memory_price).sum(by=['namespace']).publish(label='A')
+EOF
+
+  plot_type                 = "AreaChart"
+  axes_precision            = 4
+  on_chart_legend_dimension = "namespace"
+  unit_prefix               = "Metric"
+
+  axis_left {
+    label = "USD/hour"
+  }
+
+  histogram_options {
+    color_theme = "gold"
+  }
+
+  viz_options {
+    display_name = "Memory USD/hour"
+    label        = "A"
+  }
+}
+
+resource "signalfx_list_chart" "top_pod_compute_cost" {
+  name        = "Top pod compute cost"
+  description = "Ranks pods by current OpenCost CPU and memory allocation cost."
+
+  program_text = <<-EOF
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*') and filter('pod', '*')).sum(by=['cluster_id', 'namespace', 'pod', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+cpu_cost = (cpu_allocation * cpu_price).sum(by=['namespace', 'pod'])
+
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*') and filter('pod', '*')).sum(by=['cluster_id', 'namespace', 'pod', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+memory_cost = (memory_allocation * memory_price).sum(by=['namespace', 'pod'])
+
+A = (cpu_cost + memory_cost).top(count=20).publish(label='A')
+EOF
+
+  sort_by = "-value"
+
+  hide_missing_values     = true
+  max_precision           = 4
+  secondary_visualization = "Sparkline"
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "namespace"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "pod"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "sf_metric"
+  }
+
+  viz_options {
+    display_name = "USD/hour"
+    label        = "A"
+  }
+}
+
+resource "signalfx_dashboard" "opencost" {
+  name            = "OpenCost Tenant Cost"
+  description     = "OpenCost Kubernetes CPU and memory allocation cost by tenant namespace."
+  dashboard_group = var.dashboard_group
+
+  time_range = "-24h"
+
+  chart {
+    chart_id = signalfx_list_chart.tenant_hourly_compute_cost.id
+    row      = 0
+    column   = 0
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.tenant_monthly_compute_run_rate.id
+    row      = 0
+    column   = 4
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_pod_compute_cost.id
+    row      = 0
+    column   = 8
+    width    = 4
+    height   = 2
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.tenant_compute_cost_trend.id
+    row      = 1
+    column   = 0
+    width    = 8
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.tenant_cpu_cost.id
+    row      = 2
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.tenant_memory_cost.id
+    row      = 2
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/variables.tf
@@ -1,0 +1,9 @@
+variable "dashboard_group" {
+  description = "Dashboard group name for organizing dashboards."
+  type        = string
+}
+
+variable "tenant_names" {
+  description = "Tenant namespaces used to scope OpenCost allocation metrics."
+  type        = list(string)
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  # Provider versions.
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "< 10.0.0"
+    }
+  }
+
+  # OpenTofu version.
+  required_version = "~> 1.11"
+}


### PR DESCRIPTION
## Description

Adds an OpenCost Tenant Cost dashboard to the shared Splunk Observability configuration.

The dashboard uses OpenCost allocation metrics grouped by the OpenCost `namespace` label, which matches the Forge K8S tenant namespace model used by the existing runner dashboards. It includes hourly tenant compute cost, monthly run-rate, CPU and memory cost trends, and top pod compute cost.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu fmt -check -recursive modules/integrations/splunk_o11y_conf_shared`
- `git diff --check --cached`
- Pre-commit hooks during commit, including Tofu validate and Terraform validate
