### PR TITLE
chore(deps): group runner Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -58,17 +58,6 @@
       ],
     "packageRules": [
         {
-            "matchDatasources": [
-                "github-tags"
-            ],
-            "matchPackageNames": [
-                "github-aws-runners/terraform-aws-github-runner"
-            ],
-            "groupName": "terraform-aws-github-runner version",
-            "separateMajorMinor": false,
-            "separateMinorPatch": false
-        },
-        {
             "description": "Security updates - immediate processing (override stability days)",
             "matchPackagePatterns": [
                 "*"
@@ -269,6 +258,16 @@
                 "security",
                 "auto-merge"
             ]
+        },
+        {
+            "description": "Group terraform-aws-github-runner updates across all Renovate managers",
+            "matchDepNames": [
+                "github-aws-runners/terraform-aws-github-runner"
+            ],
+            "groupName": "terraform-aws-github-runner version",
+            "groupSlug": "terraform-aws-github-runner",
+            "separateMajorMinor": false,
+            "separateMinorPatch": false
         }
     ]
 }


### PR DESCRIPTION
## Description

Groups Renovate updates for `github-aws-runners/terraform-aws-github-runner` by dependency name instead of limiting the rule to the `github-tags` datasource. This lets Renovate use the same group for that dependency across managers and keeps the specific rule last so broader package rules do not override its group name.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: dependency automation config

## Testing

- `jq . renovate.json`
- `pre-commit run check-renovate --files renovate.json`
- `renovate-config-validator renovate.json`
- `git diff --check -- renovate.json`
