### PR TITLE
chore(dispatcher): document tenant config checkov exception

### DIFF
--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/tenant_configs.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/tenant_configs.tf
@@ -1,4 +1,5 @@
 resource "aws_ssm_parameter" "tenant_configs" {
+  #checkov:skip=CKV2_AWS_34:Tenant config chunks are operational routing metadata, not secrets; keep String until SecureString compatibility is reviewed.
   for_each = {
     for index, chunk in local.redelivery_tenant_config_chunks :
     tostring(index) => chunk


### PR DESCRIPTION
## Description

Documents the accepted Checkov exception for code scanning alert 161 on the Splunk stuck workflow dispatcher tenant config SSM parameters.

The tenant config chunks are operational routing metadata rather than secrets, so this keeps the existing `String` behavior while `SecureString` compatibility can be reviewed separately.

Alert: https://github.com/cisco-open/forge/security/code-scanning/161

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Security scanner exception

## Testing

- `terraform fmt -check modules/integrations/splunk_stuck_workflow_job_dispatcher/tenant_configs.tf`
- `checkov --file modules/integrations/splunk_stuck_workflow_job_dispatcher/tenant_configs.tf --check CKV2_AWS_34 --quiet`
- `git commit --amend` pre-commit hooks passed, including Terraform/IaC validation hooks
