### PR TITLE
feat(runner-logs): enrich splunk fields from metadata sidecar

### DIFF
--- a/modules/integrations/splunk_cloud_s3_runner_logs/README.md
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/README.md
@@ -18,6 +18,7 @@ Forge archives job logs and operational logs because runners are destroyed after
 - Splunk HEC endpoint and secret configuration must be correct before enabling delivery.
 - Use the backup bucket and DLQ when logs are missing from Splunk.
 - The S3 event path should match the job-log archiver bucket layout.
+- When a `.log` or `.json` object has a `metadata_key` S3 tag, the Lambda reads that sidecar object and merges its flattened GitHub workflow job fields with the S3 object tags before sending events to Splunk.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs.py
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs.py
@@ -4,9 +4,10 @@ import os
 import re
 import time
 from datetime import datetime, timezone
-from typing import Iterable
+from typing import Any, Iterable
 
 import boto3
+from botocore.exceptions import ClientError
 
 LOG = logging.getLogger()
 level_str = os.environ.get('LOG_LEVEL', 'INFO').upper()
@@ -29,6 +30,8 @@ MAX_BATCH_BYTES = min(MAX_BATCH_BYTES, 4500000)
 ACCOUNT_ID = sts_client.get_caller_identity()['Account']
 
 TIMESTAMP_RE = re.compile(r'^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)')
+METADATA_SUFFIX = '.fields'
+METADATA_TAG_KEY = 'metadata_key'
 
 
 def lambda_handler(event, _context):
@@ -81,6 +84,8 @@ def lambda_handler(event, _context):
                 LOG.warning(
                     'tag_fetch_failed bucket=%s key=%s err=%s', bucket, key, tag_err)
 
+            metadata_fields = load_metadata_fields(bucket, key, tags)
+
             # Decide ingestion strategy based on file type.
             if key.endswith('.json'):
                 # Treat entire JSON file as a single event line.
@@ -88,7 +93,8 @@ def lambda_handler(event, _context):
                     obj = s3_client.get_object(Bucket=bucket, Key=key)
                     raw = obj['Body'].read()
                     text = raw.decode('utf-8', errors='replace')
-                    shipped = ship_lines_to_kinesis([text], bucket, key, tags)
+                    shipped = ship_lines_to_kinesis(
+                        [text], bucket, key, tags, metadata_fields)
                     LOG.info(
                         'json_object_ingested bucket=%s key=%s size=%d', bucket, key, len(raw))
                 except Exception as json_err:  # pragma: no cover
@@ -98,7 +104,8 @@ def lambda_handler(event, _context):
             elif key.endswith('.log'):
                 # Line-by-line streaming for log files.
                 line_iter = stream_s3_object_lines(bucket, key)
-                shipped = ship_lines_to_kinesis(line_iter, bucket, key, tags)
+                shipped = ship_lines_to_kinesis(
+                    line_iter, bucket, key, tags, metadata_fields)
             else:
                 LOG.info('unsupported_object_skip bucket=%s key=%s', bucket, key)
                 continue
@@ -129,6 +136,69 @@ def stream_s3_object_lines(bucket: str, key: str) -> Iterable[str]:
         yield buffer
 
 
+def metadata_key_for_object(key: str, tags: dict[str, str] | None = None) -> str:
+    if tags:
+        metadata_key = tags.get(METADATA_TAG_KEY)
+        if metadata_key:
+            return metadata_key
+
+    if key.endswith('.json'):
+        return f"{key[:-5]}{METADATA_SUFFIX}"
+    if key.endswith('.log'):
+        return f"{key[:-4]}{METADATA_SUFFIX}"
+    return f"{key}{METADATA_SUFFIX}"
+
+
+def normalize_metadata_fields(raw_fields: Any) -> dict[str, Any]:
+    if not isinstance(raw_fields, dict):
+        return {}
+
+    fields: dict[str, Any] = {}
+    for key, value in raw_fields.items():
+        if not isinstance(key, str) or not key:
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            fields[key] = value
+    return fields
+
+
+def load_metadata_fields(
+    bucket: str,
+    key: str,
+    tags: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    metadata_key = metadata_key_for_object(key, tags)
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=metadata_key)
+        raw = obj['Body'].read()
+    except ClientError as err:
+        code = err.response.get('Error', {}).get('Code')
+        if code in ('NoSuchKey', '404', 'NotFound'):
+            LOG.info('metadata_sidecar_missing bucket=%s key=%s metadata_key=%s',
+                     bucket, key, metadata_key)
+        else:
+            LOG.warning('metadata_sidecar_fetch_failed bucket=%s key=%s metadata_key=%s err=%s',
+                        bucket, key, metadata_key, err)
+        return {}
+    except Exception as err:  # pragma: no cover
+        LOG.warning('metadata_sidecar_fetch_failed bucket=%s key=%s metadata_key=%s err=%s',
+                    bucket, key, metadata_key, err)
+        return {}
+
+    try:
+        payload = json.loads(raw.decode('utf-8', errors='replace'))
+    except json.JSONDecodeError as err:
+        LOG.warning('metadata_sidecar_invalid_json bucket=%s key=%s metadata_key=%s err=%s',
+                    bucket, key, metadata_key, err)
+        return {}
+
+    fields = normalize_metadata_fields(payload.get(
+        'fields') if isinstance(payload, dict) else None)
+    LOG.debug('metadata_sidecar_fields bucket=%s key=%s metadata_key=%s field_count=%d',
+              bucket, key, metadata_key, len(fields))
+    return fields
+
+
 def extract_ts(line: str, last_ts: str | float | None) -> float:
     """
     Extract timestamp from a log line.
@@ -155,13 +225,21 @@ def extract_ts(line: str, last_ts: str | float | None) -> float:
     return round(time.time(), 3)
 
 
-def wrap_line(line: str, ts: float, bucket: str, key: str, tags: dict[str, str]) -> str:
+def wrap_line(
+    line: str,
+    ts: float,
+    bucket: str,
+    key: str,
+    tags: dict[str, str],
+    metadata_fields: dict[str, Any] | None = None,
+) -> str:
     """
     Wrap a log line with metadata for Splunk/Kinesis ingestion.
     Timestamp is passed in from outside.
     """
     base_fields = {
         'AccountId': ACCOUNT_ID,
+        **(metadata_fields or {}),
         **tags,
     }
     event = {
@@ -178,7 +256,13 @@ def wrap_line(line: str, ts: float, bucket: str, key: str, tags: dict[str, str])
     return json.dumps(event) + '\n'
 
 
-def ship_lines_to_kinesis(lines: Iterable[str], bucket: str, key: str, tags: dict[str, str]) -> int:
+def ship_lines_to_kinesis(
+    lines: Iterable[str],
+    bucket: str,
+    key: str,
+    tags: dict[str, str],
+    metadata_fields: dict[str, Any] | None = None,
+) -> int:
     """Batch lines into PutRecords requests respecting count & size limits."""
     buffer: list[tuple[bytes, int]] = []  # (data_bytes, length)
     total_shipped = 0
@@ -226,7 +310,8 @@ def ship_lines_to_kinesis(lines: Iterable[str], bucket: str, key: str, tags: dic
             continue
         ts = extract_ts(line, last_ts)
         last_ts = ts
-        payload = wrap_line(line, ts, bucket, key, tags).encode('utf-8')
+        payload = wrap_line(
+            line, ts, bucket, key, tags, metadata_fields).encode('utf-8')
         payload_len = len(payload)
         if payload_len > 1000000:  # Guard insanely long lines
             LOG.warning('line_too_large_skip size=%d', payload_len)

--- a/modules/platform/forge_runners/github_actions_job_logs/README.md
+++ b/modules/platform/forge_runners/github_actions_job_logs/README.md
@@ -19,7 +19,7 @@ Archives completed GitHub Actions workflow job logs into per-tenant S3 buckets f
 2. EventBridge rule filters for `workflow_job` with `action=completed`.
 3. Dispatcher Lambda validates mapping & completion status, then enqueues a concise message to SQS.
 4. Downloader Lambda (SQS trigger) consumes batches, performs GitHub API log download, and writes to S3.
-5. Objects stored at: `s3://<bucket>/<repo_full_name>/<run_id>/<run_attempt>/<job_id>.log` (raw log) and `s3://<bucket>/<repo_full_name>/<run_id>/<run_attempt>/<job_id>.json` (the workflow_job event detail), both SSE-KMS encrypted and tagged with runner/job metadata.
+5. Objects stored at: `s3://<bucket>/<repo_full_name>/<run_id>/<run_attempt>/<job_id>.fields` (flattened Splunk fields sidecar), `s3://<bucket>/<repo_full_name>/<run_id>/<run_attempt>/<job_id>.log` (raw log), and `s3://<bucket>/<repo_full_name>/<run_id>/<run_attempt>/<job_id>.json` (the workflow_job event detail), all SSE-KMS encrypted and tagged with runner/job metadata. The `.log` and `.json` objects also include a `metadata_key` S3 tag pointing to the `.fields` sidecar.
 
 ### Direct Mode (fallback)
 Set `enable_queue_pipeline = false` to revert to the original single-Lambda flow (less durable, fewer moving parts for very low volume environments).

--- a/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
+++ b/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import os
+import re
 import time
 from typing import Any, Dict, Tuple
 from urllib.parse import quote
@@ -21,6 +22,12 @@ S3 = boto3.client('s3')
 MAX_S3_TAGS = 10
 GITHUB_RETRY_ATTEMPTS = 3
 GITHUB_RETRY_DELAY = 2
+METADATA_SUFFIX = '.fields'
+METADATA_TAG_KEY = 'metadata_key'
+MAX_METADATA_FIELDS = 500
+MAX_METADATA_LIST_ITEMS = 100
+MAX_METADATA_VALUE_LENGTH = 1024
+FIELD_NAME_RE = re.compile(r'[^A-Za-z0-9_]+')
 
 
 def _get_secret_value(parameter_name: str) -> str:
@@ -136,10 +143,15 @@ def _github_auth(secret_app_id: str, secret_private_key: str, secret_installatio
     return _get_installation_token(installation_id, jwt_token, api_base)
 
 
-def _keys(repo_full_name: str, run_id: Any, run_attempt: Any, job_id: Any) -> Tuple[str, str, str]:
+def _keys(repo_full_name: str, run_id: Any, run_attempt: Any, job_id: Any) -> Tuple[str, str, str, str]:
     run_attempt = run_attempt or 1
     base_path = f"{repo_full_name}/{run_id}/{run_attempt}/{job_id}"
-    return base_path, f"{base_path}.log", f"{base_path}.json"
+    return (
+        base_path,
+        f"{base_path}.log",
+        f"{base_path}.json",
+        f"{base_path}{METADATA_SUFFIX}",
+    )
 
 
 def _tags(wf: Dict[str, Any]) -> Dict[str, str]:
@@ -151,6 +163,77 @@ def _tags(wf: Dict[str, Any]) -> Dict[str, str]:
         'created_at': str(wf.get('created_at') or ''),
         'started_at': str(wf.get('started_at') or ''),
         'completed_at': str(wf.get('completed_at') or ''),
+    }
+
+
+def _field_name(path: Tuple[Any, ...]) -> str:
+    parts = []
+    for part in path:
+        clean = FIELD_NAME_RE.sub('_', str(part)).strip('_').lower()
+        if clean:
+            parts.append(clean)
+    return '_'.join(parts)
+
+
+def _add_metadata_field(
+    fields: Dict[str, Any],
+    path: Tuple[Any, ...],
+    value: Any,
+) -> None:
+    if value is None or len(fields) >= MAX_METADATA_FIELDS:
+        return
+
+    name = _field_name(path)
+    if not name or name in fields:
+        return
+
+    if isinstance(value, str):
+        fields[name] = value[:MAX_METADATA_VALUE_LENGTH]
+    elif isinstance(value, bool):
+        fields[name] = value
+    elif isinstance(value, (int, float)):
+        fields[name] = value
+
+
+def _flatten_metadata_fields(
+    value: Any,
+    path: Tuple[Any, ...] = (),
+    fields: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    if fields is None:
+        fields = {}
+    if len(fields) >= MAX_METADATA_FIELDS:
+        return fields
+
+    if isinstance(value, dict):
+        for key, child in value.items():
+            _flatten_metadata_fields(child, path + (key,), fields)
+            if len(fields) >= MAX_METADATA_FIELDS:
+                break
+    elif isinstance(value, list):
+        _add_metadata_field(fields, path + ('count',), len(value))
+        for idx, child in enumerate(value[:MAX_METADATA_LIST_ITEMS]):
+            _flatten_metadata_fields(child, path + (idx,), fields)
+            if len(fields) >= MAX_METADATA_FIELDS:
+                break
+    else:
+        _add_metadata_field(fields, path, value)
+
+    return fields
+
+
+def _metadata_payload(
+    detail: Dict[str, Any],
+    log_key: str,
+    event_key: str,
+) -> Dict[str, Any]:
+    fields = _flatten_metadata_fields(detail)
+    return {
+        'schema_version': 1,
+        'source_log_key': log_key,
+        'source_event_key': event_key,
+        'fields': fields,
+        'field_count': len(fields),
     }
 
 
@@ -205,16 +288,23 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:  # p
             install_token = _github_auth(
                 env['SECRET_NAME_APP_ID'], env['SECRET_NAME_PRIVATE_KEY'], env['SECRET_NAME_INSTALLATION_ID'], env['GITHUB_API']
             )
-            _, log_key, event_key = _keys(
+            _, log_key, event_key, metadata_key = _keys(
                 repo_full_name, run_id, run_attempt, job_id)
             obj_tags = _tags(workflow_job)
+            data_obj_tags = {
+                **obj_tags,
+                METADATA_TAG_KEY: metadata_key,
+            }
             body = _download_job_logs(owner, repo, int(
                 job_id), install_token, env['GITHUB_API'])
+            _put_json_object(env['BUCKET_NAME'], metadata_key,
+                             _metadata_payload(detail, log_key, event_key),
+                             env['KMS_KEY_ARN'], obj_tags)
             _put_log_object(env['BUCKET_NAME'], log_key, body,
-                            env['KMS_KEY_ARN'], obj_tags)
+                            env['KMS_KEY_ARN'], data_obj_tags)
             size = len(body)
             _put_json_object(env['BUCKET_NAME'], event_key,
-                             detail, env['KMS_KEY_ARN'], obj_tags)
+                             detail, env['KMS_KEY_ARN'], data_obj_tags)
 
             return {
                 'status': 'ok',
@@ -225,6 +315,7 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:  # p
                 'repository': repo_full_name,
                 'log_key': log_key,
                 'event_key': event_key,
+                'metadata_key': metadata_key,
                 'size': size
             }
         except Exception as e:

--- a/tests/lambdas/job_log_archiver_test.py
+++ b/tests/lambdas/job_log_archiver_test.py
@@ -111,6 +111,63 @@ def test_log_object_is_kms_encrypted(monkeypatch, s3_kms, ssm):
     assert head.get('ServerSideEncryption') == 'aws:kms'
 
 
+def test_metadata_sidecar_contains_flat_fields(monkeypatch, s3_kms, ssm):
+    alpha = s3_kms['buckets']['alpha']
+    mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)
+    monkeypatch.setattr(mod, '_download_job_logs',
+                        lambda *a, **k: b'log-bytes')
+
+    evt = _completed_event()
+    body = json.loads(evt['Records'][0]['body'])
+    body['detail']['repository'] = {
+        'full_name': 'acme/app',
+        'owner': {'login': 'acme', 'type': 'Organization'},
+        'custom_properties': {'business-unit': 'Cloudsec'},
+    }
+    body['detail']['workflow_job']['steps'] = [
+        {
+            'name': 'Set up job',
+            'status': 'completed',
+            'conclusion': 'success',
+            'number': 1,
+        },
+        {
+            'name': 'Run tests',
+            'status': 'completed',
+            'conclusion': 'success',
+            'number': 2,
+        },
+    ]
+    evt['Records'][0]['body'] = json.dumps(body)
+
+    result = mod.lambda_handler(evt, None)
+
+    s3 = s3_kms['s3']
+    metadata_key = result['metadata_key']
+    assert metadata_key == 'acme/app/99/1/4242.fields'
+    raw = s3.get_object(Bucket=alpha, Key=metadata_key)['Body'].read()
+    payload = json.loads(raw)
+
+    fields = payload['fields']
+    assert payload['source_log_key'] == 'acme/app/99/1/4242.log'
+    assert payload['source_event_key'] == 'acme/app/99/1/4242.json'
+    assert fields['action'] == 'completed'
+    assert fields['workflow_job_id'] == 4242
+    assert fields['workflow_job_run_id'] == 99
+    assert fields['workflow_job_steps_count'] == 2
+    assert fields['workflow_job_steps_0_name'] == 'Set up job'
+    assert fields['workflow_job_steps_1_name'] == 'Run tests'
+    assert fields['repository_owner_login'] == 'acme'
+    assert fields['repository_custom_properties_business_unit'] == 'Cloudsec'
+
+    for key in ('acme/app/99/1/4242.log', 'acme/app/99/1/4242.json'):
+        tags = {
+            tag['Key']: tag['Value']
+            for tag in s3.get_object_tagging(Bucket=alpha, Key=key)['TagSet']
+        }
+        assert tags['metadata_key'] == metadata_key
+
+
 def test_skipped_jobs_are_not_archived(monkeypatch, s3_kms, ssm):
     alpha = s3_kms['buckets']['alpha']
     mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)

--- a/tests/lambdas/splunk_s3_runner_logs_test.py
+++ b/tests/lambdas/splunk_s3_runner_logs_test.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+
+from conftest import requires_aws
+from support import load_handler_module
+
+pytestmark = requires_aws
+
+
+def _load_splunk(monkeypatch):
+    monkeypatch.setenv('KINESIS_STREAM_NAME', 'splunk-runner-logs-test')
+    return load_handler_module('splunk_s3_runner_logs')
+
+
+def test_metadata_key_for_object(monkeypatch, aws):
+    mod = _load_splunk(monkeypatch)
+
+    assert mod.metadata_key_for_object(
+        'acme/app/99/1/4242.log',
+        {'metadata_key': 'metadata/custom.fields'},
+    ) == 'metadata/custom.fields'
+    assert mod.metadata_key_for_object('acme/app/99/1/4242.log') == (
+        'acme/app/99/1/4242.fields'
+    )
+    assert mod.metadata_key_for_object('acme/app/99/1/4242.json') == (
+        'acme/app/99/1/4242.fields'
+    )
+
+
+def test_load_metadata_fields_reads_sidecar(monkeypatch, s3_kms):
+    mod = _load_splunk(monkeypatch)
+    bucket = s3_kms['buckets']['alpha']
+    s3 = s3_kms['s3']
+    s3.put_object(
+        Bucket=bucket,
+        Key='metadata/custom.fields',
+        Body=json.dumps({
+            'fields': {
+                'workflow_job_id': 4242,
+                'repository_full_name': 'acme/app',
+                'workflow_job_conclusion': 'success',
+                'skip_nested': {'value': 'ignored'},
+                'skip_list': ['ignored'],
+                'skip_null': None,
+            },
+        }).encode(),
+    )
+
+    fields = mod.load_metadata_fields(
+        bucket,
+        'acme/app/99/1/4242.log',
+        {'metadata_key': 'metadata/custom.fields'},
+    )
+
+    assert fields == {
+        'workflow_job_id': 4242,
+        'repository_full_name': 'acme/app',
+        'workflow_job_conclusion': 'success',
+    }
+
+
+def test_wrap_line_merges_tags_and_metadata_fields(monkeypatch, aws):
+    mod = _load_splunk(monkeypatch)
+
+    wrapped = mod.wrap_line(
+        '2026-07-03T22:26:04.000Z hello',
+        1783117564.0,
+        'forge-gh-logs',
+        'acme/app/99/1/4242.log',
+        {'runner_name': 'forge-runner-1', 'conclusion': 'success'},
+        {'workflow_job_id': 4242, 'repository_full_name': 'acme/app'},
+    )
+
+    event = json.loads(wrapped)
+    assert event['fields']['AccountId'] == '123456789012'
+    assert event['fields']['runner_name'] == 'forge-runner-1'
+    assert event['fields']['conclusion'] == 'success'
+    assert event['fields']['workflow_job_id'] == 4242
+    assert event['fields']['repository_full_name'] == 'acme/app'

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -50,6 +50,9 @@ LAMBDA_DIRS: dict[str, str] = {
         'modules/platform/forge_runners/github_actions_job_logs/lambda/'
         'job_log_archiver'
     ),
+    'splunk_s3_runner_logs': (
+        'modules/integrations/splunk_cloud_s3_runner_logs/lambda'
+    ),
     'redrive_deadletter': (
         'modules/platform/forge_runners/redrive_deadletter/lambda'
     ),


### PR DESCRIPTION
## Description

Adds a metadata sidecar for archived GitHub Actions runner logs and uses it to enrich Splunk fields.

- Write `<job_id>.fields` objects containing flattened scalar fields from the workflow job event detail.
- Tag the archived `.log` and `.json` objects with `metadata_key` pointing to the sidecar object.
- Update the Splunk S3 runner logs Lambda to read the `metadata_key` tag, load sidecar fields, and merge them into the Splunk `fields` payload with existing S3 tags.
- Add unit coverage for sidecar creation, tag wiring, and Splunk field merging.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

`/private/tmp/forge-lambda-tests-venv/bin/python -m pytest tests/lambdas -q --no-cov`

Result: 53 passed, 9 expected xfails.
