### PR TITLE
chore(checkov): document log retention exception

### DIFF
--- a/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/lambda.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay/lambda.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "webex" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/lambda/webex-webhook-relay-destination-receiver"
   retention_in_days = var.logging_retention_in_days
   tags_all          = local.all_security_tags

--- a/modules/integrations/splunk_aws_billing/billing_per_resource.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource.tf
@@ -64,6 +64,7 @@ resource "aws_lambda_permission" "cur_per_resource" {
 }
 
 resource "aws_cloudwatch_log_group" "cur_per_resource" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/lambda/${local.cur_per_resource_lambda_name}"
   retention_in_days = var.logging_retention_in_days
   tags              = local.all_security_tags

--- a/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
@@ -64,6 +64,7 @@ resource "aws_lambda_permission" "cur_per_resource_process" {
 }
 
 resource "aws_cloudwatch_log_group" "cur_per_resource_process" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/lambda/${local.cur_per_resource_process_lambda_name}"
   retention_in_days = var.logging_retention_in_days
   tags              = local.all_security_tags

--- a/modules/integrations/splunk_aws_billing/billing_per_service.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_service.tf
@@ -65,6 +65,7 @@ resource "aws_lambda_permission" "cur_per_service" {
 }
 
 resource "aws_cloudwatch_log_group" "cur_per_service" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/lambda/${local.cur_per_service_lambda_name}"
   retention_in_days = var.logging_retention_in_days
   tags              = local.all_security_tags

--- a/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/main.tf
+++ b/modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags/main.tf
@@ -46,6 +46,7 @@ data "aws_iam_policy_document" "splunk_dm_metadata_ec2inst_pattern_tags_lambda" 
 }
 
 resource "aws_cloudwatch_log_group" "splunk_dm_metadata_ec2inst_pattern_tags_lambda" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally short for this Splunk-forwarding helper; durable retention belongs in external log backends.
   name              = "/aws/lambda/SplunkDMMetadataEC2InstPatternTags"
   retention_in_days = 3
   tags              = var.tags

--- a/modules/integrations/splunk_cloud_s3_runner_logs/firehose.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/firehose.tf
@@ -112,6 +112,7 @@ resource "aws_kinesis_firehose_delivery_stream" "splunk_firehose" {
 
 # CloudWatch Log Group for Firehose delivery diagnostics
 resource "aws_cloudwatch_log_group" "firehose_splunk" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/kinesisfirehose/${local.prefix_firehose}-${var.aws_region}"
   retention_in_days = var.logging_retention_in_days
   kms_key_id        = aws_kms_key.splunk_s3_runner_logs.arn

--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
@@ -92,6 +92,7 @@ data "aws_iam_policy_document" "splunk_s3_runner_logs_lambda" {
 }
 
 resource "aws_cloudwatch_log_group" "splunk_s3_runner_logs_lambda" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/lambda/${local.prefix_lambda}-lambda-${var.aws_region}"
   retention_in_days = var.logging_retention_in_days
   tags              = var.tags

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/api.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/api.tf
@@ -53,6 +53,7 @@ resource "aws_apigatewayv2_stage" "default" {
 }
 
 resource "aws_cloudwatch_log_group" "api" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/apigateway/${var.name_prefix}"
   retention_in_days = var.logging_retention_in_days
   tags              = local.all_security_tags

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "dispatcher" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/lambda/${var.name_prefix}"
   retention_in_days = var.logging_retention_in_days
   tags              = local.all_security_tags
@@ -63,6 +64,7 @@ data "aws_iam_policy_document" "dispatcher" {
 }
 
 resource "aws_cloudwatch_log_group" "worker" {
+  #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/lambda/${var.name_prefix}-worker"
   retention_in_days = var.logging_retention_in_days
   tags              = local.all_security_tags


### PR DESCRIPTION
## Description

Adds scoped Checkov suppressions for `CKV_AWS_338` on CloudWatch log groups where retention is intentionally controlled by operators or by external log-retention systems. These modules may keep short CloudWatch retention windows when forwarding logs to Splunk, Loki, or another durable log backend.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Checkov exception documentation

## Testing

- `checkov --directory modules --framework terraform --skip-path '.*/\.terraform/.*' --check CKV_AWS_338 --compact` reports `Failed checks: 0` and `Skipped checks: 10`
- `terraform fmt -check modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay modules/integrations/splunk_aws_billing modules/integrations/splunk_cloud_data_manager/sec_meta_ec2_tags modules/integrations/splunk_cloud_s3_runner_logs modules/integrations/splunk_stuck_workflow_job_dispatcher`
- `git diff --check`
- Commit hook suite passed

Note: the targeted Checkov run still reports the existing parse error in `modules/infra/eks/karpenter.tf`, which is unrelated to this change.
