### PR TITLE
chore(checkov): document Packer build exception

### DIFF
--- a/modules/infra/forge_subscription/policies.tf
+++ b/modules/infra/forge_subscription/policies.tf
@@ -39,6 +39,7 @@ data "aws_iam_policy_document" "secrets_access_for_forge_runners" {
 # Permissions needed for Packer builds. See:
 # <https://developer.hashicorp.com/packer/plugins/builders/amazon>.
 data "aws_iam_policy_document" "packer_support_for_forge_runners" {
+  #checkov:skip=CKV_AWS_110:Tenant Packer builds intentionally use Forge-hosted runners to build AMIs in tenant accounts; runner workloads do not use this path directly.
   statement {
     effect = "Allow"
     actions = [


### PR DESCRIPTION
## Description

Adds a scoped Checkov `CKV_AWS_110` suppression for `aws_iam_policy_document.packer_support_for_forge_runners`.

The broad IAM permission path is intentional for tenant Packer builds: tenants can build AMIs in their own AWS accounts using Forge-hosted runners, and normal runner workloads do not use this path directly.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: ____________

## Testing

- `git diff --check`
- `tofu fmt -check modules/infra/forge_subscription/policies.tf`
- `env PIPX_HOME=/private/tmp/checkov-pipx PIPX_BIN_DIR=/private/tmp/checkov-pipx-bin PIPX_LOG_DIR=/private/tmp/checkov-pipx-logs PIP_CACHE_DIR=/private/tmp/checkov-pip-cache pipx run --spec checkov==3.2.334 checkov --file modules/infra/forge_subscription/policies.tf --framework terraform --check CKV_AWS_110 --compact`
- `git commit` hooks
