### PR TITLE
chore(checkov): document CloudFormation exception

### DIFF
--- a/modules/integrations/splunk_cloud_data_manager/cloudwatch.tf
+++ b/modules/integrations/splunk_cloud_data_manager/cloudwatch.tf
@@ -58,7 +58,7 @@ module "splunk_cloudwatch" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_cloudwatch_iam_region" {
-  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation template is provided by a trusted entity; SNS notifications are not required for this module.
   count = var.cloudwatch_log_groups_config.enabled ? 1 : 0
   name  = module.splunk_cloudwatch[0].splunk_integration_name
 
@@ -78,7 +78,7 @@ resource "aws_cloudformation_stack" "cf_splunk_cloudwatch_iam_region" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_cloudwatch_region" {
-  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation template is provided by a trusted entity; SNS notifications are not required for this module.
   for_each = var.cloudwatch_log_groups_config.enabled ? toset(setsubtract(var.cloudwatch_log_groups_config.regions, [var.aws_region])) : []
   provider = aws.by_region[each.value]
   name     = module.splunk_cloudwatch[0].splunk_integration_name

--- a/modules/integrations/splunk_cloud_data_manager/custom_cloudwatch.tf
+++ b/modules/integrations/splunk_cloud_data_manager/custom_cloudwatch.tf
@@ -69,7 +69,7 @@ module "splunk_custom_cloudwatch" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_custom_cloudwatch_iam_region" {
-  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation template is provided by a trusted entity; SNS notifications are not required for this module.
   count = var.custom_cloudwatch_log_groups_config.enabled ? 1 : 0
   name  = module.splunk_custom_cloudwatch[0].splunk_integration_name
 
@@ -89,7 +89,7 @@ resource "aws_cloudformation_stack" "cf_splunk_custom_cloudwatch_iam_region" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_custom_cloudwatch_region" {
-  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation template is provided by a trusted entity; SNS notifications are not required for this module.
   for_each = var.custom_cloudwatch_log_groups_config.enabled ? toset(setsubtract(local.custom_log_group_regions, [var.aws_region])) : []
   provider = aws.by_region[each.key]
   name     = module.splunk_custom_cloudwatch[0].splunk_integration_name

--- a/modules/integrations/splunk_cloud_data_manager/sec_meta.tf
+++ b/modules/integrations/splunk_cloud_data_manager/sec_meta.tf
@@ -64,7 +64,7 @@ module "splunk_security_metadata" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_security_metadata_iam_region" {
-  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation template is provided by a trusted entity; SNS notifications are not required for this module.
   count = var.security_metadata_config.enabled ? 1 : 0
   name  = module.splunk_security_metadata[0].splunk_integration_name
 
@@ -84,7 +84,7 @@ resource "aws_cloudformation_stack" "cf_splunk_security_metadata_iam_region" {
 }
 
 resource "aws_cloudformation_stack" "cf_splunk_security_metadata_region" {
-  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation template is provided by a trusted entity; SNS notifications are not required for this module.
   for_each = var.security_metadata_config.enabled ? toset(setsubtract(var.security_metadata_config.regions, [var.aws_region])) : []
   provider = aws.by_region[each.value]
   name     = module.splunk_security_metadata[0].splunk_integration_name

--- a/modules/integrations/splunk_o11y_aws_integration/cf.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/cf.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudformation_stack" "splunk_integration" {
-  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation integration stack does not require SNS notifications in this module.
+  #checkov:skip=CKV_AWS_124:Splunk-managed CloudFormation template is provided by a trusted entity; SNS notifications are not required for this module.
   name = "splunk-integration"
 
   parameters = {


### PR DESCRIPTION
## Description

Updates the scoped `CKV_AWS_124` Checkov suppressions on Splunk-managed CloudFormation stacks to document the accepted risk: the CloudFormation templates are provided by a trusted entity, so SNS event notifications are not required in these modules.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Checkov exception documentation

## Testing

- `checkov --directory modules --framework terraform --skip-path '.*/\.terraform/.*' --check CKV_AWS_124 --compact` reports `Failed checks: 0` and `Skipped checks: 7`
- `terraform fmt -check modules/integrations/splunk_cloud_data_manager modules/integrations/splunk_o11y_aws_integration`
- `git diff --check`
- Commit hook suite passed

Note: the targeted Checkov run still reports the existing parse error in `modules/infra/eks/karpenter.tf`, which is unrelated to this change.
