### PR TITLE
chore(deps): group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - '*'
     labels:
       - dependencies
       - github-actions
@@ -17,6 +21,10 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    groups:
+      python-dependencies:
+        patterns:
+          - '*'
     labels:
       - dependencies
       - python
@@ -27,6 +35,10 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    groups:
+      terraform-modules-dependencies:
+        patterns:
+          - '*'
     labels:
       - dependencies
       - terraform
@@ -37,6 +49,10 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    groups:
+      terraform-examples-dependencies:
+        patterns:
+          - '*'
     labels:
       - dependencies
       - terraform
@@ -47,6 +63,10 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
+    groups:
+      docker-dependencies:
+        patterns:
+          - '*'
     labels:
       - dependencies
       - docker


### PR DESCRIPTION
## Description

Groups Dependabot version update pull requests by configured ecosystem/directory. Each update block now has a catch-all group so GitHub Actions, Python, Terraform modules, Terraform examples, and Docker updates are raised as grouped dependency PRs instead of one PR per dependency.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Dependency automation

## Testing

- `pre-commit run yamlfmt --files .github/dependabot.yml`
- `pre-commit run check-yaml --files .github/dependabot.yml`
- `pre-commit run check-dependabot --files .github/dependabot.yml`
- `pre-commit run yamllint --files .github/dependabot.yml`
- `git diff --check`
- Commit hook suite passed
