### PR TITLE
fix(ci): remediate zizmor alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - github-actions
@@ -13,6 +15,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - python
@@ -21,6 +25,8 @@ updates:
     directory: /modules
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - terraform
@@ -29,6 +35,8 @@ updates:
     directory: /examples/deployments
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - terraform
@@ -37,6 +45,8 @@ updates:
     directory: /.docker
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - docker

--- a/.github/workflows/build-forge-github-app-register.yml
+++ b/.github/workflows/build-forge-github-app-register.yml
@@ -24,6 +24,12 @@ on:
       - .docker/forge-github-app-register/**
       - .github/workflows/build-forge-github-app-register.yml
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   PLATFORMS: linux/amd64
   REGISTRY: ghcr.io
@@ -34,12 +40,14 @@ jobs:
     name: Build and push Docker image
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: read # Required to checkout the repository.
+      packages: write # Required to publish container images to GHCR.
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/build-pre-commit.yml
+++ b/.github/workflows/build-pre-commit.yml
@@ -24,6 +24,12 @@ on:
       - .docker/pre-commit/**
       - .github/workflows/build-pre-commit.yml
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   PLATFORMS: linux/amd64
   REGISTRY: ghcr.io
@@ -34,12 +40,14 @@ jobs:
     name: Build and push Docker image
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: read # Required to checkout the repository.
+      packages: write # Required to publish container images to GHCR.
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,19 +17,26 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: read # Required to checkout and lint the repository.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run-pre-commit:
+    name: Run pre-commit
     runs-on: ubuntu-latest
     timeout-minutes: 60
     container:
-      image: ghcr.io/${{ github.repository }}-pre-commit:main
+      image: ghcr.io/cisco-open/forge-pre-commit:main@sha256:5b67305d0ca440bb13f20525667ee62111d5d5a8d6665920f4bb4e0207e32b81
 
     if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Cache Pre-commit
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
## Description

Remediates the open zizmor findings on `main` by adding Dependabot cooldowns, tightening workflow token defaults, documenting required package publishing permissions, disabling checkout credential persistence, adding workflow concurrency, naming the pre-commit job, and pinning the pre-commit container image to the current GHCR digest.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: CI security hardening

## Testing

- `zizmor --persona pedantic --format json --no-progress --cache-dir /private/tmp/zizmor-cache .` returned `[]`
- `pre-commit run yamlfmt --files .github/dependabot.yml .github/workflows/build-forge-github-app-register.yml .github/workflows/build-pre-commit.yml .github/workflows/pre-commit.yml`
- `pre-commit run check-yaml --files .github/dependabot.yml .github/workflows/build-forge-github-app-register.yml .github/workflows/build-pre-commit.yml .github/workflows/pre-commit.yml`
- `pre-commit run yamllint --files .github/dependabot.yml .github/workflows/build-forge-github-app-register.yml .github/workflows/build-pre-commit.yml .github/workflows/pre-commit.yml`
- `pre-commit run check-github-workflows --files .github/workflows/build-forge-github-app-register.yml .github/workflows/build-pre-commit.yml .github/workflows/pre-commit.yml`
- `pre-commit run check-dependabot --files .github/dependabot.yml`
- Commit hook suite passed
