### PR TITLE
chore(checkov): document S3 replication exception

### DIFF
--- a/modules/infra/storage/main.tf
+++ b/modules/infra/storage/main.tf
@@ -2,7 +2,7 @@
 # Long-term storage (i.e. release builds and SBOMs we need to retain long-term
 # for stability and auditing purposes).
 resource "aws_s3_bucket" "s3_long_term" {
-  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
+  #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
   bucket = "${data.aws_caller_identity.current.account_id}-long-term-storage"
   tags   = local.all_security_tags
 }
@@ -48,7 +48,7 @@ resource "aws_s3_bucket_public_access_block" "s3_long_term" {
 # Short-term storage (i.e. temporary/feature-branch builds, core dumps, and
 # other artifacts we aren't obligated to retain long-term).
 resource "aws_s3_bucket" "s3_short_term" {
-  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
+  #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
   bucket = "${data.aws_caller_identity.current.account_id}-short-term-storage"
   tags   = local.all_security_tags
 }

--- a/modules/integrations/splunk_aws_billing/s3.tf
+++ b/modules/integrations/splunk_aws_billing/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "aws_billing_report" {
-  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
+  #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
   bucket = "${data.aws_caller_identity.current.account_id}-aws-billing-report"
   tags   = local.all_security_tags
 }

--- a/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "firehose_backup" {
-  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
+  #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
   bucket = "splunk-s3-runner-logs-failed-${data.aws_caller_identity.current.account_id}-${var.aws_region}"
   tags   = var.tags
 }

--- a/modules/platform/forge_runners/github_actions_job_logs/s3.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "gh_logs" {
-  #checkov:skip=CKV_AWS_144:Cross-region replication is an accepted policy exception for this Forge storage bucket.
+  #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
   bucket = "${var.prefix}-forge-gh-logs-${data.aws_caller_identity.current.account_id}"
   tags   = var.tags
 }


### PR DESCRIPTION
## Description

Updates the scoped `CKV_AWS_144` Checkov suppressions on Forge S3 buckets to document the accepted risk: cross-region replication is intentionally omitted because it is not needed for these bucket use cases.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Checkov exception documentation

## Testing

- `checkov==3.2.334 --directory modules --framework terraform --skip-path '.*/\.terraform/.*' --check CKV_AWS_144 --compact` reports `Failed checks: 0` and `Skipped checks: 5`
- `terraform fmt -check modules/integrations/splunk_aws_billing modules/integrations/splunk_cloud_s3_runner_logs modules/platform/forge_runners/github_actions_job_logs modules/infra/storage`
- `git diff --check`
- Commit hook suite passed

Note: the targeted Checkov run still reports the existing parse error in `modules/infra/eks/karpenter.tf`, which is unrelated to this change.
