### PR TITLE
chore(checkov): document S3 access logging exception

### DIFF
--- a/modules/infra/storage/main.tf
+++ b/modules/infra/storage/main.tf
@@ -3,6 +3,7 @@
 # for stability and auditing purposes).
 resource "aws_s3_bucket" "s3_long_term" {
   #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
+  #checkov:skip=CKV_AWS_18:S3 server access logging is an accepted policy exception for this Forge storage bucket; audit needs are handled outside S3 access logs.
   bucket = "${data.aws_caller_identity.current.account_id}-long-term-storage"
   tags   = local.all_security_tags
 }
@@ -49,6 +50,7 @@ resource "aws_s3_bucket_public_access_block" "s3_long_term" {
 # other artifacts we aren't obligated to retain long-term).
 resource "aws_s3_bucket" "s3_short_term" {
   #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
+  #checkov:skip=CKV_AWS_18:S3 server access logging is an accepted policy exception for this Forge storage bucket; audit needs are handled outside S3 access logs.
   bucket = "${data.aws_caller_identity.current.account_id}-short-term-storage"
   tags   = local.all_security_tags
 }

--- a/modules/integrations/splunk_aws_billing/s3.tf
+++ b/modules/integrations/splunk_aws_billing/s3.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "aws_billing_report" {
   #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
+  #checkov:skip=CKV_AWS_18:S3 server access logging is an accepted policy exception for this Forge storage bucket; audit needs are handled outside S3 access logs.
   bucket = "${data.aws_caller_identity.current.account_id}-aws-billing-report"
   tags   = local.all_security_tags
 }

--- a/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "firehose_backup" {
   #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
+  #checkov:skip=CKV_AWS_18:S3 server access logging is an accepted policy exception for this Forge storage bucket; audit needs are handled outside S3 access logs.
   bucket = "splunk-s3-runner-logs-failed-${data.aws_caller_identity.current.account_id}-${var.aws_region}"
   tags   = var.tags
 }

--- a/modules/platform/forge_runners/github_actions_job_logs/s3.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/s3.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "gh_logs" {
   #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
+  #checkov:skip=CKV_AWS_18:S3 server access logging is an accepted policy exception for this Forge storage bucket; audit needs are handled outside S3 access logs.
   bucket = "${var.prefix}-forge-gh-logs-${data.aws_caller_identity.current.account_id}"
   tags   = var.tags
 }


### PR DESCRIPTION
## Description

Adds scoped Checkov `CKV_AWS_18` suppressions for Forge-managed S3 buckets where S3 server access logging is an accepted policy exception.

Covered buckets:

- `aws_s3_bucket.s3_long_term`
- `aws_s3_bucket.s3_short_term`
- `aws_s3_bucket.aws_billing_report`
- `aws_s3_bucket.firehose_backup`
- `aws_s3_bucket.gh_logs`

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: ____________

## Testing

- `git diff --check`
- `tofu fmt -check modules/infra/storage/main.tf modules/integrations/splunk_aws_billing/s3.tf modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf modules/platform/forge_runners/github_actions_job_logs/s3.tf`
- `env PIPX_HOME=/private/tmp/checkov-pipx PIPX_BIN_DIR=/private/tmp/checkov-pipx-bin PIPX_LOG_DIR=/private/tmp/checkov-pipx-logs PIP_CACHE_DIR=/private/tmp/checkov-pip-cache pipx run --spec checkov==3.2.334 checkov --directory modules --framework terraform --skip-path '.*/\\.terraform/.*' --check CKV_AWS_18 --compact`
- `git commit` hooks
