### PR TITLE
chore(checkov): document accepted policy exceptions

### DIFF
--- a/modules/infra/ami_policy/global_policy.tf
+++ b/modules/infra/ami_policy/global_policy.tf
@@ -1,6 +1,7 @@
 # Always encrypt new EBS volumes (e.g. AMI images) by default. Packer is not
 # able to override/disable this setting.
 resource "aws_ebs_encryption_by_default" "gpol_encrypt_ebs" {
+  #checkov:skip=CKV_AWS_106:AMI build helper leaves account EBS default encryption disabled until tenant accounts provide their own KMS key strategy.
   # We'll re-enable this when we have a custom KMS key prepared.
   enabled = false
 }

--- a/modules/infra/ami_policy/policies.tf
+++ b/modules/infra/ami_policy/policies.tf
@@ -25,6 +25,8 @@ EOF
 
 # For defining the permissions needed for this lifecycle to take effect.
 resource "aws_iam_role_policy" "dlm_lifecycle" {
+  #checkov:skip=CKV_AWS_290:AMI lifecycle cleanup is an ops helper for managing platform build artifacts and intentionally discovers snapshots account-wide.
+  #checkov:skip=CKV_AWS_355:AMI lifecycle cleanup is an ops helper for managing platform build artifacts and intentionally discovers snapshots account-wide.
   name = "dlm-lifecycle-policy"
   role = aws_iam_role.dlm_lifecycle_role.id
 

--- a/modules/infra/ami_sharing/main.tf
+++ b/modules/infra/ami_sharing/main.tf
@@ -29,6 +29,7 @@ locals {
 }
 
 resource "aws_ami_launch_permission" "share_amis" {
+  #checkov:skip=CKV_AWS_205:AMI sharing is an ops helper for managing platform build artifacts and is limited to explicit account IDs from var.account_ids.
   for_each = { for pair in local.ami_account_pairs : "${pair.ami_id}-${pair.account}" => pair }
 
   image_id   = each.value.ami_id

--- a/modules/infra/cloud_custodian/main.tf
+++ b/modules/infra/cloud_custodian/main.tf
@@ -1,4 +1,6 @@
 data "aws_iam_policy_document" "cloud_custodian_policy" {
+  #checkov:skip=CKV_AWS_111:Cloud Custodian is an ops cleanup helper and intentionally account-wide so it can remove stale runner resources across supported services.
+  #checkov:skip=CKV_AWS_356:Cloud Custodian is an ops cleanup helper and intentionally account-wide so it can remove stale runner resources across supported services.
   version = "2012-10-17"
 
   statement {

--- a/modules/infra/ecr/main.tf
+++ b/modules/infra/ecr/main.tf
@@ -1,5 +1,8 @@
 # Create the actual ECR registries (one per image type).
 resource "aws_ecr_repository" "ops_container_repository" {
+  #checkov:skip=CKV_AWS_51:Ops helper repositories are parameterized by repository config; immutable tags can be enabled where required.
+  #checkov:skip=CKV_AWS_136:Ops helper repositories use default ECR encryption; customer KMS keys are not required for these operational artifacts.
+  #checkov:skip=CKV_AWS_163:Ops helper repositories are parameterized by repository config; scan-on-push can be enabled where required.
   for_each = {
     for key, val in var.repositories : val.repo => val
   }

--- a/modules/infra/forge_subscription/policies.tf
+++ b/modules/infra/forge_subscription/policies.tf
@@ -1,6 +1,10 @@
 # Helper policy for Forge runners that assume this role in tenant accounts.
 # Allows runner jobs to operate on tenant ops S3 buckets, not Forge-account buckets.
 data "aws_iam_policy_document" "s3_access_for_forge_runners" {
+  #checkov:skip=CKV_AWS_108:Forge subscription is an ops helper; tenant ops buckets are created outside this module and runners assume this tenant role to operate on them.
+  #checkov:skip=CKV_AWS_109:Forge subscription is an ops helper; tenant ops buckets are created outside this module and runners assume this tenant role to operate on them.
+  #checkov:skip=CKV_AWS_111:Forge subscription is an ops helper; tenant ops buckets are created outside this module and runners assume this tenant role to operate on them.
+  #checkov:skip=CKV_AWS_356:Forge subscription is an ops helper; tenant ops buckets are created outside this module and runners assume this tenant role to operate on them.
   statement {
     effect = "Allow"
     actions = [
@@ -24,6 +28,8 @@ data "aws_iam_policy_document" "s3_access_for_forge_runners" {
 # Helper policy for Forge runners that assume this role in tenant accounts.
 # Allows runner jobs to read tenant Secrets Manager values needed for operations.
 data "aws_iam_policy_document" "secrets_access_for_forge_runners" {
+  #checkov:skip=CKV_AWS_108:Forge subscription is an ops helper; tenant secrets are operator-defined and runners assume this tenant role to discover required values.
+  #checkov:skip=CKV_AWS_356:Forge subscription is an ops helper; tenant secrets are operator-defined and runners assume this tenant role to discover required values.
   statement {
     actions = [
       "secretsmanager:ListSecrets",
@@ -40,7 +46,11 @@ data "aws_iam_policy_document" "secrets_access_for_forge_runners" {
 # Packer builds and build AMIs in tenant accounts, not the Forge account. See:
 # <https://developer.hashicorp.com/packer/plugins/builders/amazon>.
 data "aws_iam_policy_document" "packer_support_for_forge_runners" {
+  #checkov:skip=CKV_AWS_107:Forge subscription is an ops helper; tenant Packer builds need broad EC2/ECR/IAM permissions from Forge-hosted runners in tenant accounts.
+  #checkov:skip=CKV_AWS_109:Forge subscription is an ops helper; tenant Packer builds need broad EC2/ECR/IAM permissions from Forge-hosted runners in tenant accounts.
   #checkov:skip=CKV_AWS_110:Tenant Packer builds intentionally use Forge-hosted runners to build AMIs in tenant accounts; runner workloads do not use this path directly.
+  #checkov:skip=CKV_AWS_111:Forge subscription is an ops helper; tenant Packer builds need broad EC2/ECR/IAM permissions from Forge-hosted runners in tenant accounts.
+  #checkov:skip=CKV_AWS_356:Forge subscription is an ops helper; tenant Packer builds need broad EC2/ECR/IAM permissions from Forge-hosted runners in tenant accounts.
   statement {
     effect = "Allow"
     actions = [

--- a/modules/infra/storage/main.tf
+++ b/modules/infra/storage/main.tf
@@ -4,6 +4,7 @@
 resource "aws_s3_bucket" "s3_long_term" {
   #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
   #checkov:skip=CKV_AWS_18:S3 server access logging is an accepted policy exception for this Forge storage bucket; audit needs are handled outside S3 access logs.
+  #checkov:skip=CKV2_AWS_62:Ops storage bucket has no event-driven consumer; S3 event notifications are intentionally not configured for this use case.
   bucket = "${data.aws_caller_identity.current.account_id}-long-term-storage"
   tags   = local.all_security_tags
 }
@@ -51,6 +52,7 @@ resource "aws_s3_bucket_public_access_block" "s3_long_term" {
 resource "aws_s3_bucket" "s3_short_term" {
   #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
   #checkov:skip=CKV_AWS_18:S3 server access logging is an accepted policy exception for this Forge storage bucket; audit needs are handled outside S3 access logs.
+  #checkov:skip=CKV2_AWS_62:Ops storage bucket has no event-driven consumer; S3 event notifications are intentionally not configured for this use case.
   bucket = "${data.aws_caller_identity.current.account_id}-short-term-storage"
   tags   = local.all_security_tags
 }

--- a/modules/integrations/splunk_cloud_data_manager_common/role.tf
+++ b/modules/integrations/splunk_cloud_data_manager_common/role.tf
@@ -1,4 +1,5 @@
 data "aws_iam_policy_document" "splunk_dm_policy" {
+  #checkov:skip=CKV_AWS_356:Splunk Cloud Data Manager requires account-wide read and list discovery across supported AWS services.
   statement {
     effect = "Allow"
     actions = [

--- a/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
@@ -1,6 +1,7 @@
 resource "aws_s3_bucket" "firehose_backup" {
   #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
   #checkov:skip=CKV_AWS_18:S3 server access logging is an accepted policy exception for this Forge storage bucket; audit needs are handled outside S3 access logs.
+  #checkov:skip=CKV2_AWS_62:Backup bucket is only a failed-delivery target and has no event-driven consumer.
   bucket = "splunk-s3-runner-logs-failed-${data.aws_caller_identity.current.account_id}-${var.aws_region}"
   tags   = var.tags
 }

--- a/modules/integrations/splunk_o11y_aws_integration_common/role.tf
+++ b/modules/integrations/splunk_o11y_aws_integration_common/role.tf
@@ -1,4 +1,6 @@
 data "aws_iam_policy_document" "splunk_integration" {
+  #checkov:skip=CKV_AWS_111:Splunk Observability integration follows the vendor-required account inventory and metric-stream permission model.
+  #checkov:skip=CKV_AWS_356:Splunk Observability integration follows the vendor-required account inventory and metric-stream permission model.
   statement {
     effect = "Allow"
     actions = [
@@ -102,6 +104,8 @@ data "aws_iam_policy_document" "splunk_integration" {
 }
 
 data "aws_iam_policy_document" "splunk_managed_policy" {
+  #checkov:skip=CKV_AWS_111:Splunk Observability integration follows the vendor-required account inventory and metric-stream permission model.
+  #checkov:skip=CKV_AWS_356:Splunk Observability integration follows the vendor-required account inventory and metric-stream permission model.
   statement {
     effect = "Allow"
     actions = [

--- a/modules/integrations/teleport/role.tf
+++ b/modules/integrations/teleport/role.tf
@@ -1,4 +1,5 @@
 data "aws_iam_policy_document" "eks_policy" {
+  #checkov:skip=CKV_AWS_356:Teleport needs account-wide EKS cluster discovery; eks:ListClusters cannot be scoped to a single cluster ARN.
   statement {
     sid    = "EKSListPolicy"
     effect = "Allow"

--- a/modules/platform/forge_runners/github_actions_job_logs/s3.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/s3.tf
@@ -1,6 +1,7 @@
 resource "aws_s3_bucket" "gh_logs" {
   #checkov:skip=CKV_AWS_144:Cross-region replication is intentionally omitted because it is not needed for this bucket's use case.
   #checkov:skip=CKV_AWS_18:S3 server access logging is an accepted policy exception for this Forge storage bucket; audit needs are handled outside S3 access logs.
+  #checkov:skip=CKV2_AWS_62:Job log bucket is written and read by the logging workflow; no S3 event notification consumer is required.
   bucket = "${var.prefix}-forge-gh-logs-${data.aws_caller_identity.current.account_id}"
   tags   = var.tags
 }


### PR DESCRIPTION
## Description

Documents accepted-risk Checkov exceptions with scoped `#checkov:skip` comments for operational helper modules. These modules help operations manage the platform, for example sharing and building AMIs, cleaning stale AMI or runner resources, creating ops S3 buckets, enabling opt-in regions, enabling service-linked roles, and creating ops ECR repositories. They are not the strict platform runtime boundary.

This covers the Forge tenant helper role, AMI lifecycle policy, AMI sharing, ops ECR repositories, vendor integration roles for Splunk and Teleport, Cloud Custodian cleanup, `CKV2_AWS_62` S3 notification findings, and `CKV_AWS_205` AMI launch permissions. `CKV_AWS_18` S3 access logging remains covered by PR #404.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [x] Other: Security scan exception documentation

## Testing

- `git diff --check`
- `tofu fmt -check modules/infra/ami_policy/global_policy.tf modules/infra/ami_policy/policies.tf modules/infra/ecr/main.tf modules/infra/ami_sharing/main.tf modules/infra/cloud_custodian/main.tf modules/infra/forge_subscription/policies.tf modules/infra/storage/main.tf`
- Targeted Checkov 3.2.334 scans for `CKV_AWS_51`, `CKV_AWS_106`, `CKV_AWS_107`, `CKV_AWS_108`, `CKV_AWS_109`, `CKV_AWS_110`, `CKV_AWS_111`, `CKV_AWS_136`, `CKV_AWS_163`, `CKV_AWS_205`, `CKV_AWS_290`, `CKV_AWS_355`, `CKV_AWS_356`, and `CKV2_AWS_62`
- Pre-commit hooks run by `git commit`
