### PR TITLE
fix: enable OpenCost Prometheus source metrics

### DIFF
--- a/modules/integrations/splunk_opencost_eks/README.md
+++ b/modules/integrations/splunk_opencost_eks/README.md
@@ -1,6 +1,6 @@
 # Splunk OpenCost for EKS
 
-This module installs OpenCost and a minimal Prometheus release on an EKS cluster.
+This module installs OpenCost and an OpenCost-ready Prometheus release on an EKS cluster.
 
 OpenCost exposes Prometheus-format cost metrics on `/metrics`. The existing `splunk_otel_eks` module should scrape those metrics through the static pod and service annotations configured here.
 
@@ -14,9 +14,11 @@ OpenCost exposes Prometheus-format cost metrics on `/metrics`. The existing `spl
 
 - OpenCost namespace: `opencost`
 - OpenCost service account: `opencost`
-- OpenCost chart: `opencost/opencost` version `2.5.20`
+- OpenCost chart: `opencost/opencost` version `2.5.25`
 - Prometheus namespace: `prometheus-system`
 - Prometheus chart: `prometheus-community/prometheus` version `29.14.0`
+- Prometheus keeps kube-state-metrics and node-exporter enabled for OpenCost source metrics
+- Prometheus scrapes the OpenCost exporter with the upstream OpenCost scrape config
 - OpenCost metrics endpoint: `http://opencost.opencost.svc.cluster.local:9003/metrics`
 
 ## Example

--- a/modules/integrations/splunk_opencost_eks/main.tf
+++ b/modules/integrations/splunk_opencost_eks/main.tf
@@ -12,14 +12,6 @@ resource "helm_release" "managed_prometheus" {
       value = false
     },
     {
-      name  = "kube-state-metrics.enabled"
-      value = false
-    },
-    {
-      name  = "prometheus-node-exporter.enabled"
-      value = false
-    },
-    {
       name  = "prometheus-pushgateway.enabled"
       value = false
     },
@@ -30,6 +22,23 @@ resource "helm_release" "managed_prometheus" {
     {
       name  = "server.service.servicePort"
       value = 80
+    },
+    {
+      name  = "extraScrapeConfigs"
+      value = <<-EOT
+      - job_name: opencost
+        honor_labels: true
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        metrics_path: /metrics
+        scheme: http
+        dns_sd_configs:
+          - names:
+              - opencost.opencost
+            type: A
+            port: 9003
+      EOT
+      type  = "string"
     }
   ]
 


### PR DESCRIPTION
## Description

Fixes the OpenCost EKS install so OpenCost has the Prometheus source metrics it needs before Splunk OTel scrapes its exported cost metrics.

- keeps kube-state-metrics and node-exporter enabled in the managed Prometheus release
- adds the upstream OpenCost Prometheus scrape config for the OpenCost exporter
- updates the module README defaults to match the current chart version and Prometheus behavior

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `git diff --check`
- Commit hook run passed generic checks, Terragrunt fmt, Tofu fmt, Tofu validate, Terraform fmt, Terraform validate, gitleaks, Ansible lint, and Packer validate after using `/opt/homebrew/bin/gpg` for signing.
- `terraform_tflint` could not run locally because `tflint` is not installed in this shell.
