### PR TITLE
fix(splunk): use PyJWT for GitHub app JWTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ AWS role, ECR, and troubleshooting patterns.
 
 Technical background:
 
-- [No Silver Bullets: Engineering a Multi-Tenant CI Platform a Small Team Can Run](https://dev.to/edersonbrilhante/no-silver-bullets-engineering-a-multi-tenant-ci-platform-a-small-team-can-run-if)
 - [Forge: scalable, secure multi-tenant GitHub runner platform](https://www.linkedin.com/pulse/forge-scalable-secure-multi-tenant-github-runner-brilhante--fyxbf)
 - [Scaling GitHub Actions on AWS with ForgeMT's security and multi-tenancy](https://hackernoon.com/scaling-github-actions-on-aws-with-forgemts-security-and-multi-tenancy)
 - [No Silver Bullets: engineering a multi-tenant CI platform a small team can run](https://www.linkedin.com/pulse/silver-bullets-engineering-multi-tenant-ci-platform-small-brilhante-ofjpf/)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ForgeMT
 
 [![Release](https://img.shields.io/github/v/release/cisco-open/forge?display_name=tag)](https://github.com/cisco-open/forge/releases/latest/)
-[![License](https://img.shields.io/github/license/cisco-open/forge)](LICENSE.md)
+[![License](https://img.shields.io/github/license/cisco-open/forge)](LICENSE)
 [![Maintainer](https://img.shields.io/badge/Maintainer-Cisco-00bceb.svg)](https://opensource.cisco.com)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://cisco-open.github.io/forge/)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cisco-open/forge/badge)](https://scorecard.dev/viewer/?uri=github.com/cisco-open/forge)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10894/badge)](https://www.bestpractices.dev/projects/10905)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10905/badge)](https://www.bestpractices.dev/projects/10905)
 ![CI](https://img.shields.io/github/check-runs/cisco-open/forge/main)
 ![Commits since latest release](https://img.shields.io/github/commits-since/cisco-open/forge/latest)
 [![Contributors](https://img.shields.io/github/contributors/cisco-open/forge)](https://github.com/cisco-open/forge/graphs/contributors)

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -52,7 +52,6 @@ These articles explain the architecture and tradeoffs behind Forge. Treat them
 as background context; use the docs in this site for the current implementation
 and copyable paths.
 
-- [No Silver Bullets: Engineering a Multi-Tenant CI Platform a Small Team Can Run](https://dev.to/edersonbrilhante/no-silver-bullets-engineering-a-multi-tenant-ci-platform-a-small-team-can-run-if)
 - [Forge: scalable, secure multi-tenant GitHub runner platform](https://www.linkedin.com/pulse/forge-scalable-secure-multi-tenant-github-runner-brilhante--fyxbf)
 - [Scaling GitHub Actions on AWS with ForgeMT's security and multi-tenancy](https://hackernoon.com/scaling-github-actions-on-aws-with-forgemts-security-and-multi-tenancy)
 - [No Silver Bullets: engineering a multi-tenant CI platform a small team can run](https://www.linkedin.com/pulse/silver-bullets-engineering-multi-tenant-ci-platform-small-brilhante-ofjpf/)

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
@@ -89,8 +89,9 @@ module "worker" {
   }]
 
   layers = [
-    "arn:aws:lambda:${var.aws_region}:770693421928:layer:Klayers-p312-cryptography:17",
-    "arn:aws:lambda:${var.aws_region}:770693421928:layer:Klayers-p312-PyJWT:1",
+    "arn:aws:lambda:${data.aws_region.current.region}:770693421928:layer:Klayers-p312-cryptography:17",
+    "arn:aws:lambda:${data.aws_region.current.region}:770693421928:layer:Klayers-p312-requests:17",
+    "arn:aws:lambda:${data.aws_region.current.region}:770693421928:layer:Klayers-p312-PyJWT:1",
   ]
 
   logging_log_group                 = aws_cloudwatch_log_group.worker.name
@@ -124,6 +125,8 @@ resource "aws_lambda_event_source_mapping" "worker_from_dedupe_stream" {
   starting_position = "LATEST"
   batch_size        = 10
 }
+
+data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
@@ -88,6 +88,11 @@ module "worker" {
     path = "${path.module}/lambda"
   }]
 
+  layers = [
+    "arn:aws:lambda:${var.aws_region}:770693421928:layer:Klayers-p312-cryptography:17",
+    "arn:aws:lambda:${var.aws_region}:770693421928:layer:Klayers-p312-PyJWT:1",
+  ]
+
   logging_log_group                 = aws_cloudwatch_log_group.worker.name
   use_existing_cloudwatch_log_group = true
 

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
@@ -1,5 +1,4 @@
 import base64
-import hashlib
 import json
 import logging
 import os
@@ -11,8 +10,10 @@ from decimal import Decimal
 from typing import Any, Dict, Iterable, List, Tuple
 
 import boto3
+import jwt
 from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError
+from cryptography.hazmat.primitives import serialization
 
 LOG = logging.getLogger()
 LOG.setLevel(getattr(logging, os.environ.get(
@@ -28,70 +29,6 @@ DELIVERY_GUID_RE = re.compile(
 )
 MAX_DELIVERIES = 5000
 PER_PAGE = 100
-SHA256_DIGESTINFO_PREFIX = bytes.fromhex(
-    '3031300d060960864801650304020105000420')
-
-
-class DerReader:
-    def __init__(self, data: bytes):
-        self.data = data
-        self.pos = 0
-
-    def eof(self) -> bool:
-        return self.pos >= len(self.data)
-
-    def peek_tag(self) -> int:
-        if self.eof():
-            raise ValueError('Unexpected end of DER data')
-        return self.data[self.pos]
-
-    def read_tlv(self) -> Tuple[int, bytes]:
-        if self.eof():
-            raise ValueError('Unexpected end of DER data')
-
-        tag = self.data[self.pos]
-        self.pos += 1
-        if self.eof():
-            raise ValueError('Missing DER length')
-
-        length_octet = self.data[self.pos]
-        self.pos += 1
-        if length_octet & 0x80:
-            length_octets = length_octet & 0x7F
-            if length_octets == 0:
-                raise ValueError('Indefinite DER length is not supported')
-            if self.pos + length_octets > len(self.data):
-                raise ValueError('DER length exceeds input')
-            length = int.from_bytes(
-                self.data[self.pos:self.pos + length_octets], 'big')
-            self.pos += length_octets
-        else:
-            length = length_octet
-
-        if self.pos + length > len(self.data):
-            raise ValueError('DER value exceeds input')
-
-        value = self.data[self.pos:self.pos + length]
-        self.pos += length
-        return tag, value
-
-    def read_sequence(self) -> 'DerReader':
-        tag, value = self.read_tlv()
-        if tag != 0x30:
-            raise ValueError(f"Expected DER SEQUENCE, got tag 0x{tag:02x}")
-        return DerReader(value)
-
-    def read_integer(self) -> int:
-        tag, value = self.read_tlv()
-        if tag != 0x02:
-            raise ValueError(f"Expected DER INTEGER, got tag 0x{tag:02x}")
-        return int.from_bytes(value.lstrip(b'\x00') or b'\x00', 'big')
-
-    def read_octet_string(self) -> bytes:
-        tag, value = self.read_tlv()
-        if tag != 0x04:
-            raise ValueError(f"Expected DER OCTET STRING, got tag 0x{tag:02x}")
-        return value
 
 
 def json_default(value: Any) -> Any:
@@ -100,86 +37,31 @@ def json_default(value: Any) -> Any:
     raise TypeError(f"Unsupported JSON value: {type(value).__name__}")
 
 
-def b64url(data: bytes) -> str:
-    return base64.urlsafe_b64encode(data).rstrip(b'=').decode('ascii')
-
-
 def normalize_parameter_value(value: str) -> str:
     return value.strip().strip("'\"")
 
 
-def pem_to_der(raw_key: str) -> bytes:
+def normalize_private_key(raw_key: str) -> Any:
     key_text = raw_key.replace('\\n', '\n').strip()
-    if 'BEGIN' not in key_text:
-        compact = re.sub(r'\s+', '', key_text)
-        decoded = base64.b64decode(compact)
-        if b'BEGIN' in decoded:
-            key_text = decoded.decode('utf-8').replace('\\n', '\n').strip()
-        else:
-            return decoded
+    if 'BEGIN' in key_text:
+        return key_text
 
-    lines = [
-        line.strip()
-        for line in key_text.splitlines()
-        if line.strip() and not line.startswith('-----')
-    ]
-    return base64.b64decode(''.join(lines))
+    decoded = base64.b64decode(re.sub(r'\s+', '', key_text), validate=True)
+    if b'BEGIN' in decoded:
+        return decoded.decode('utf-8').replace('\\n', '\n').strip()
+    return serialization.load_der_private_key(decoded, password=None)
 
 
-def parse_rsa_private_key(raw_key: str) -> Tuple[int, int]:
-    der = pem_to_der(raw_key)
-    sequence = DerReader(der).read_sequence()
-    sequence.read_integer()
-
-    next_tag = sequence.peek_tag()
-    if next_tag == 0x30:
-        sequence.read_tlv()
-        private_key_der = sequence.read_octet_string()
-        return parse_rsa_private_key_from_pkcs1(private_key_der)
-    if next_tag == 0x02:
-        return parse_rsa_private_key_from_sequence(sequence)
-
-    raise ValueError(f"Unsupported private key DER tag 0x{next_tag:02x}")
-
-
-def parse_rsa_private_key_from_pkcs1(der: bytes) -> Tuple[int, int]:
-    sequence = DerReader(der).read_sequence()
-    sequence.read_integer()
-    return parse_rsa_private_key_from_sequence(sequence)
-
-
-def parse_rsa_private_key_from_sequence(sequence: DerReader) -> Tuple[int, int]:
-    modulus = sequence.read_integer()
-    sequence.read_integer()
-    private_exponent = sequence.read_integer()
-    return modulus, private_exponent
-
-
-def rsa_sha256_sign(private_key: Tuple[int, int], message: bytes) -> bytes:
-    modulus, private_exponent = private_key
-    key_size = (modulus.bit_length() + 7) // 8
-    digest = hashlib.sha256(message).digest()
-    digest_info = SHA256_DIGESTINFO_PREFIX + digest
-    padding_length = key_size - len(digest_info) - 3
-    if padding_length < 8:
-        raise ValueError('RSA key is too small for SHA-256 signature')
-    encoded = b'\x00\x01' + (b'\xff' * padding_length) + b'\x00' + digest_info
-    signature = pow(int.from_bytes(encoded, 'big'), private_exponent, modulus)
-    return signature.to_bytes(key_size, 'big')
-
-
-def create_github_app_jwt(issuer: str, private_key: Tuple[int, int]) -> str:
+def create_github_app_jwt(issuer: str, private_key: Any) -> str:
     now = int(time.time())
-    header = b64url(b'{"typ":"JWT","alg":"RS256"}')
-    payload = b64url(
-        json.dumps(
-            {'iat': now - 60, 'exp': now + 540, 'iss': issuer},
-            separators=(',', ':'),
-        ).encode('utf-8')
+    token = jwt.encode(
+        {'iat': now - 60, 'exp': now + 540, 'iss': issuer},
+        private_key,
+        algorithm='RS256',
     )
-    signing_input = f"{header}.{payload}".encode('ascii')
-    signature = b64url(rsa_sha256_sign(private_key, signing_input))
-    return f"{header}.{payload}.{signature}"
+    if isinstance(token, bytes):
+        token = token.decode('ascii')
+    return token
 
 
 def github_request(
@@ -349,7 +231,7 @@ def load_github_app_credentials(payload: Dict[str, Any]) -> Dict[str, Any]:
     )
     return {
         'issuer': issuer,
-        'private_key': parse_rsa_private_key(raw_key),
+        'private_key': normalize_private_key(raw_key),
         'github_api_url': tenant_config['github_api_url'],
         'github_api_version': tenant_config['github_api_version'],
         'installation_id': installation_id,

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
@@ -19,13 +19,6 @@ dynamodb = boto3.client('dynamodb')
 deserializer = TypeDeserializer()
 tenant_configs_cache: List[Dict[str, Any]] | None = None
 
-DELIVERY_GUID_RE = re.compile(
-    r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-    re.IGNORECASE,
-)
-MAX_DELIVERIES = 5000
-PER_PAGE = 100
-
 
 def json_default(value: Any) -> Any:
     if isinstance(value, Decimal):
@@ -234,13 +227,9 @@ def load_github_app_credentials(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def normalize_delivery_references(
-    values: Iterable[Any],
-) -> Tuple[List[str], List[str]]:
+def normalize_delivery_ids(values: Iterable[Any]) -> List[str]:
     numeric_delivery_ids: List[str] = []
-    delivery_guids: List[str] = []
     seen_ids = set()
-    seen_guids = set()
 
     if isinstance(values, str):
         values = [values]
@@ -257,172 +246,24 @@ def normalize_delivery_references(
             numeric_delivery_ids.append(delivery_reference)
             continue
 
-        if DELIVERY_GUID_RE.fullmatch(delivery_reference):
-            delivery_guid = delivery_reference.lower()
-            if delivery_guid in seen_guids:
-                continue
-            seen_guids.add(delivery_guid)
-            delivery_guids.append(delivery_guid)
-            continue
+        raise ValueError(f"Invalid delivery ID: {delivery_reference}")
 
-        raise ValueError(f"Invalid delivery ID/GUID: {delivery_reference}")
-
-    return numeric_delivery_ids, delivery_guids
+    return numeric_delivery_ids
 
 
 def delivery_row_from_id(delivery_id: str) -> Dict[str, Any]:
-    return {
-        'id': delivery_id,
-        'guid': '-',
-        'event': 'explicit-id',
-        'action': '-',
-        'delivered_at': '-',
-        'status_code': '-',
-        'status': '-',
-        'repository_id': '-',
-    }
+    return {'id': delivery_id}
 
 
-def delivery_row_from_github_delivery(
-    delivery: Dict[str, Any],
-) -> Dict[str, Any]:
-    delivery_id = str(delivery.get('id') or '').strip()
-    if not re.fullmatch(r'\d+', delivery_id):
-        raise ValueError(
-            f"Resolved GitHub delivery has invalid numeric ID: {delivery_id}")
-
-    return {
-        'id': delivery_id,
-        'guid': str(delivery.get('guid') or '-'),
-        'event': str(delivery.get('event') or '-'),
-        'action': str(delivery.get('action') or '-'),
-        'delivered_at': str(delivery.get('delivered_at') or '-'),
-        'status_code': str(delivery.get('status_code') or '-'),
-        'status': str(delivery.get('status') or '-'),
-        'repository_id': str(delivery.get('repository_id') or '-'),
-    }
-
-
-def next_cursor_from_headers(headers: Dict[str, str]) -> str:
-    link = headers.get('link') or ''
-    for part in link.split(','):
-        if 'rel="next"' not in part:
-            continue
-        match = re.search(r'[?&]cursor=([^&>]+)', part)
-        if match:
-            return match.group(1)
-    return ''
-
-
-def resolve_delivery_guid_rows(
-    jwt: str,
-    delivery_guids: List[str],
-    installation_id: str,
-    api_url: str | None = None,
-    api_version: str | None = None,
-) -> List[Dict[str, Any]]:
-    remaining_guids = set(delivery_guids)
-    rows: List[Dict[str, Any]] = []
-    path = f"/app/hook/deliveries?per_page={PER_PAGE}"
-    scanned = 0
-    pages = 0
-
-    while remaining_guids and scanned < MAX_DELIVERIES:
-        status, headers, body = github_request(
-            jwt,
-            'GET',
-            path,
-            api_url=api_url,
-            api_version=api_version,
-        )
-        if status != 200:
-            error_body = body.decode('utf-8', 'replace')
-            raise RuntimeError(
-                f"GitHub delivery lookup failed HTTP {status}: {error_body}"
-            )
-
-        deliveries = json.loads(body.decode('utf-8'))
-        if not isinstance(deliveries, list):
-            raise ValueError(
-                'GitHub delivery lookup returned a non-list payload')
-
-        pages += 1
-        delivery_page = deliveries[:max(MAX_DELIVERIES - scanned, 0)]
-        scanned += len(delivery_page)
-
-        for delivery in delivery_page:
-            if not isinstance(delivery, dict):
-                continue
-            delivery_guid = str(delivery.get('guid') or '').lower()
-            if delivery_guid not in remaining_guids:
-                continue
-            delivery_installation_id = str(
-                delivery.get('installation_id') or '')
-            if installation_id and delivery_installation_id != installation_id:
-                continue
-
-            rows.append(delivery_row_from_github_delivery(delivery))
-            remaining_guids.remove(delivery_guid)
-
-        if not deliveries or len(delivery_page) < len(deliveries):
-            break
-
-        next_cursor = next_cursor_from_headers(headers)
-        if not next_cursor:
-            break
-        path = (
-            f"/app/hook/deliveries?per_page={PER_PAGE}"
-            f"&cursor={next_cursor}"
-        )
-
-    LOG.info(
-        'resolved_delivery_guids requested=%d resolved=%d scanned=%d pages=%d',
-        len(delivery_guids),
-        len(delivery_guids) - len(remaining_guids),
-        scanned,
-        pages,
-    )
-    if remaining_guids:
-        raise ValueError(
-            'GitHub delivery GUIDs not found in recent deliveries: '
-            f"{', '.join(sorted(remaining_guids))}"
-        )
-
-    return rows
-
-
-def delivery_rows(
-    payload: Dict[str, Any],
-    jwt: str,
-    api_url: str | None = None,
-    api_version: str | None = None,
-    installation_id: str = '',
-) -> List[Dict[str, Any]]:
-    numeric_delivery_ids, delivery_guids = normalize_delivery_references(
-        payload.get('github_delivery') or [])
-    if not numeric_delivery_ids and not delivery_guids:
+def delivery_rows(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    delivery_ids = normalize_delivery_ids(payload.get('github_delivery') or [])
+    if not delivery_ids:
         raise ValueError('No github_delivery provided by Splunk')
 
-    rows = [
+    return [
         delivery_row_from_id(delivery_id)
-        for delivery_id in numeric_delivery_ids
+        for delivery_id in delivery_ids
     ]
-    if delivery_guids:
-        rows.extend(resolve_delivery_guid_rows(
-            jwt,
-            delivery_guids,
-            installation_id,
-            api_url,
-            api_version,
-        ))
-
-    return rows
-
-
-def format_event_action(row: Dict[str, Any]) -> str:
-    if row.get('action') in {'', '-'}:
-        return str(row.get('event') or '-')
-    return f"{row.get('event')}.{row.get('action')}"
 
 
 def redeliver_delivery(
@@ -458,16 +299,9 @@ def process_rows(
 
     for index, row in enumerate(rows):
         LOG.info(
-            '%s tenant=%s delivery_id=%s guid=%s event=%s delivered_at=%s status=%s status_code=%s repository_id=%s',
-            'redelivery_execute',
+            'redelivery_execute tenant=%s delivery_id=%s',
             tenant,
             row.get('id'),
-            row.get('guid'),
-            format_event_action(row),
-            row.get('delivered_at'),
-            row.get('status'),
-            row.get('status_code'),
-            row.get('repository_id'),
         )
 
         if index == 0:
@@ -534,13 +368,7 @@ def process_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
         credentials['issuer'], credentials['private_key'])
     api_url = credentials['github_api_url']
     api_version = credentials['github_api_version']
-    rows = delivery_rows(
-        payload,
-        jwt,
-        api_url,
-        api_version,
-        credentials.get('installation_id') or '',
-    )
+    rows = delivery_rows(payload)
 
     return process_rows(jwt, payload, rows, api_url, api_version)
 

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
@@ -18,6 +18,12 @@ LOG.setLevel(getattr(logging, os.environ.get(
 dynamodb = boto3.client('dynamodb')
 deserializer = TypeDeserializer()
 tenant_configs_cache: List[Dict[str, Any]] | None = None
+DELIVERY_GUID_RE = re.compile(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+    re.IGNORECASE,
+)
+MAX_DELIVERIES = 5000
+PER_PAGE = 100
 
 
 def json_default(value: Any) -> Any:
@@ -227,9 +233,13 @@ def load_github_app_credentials(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def normalize_delivery_ids(values: Iterable[Any]) -> List[str]:
+def normalize_delivery_references(
+    values: Iterable[Any],
+) -> Tuple[List[str], List[str]]:
     numeric_delivery_ids: List[str] = []
+    delivery_guids: List[str] = []
     seen_ids = set()
+    seen_guids = set()
 
     if isinstance(values, str):
         values = [values]
@@ -246,24 +256,142 @@ def normalize_delivery_ids(values: Iterable[Any]) -> List[str]:
             numeric_delivery_ids.append(delivery_reference)
             continue
 
-        raise ValueError(f"Invalid delivery ID: {delivery_reference}")
+        if DELIVERY_GUID_RE.fullmatch(delivery_reference):
+            delivery_guid = delivery_reference.lower()
+            if delivery_guid in seen_guids:
+                continue
+            seen_guids.add(delivery_guid)
+            delivery_guids.append(delivery_guid)
+            continue
 
-    return numeric_delivery_ids
+        raise ValueError(
+            f"Invalid GitHub delivery reference: {delivery_reference}")
+
+    return numeric_delivery_ids, delivery_guids
 
 
 def delivery_row_from_id(delivery_id: str) -> Dict[str, Any]:
     return {'id': delivery_id}
 
 
-def delivery_rows(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
-    delivery_ids = normalize_delivery_ids(payload.get('github_delivery') or [])
-    if not delivery_ids:
+def next_cursor_from_headers(headers: Dict[str, str]) -> str:
+    link = headers.get('link') or ''
+    for part in link.split(','):
+        if 'rel="next"' not in part:
+            continue
+        match = re.search(r'[?&]cursor=([^&>]+)', part)
+        if match:
+            return match.group(1)
+    return ''
+
+
+def resolve_delivery_guid_rows(
+    jwt: str,
+    delivery_guids: List[str],
+    installation_id: str,
+    api_url: str | None = None,
+    api_version: str | None = None,
+) -> List[Dict[str, Any]]:
+    remaining_guids = set(delivery_guids)
+    rows: List[Dict[str, Any]] = []
+    path = f"/app/hook/deliveries?per_page={PER_PAGE}"
+    scanned = 0
+    pages = 0
+
+    while remaining_guids and scanned < MAX_DELIVERIES:
+        status, headers, body = github_request(
+            jwt,
+            'GET',
+            path,
+            api_url=api_url,
+            api_version=api_version,
+        )
+        if status != 200:
+            error_body = body.decode('utf-8', 'replace')
+            raise RuntimeError(
+                f"GitHub delivery lookup failed HTTP {status}: {error_body}"
+            )
+
+        deliveries = json.loads(body.decode('utf-8'))
+        if not isinstance(deliveries, list):
+            raise ValueError(
+                'GitHub delivery lookup returned a non-list payload')
+
+        pages += 1
+        delivery_page = deliveries[:max(MAX_DELIVERIES - scanned, 0)]
+        scanned += len(delivery_page)
+
+        for delivery in delivery_page:
+            if not isinstance(delivery, dict):
+                continue
+            delivery_guid = str(delivery.get('guid') or '').lower()
+            if delivery_guid not in remaining_guids:
+                continue
+            delivery_installation_id = str(
+                delivery.get('installation_id') or '')
+            if installation_id and delivery_installation_id != installation_id:
+                continue
+            delivery_id = str(delivery.get('id') or '').strip()
+            if not re.fullmatch(r'\d+', delivery_id):
+                raise ValueError(
+                    f"Resolved GitHub delivery has invalid numeric ID: {delivery_id}")
+
+            rows.append(delivery_row_from_id(delivery_id))
+            remaining_guids.remove(delivery_guid)
+
+        if not deliveries or len(delivery_page) < len(deliveries):
+            break
+
+        next_cursor = next_cursor_from_headers(headers)
+        if not next_cursor:
+            break
+        path = (
+            f"/app/hook/deliveries?per_page={PER_PAGE}"
+            f"&cursor={next_cursor}"
+        )
+
+    LOG.info(
+        'resolved_delivery_guids requested=%d resolved=%d scanned=%d pages=%d',
+        len(delivery_guids),
+        len(delivery_guids) - len(remaining_guids),
+        scanned,
+        pages,
+    )
+    if remaining_guids:
+        raise ValueError(
+            'GitHub delivery GUIDs not found in recent deliveries: '
+            f"{', '.join(sorted(remaining_guids))}"
+        )
+
+    return rows
+
+
+def delivery_rows(
+    payload: Dict[str, Any],
+    jwt: str,
+    api_url: str | None = None,
+    api_version: str | None = None,
+    installation_id: str = '',
+) -> List[Dict[str, Any]]:
+    delivery_ids, delivery_guids = normalize_delivery_references(
+        payload.get('github_delivery') or [])
+    if not delivery_ids and not delivery_guids:
         raise ValueError('No github_delivery provided by Splunk')
 
-    return [
+    rows = [
         delivery_row_from_id(delivery_id)
         for delivery_id in delivery_ids
     ]
+    if delivery_guids:
+        rows.extend(resolve_delivery_guid_rows(
+            jwt,
+            delivery_guids,
+            installation_id,
+            api_url,
+            api_version,
+        ))
+
+    return rows
 
 
 def redeliver_delivery(
@@ -368,7 +496,13 @@ def process_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
         credentials['issuer'], credentials['private_key'])
     api_url = credentials['github_api_url']
     api_version = credentials['github_api_version']
-    rows = delivery_rows(payload)
+    rows = delivery_rows(
+        payload,
+        jwt,
+        api_url,
+        api_version,
+        credentials.get('installation_id') or '',
+    )
 
     return process_rows(jwt, payload, rows, api_url, api_version)
 

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
@@ -4,16 +4,12 @@ import logging
 import os
 import re
 import time
-import urllib.error
-import urllib.request
 from decimal import Decimal
 from typing import Any, Dict, Iterable, List, Tuple
 
 import boto3
-import jwt
 from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError
-from cryptography.hazmat.primitives import serialization
 
 LOG = logging.getLogger()
 LOG.setLevel(getattr(logging, os.environ.get(
@@ -49,10 +45,15 @@ def normalize_private_key(raw_key: str) -> Any:
     decoded = base64.b64decode(re.sub(r'\s+', '', key_text), validate=True)
     if b'BEGIN' in decoded:
         return decoded.decode('utf-8').replace('\\n', '\n').strip()
+
+    from cryptography.hazmat.primitives import serialization
+
     return serialization.load_der_private_key(decoded, password=None)
 
 
 def create_github_app_jwt(issuer: str, private_key: Any) -> str:
+    import jwt
+
     now = int(time.time())
     token = jwt.encode(
         {'iat': now - 60, 'exp': now + 540, 'iss': issuer},
@@ -72,11 +73,12 @@ def github_request(
     api_url: str | None = None,
     api_version: str | None = None,
 ) -> Tuple[int, Dict[str, str], bytes]:
+    import requests
+
     resolved_api_url = (api_url or 'https://api.github.com').rstrip('/')
     resolved_api_version = (
         '2022-11-28' if api_version is None else api_version
     )
-    data = json.dumps(body).encode('utf-8') if body is not None else None
     headers = {
         'Accept': 'application/vnd.github+json',
         'Authorization': f"Bearer {jwt}",
@@ -86,21 +88,15 @@ def github_request(
     if resolved_api_version:
         headers['X-GitHub-Api-Version'] = resolved_api_version
 
-    request = urllib.request.Request(
+    response = requests.request(
+        method,
         f"{resolved_api_url}{path}",
-        data=data,
         headers=headers,
-        method=method,
+        json=body,
+        timeout=30,
     )
-
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            headers = {key.lower(): value for key,
-                       value in response.headers.items()}
-            return response.status, headers, response.read()
-    except urllib.error.HTTPError as err:
-        headers = {key.lower(): value for key, value in err.headers.items()}
-        return err.code, headers, err.read()
+    headers = {key.lower(): value for key, value in response.headers.items()}
+    return response.status_code, headers, response.content
 
 
 def load_tenant_configs() -> List[Dict[str, Any]]:

--- a/tests/lambdas/splunk_stuck_worker_test.py
+++ b/tests/lambdas/splunk_stuck_worker_test.py
@@ -111,78 +111,33 @@ def test_github_request_uses_requests(monkeypatch, aws):
     ]
 
 
-def test_normalize_delivery_references_dedupes_ids_and_guids(
-    monkeypatch, aws
-):
+def test_normalize_delivery_ids_dedupes_numeric_ids(monkeypatch, aws):
     mod = _load_worker(monkeypatch)
-    guid = 'F1234567-89AB-4CDE-8123-456789ABCDEF'
 
-    ids, guids = mod.normalize_delivery_references([
+    ids = mod.normalize_delivery_ids([
         '123',
         ' 123 ',
-        guid,
-        guid.lower(),
+        '456',
+        '456',
         '',
     ])
 
-    assert ids == ['123']
-    assert guids == [guid.lower()]
+    assert ids == ['123', '456']
 
 
-def test_normalize_delivery_references_rejects_invalid_value(
-    monkeypatch, aws
-):
+def test_normalize_delivery_ids_rejects_invalid_value(monkeypatch, aws):
     mod = _load_worker(monkeypatch)
 
-    with pytest.raises(ValueError, match='Invalid delivery ID/GUID'):
-        mod.normalize_delivery_references(['not-a-delivery-reference'])
+    with pytest.raises(ValueError, match='Invalid delivery ID'):
+        mod.normalize_delivery_ids(['not-a-delivery-reference'])
 
 
-def test_delivery_rows_combines_explicit_ids_and_resolved_guids(
-    monkeypatch, aws
-):
-    mod = _load_worker(monkeypatch)
-    guid = 'f1234567-89ab-4cde-8123-456789abcdef'
-    monkeypatch.setattr(
-        mod,
-        'resolve_delivery_guid_rows',
-        lambda jwt, guids, installation_id, api_url, api_version: [
-            {
-                'id': '99',
-                'guid': guids[0],
-                'event': 'workflow_job',
-                'action': 'queued',
-                'delivered_at': '-',
-                'status_code': '500',
-                'status': 'failed',
-                'repository_id': '42',
-            }
-        ],
-    )
-
-    rows = mod.delivery_rows(
-        {'github_delivery': ['123', guid]},
-        'jwt-token',
-        'https://api.github.test',
-        '2022-11-28',
-        'installation-1',
-    )
-
-    assert [row['id'] for row in rows] == ['123', '99']
-    assert rows[0]['event'] == 'explicit-id'
-    assert rows[1]['guid'] == guid
-
-
-def test_next_cursor_from_link_header(monkeypatch, aws):
+def test_delivery_rows_uses_splunk_delivery_ids(monkeypatch, aws):
     mod = _load_worker(monkeypatch)
 
-    assert mod.next_cursor_from_headers({
-        'link': (
-            '<https://api.github.test/app/hook/deliveries?cursor=abc>; '
-            'rel="next"'
-        ),
-    }) == 'abc'
-    assert mod.next_cursor_from_headers({'link': '<x>; rel="last"'}) == ''
+    rows = mod.delivery_rows({'github_delivery': ['123', '456']})
+
+    assert [row['id'] for row in rows] == ['123', '456']
 
 
 def test_resolve_tenant_config_uses_matching_tenant_and_region(
@@ -273,71 +228,6 @@ def test_resolve_tenant_config_rejects_ambiguous_matches(monkeypatch, aws):
             'tenant': 'acgw',
             'aws_region': 'us-west-2',
         })
-
-
-def test_resolve_delivery_guid_rows_pages_and_filters_installation(
-    monkeypatch, aws
-):
-    mod = _load_worker(monkeypatch)
-    first_guid = 'f1234567-89ab-4cde-8123-456789abcdef'
-    second_guid = 'e1234567-89ab-4cde-8123-456789abcdef'
-    calls = []
-
-    def _github_request(_jwt, method, path, **_kwargs):
-        calls.append((method, path))
-        if len(calls) == 1:
-            return 200, {
-                'link': (
-                    '<https://api.github.test/app/hook/deliveries?'
-                    'cursor=next-page>; rel="next"'
-                ),
-            }, json.dumps([
-                {
-                    'id': '11',
-                    'guid': first_guid,
-                    'installation_id': 'wrong-installation',
-                },
-                {
-                    'id': '12',
-                    'guid': first_guid,
-                    'installation_id': 'install-1',
-                    'event': 'workflow_job',
-                    'action': 'queued',
-                    'delivered_at': '2026-07-03T00:00:00Z',
-                    'status_code': 500,
-                    'status': 'failed',
-                    'repository_id': 42,
-                },
-            ]).encode()
-        return 200, {}, json.dumps([
-            {
-                'id': '13',
-                'guid': second_guid,
-                'installation_id': 'install-1',
-                'event': 'workflow_job',
-                'action': 'in_progress',
-                'delivered_at': '2026-07-03T00:01:00Z',
-                'status_code': 500,
-                'status': 'failed',
-                'repository_id': 42,
-            },
-        ]).encode()
-
-    monkeypatch.setattr(mod, 'github_request', _github_request)
-
-    rows = mod.resolve_delivery_guid_rows(
-        'jwt-token',
-        [first_guid, second_guid],
-        'install-1',
-        'https://api.github.test',
-        '2022-11-28',
-    )
-
-    assert [row['id'] for row in rows] == ['12', '13']
-    assert calls == [
-        ('GET', '/app/hook/deliveries?per_page=100'),
-        ('GET', '/app/hook/deliveries?per_page=100&cursor=next-page'),
-    ]
 
 
 def test_process_rows_redelivers_each_candidate(monkeypatch, aws):

--- a/tests/lambdas/splunk_stuck_worker_test.py
+++ b/tests/lambdas/splunk_stuck_worker_test.py
@@ -111,33 +111,73 @@ def test_github_request_uses_requests(monkeypatch, aws):
     ]
 
 
-def test_normalize_delivery_ids_dedupes_numeric_ids(monkeypatch, aws):
+def test_normalize_delivery_references_dedupes_ids_and_guids(
+    monkeypatch, aws
+):
     mod = _load_worker(monkeypatch)
+    guid = '9FFF76F0-77ED-11F1-910C-57C17856FA99'
 
-    ids = mod.normalize_delivery_ids([
+    ids, guids = mod.normalize_delivery_references([
         '123',
         ' 123 ',
-        '456',
-        '456',
+        guid,
+        guid.lower(),
         '',
     ])
 
-    assert ids == ['123', '456']
+    assert ids == ['123']
+    assert guids == [guid.lower()]
 
 
-def test_normalize_delivery_ids_rejects_invalid_value(monkeypatch, aws):
+def test_normalize_delivery_references_rejects_invalid_value(
+    monkeypatch, aws
+):
     mod = _load_worker(monkeypatch)
 
-    with pytest.raises(ValueError, match='Invalid delivery ID'):
-        mod.normalize_delivery_ids(['not-a-delivery-reference'])
+    with pytest.raises(ValueError, match='Invalid GitHub delivery reference'):
+        mod.normalize_delivery_references(['not-a-delivery-reference'])
 
 
-def test_delivery_rows_uses_splunk_delivery_ids(monkeypatch, aws):
+def test_delivery_rows_uses_numeric_delivery_ids_directly(monkeypatch, aws):
     mod = _load_worker(monkeypatch)
 
-    rows = mod.delivery_rows({'github_delivery': ['123', '456']})
+    rows = mod.delivery_rows(
+        {'github_delivery': ['123', '456']},
+        'jwt-token',
+    )
 
     assert [row['id'] for row in rows] == ['123', '456']
+
+
+def test_delivery_rows_resolves_splunk_delivery_guid(monkeypatch, aws):
+    mod = _load_worker(monkeypatch)
+    guid = '9fff76f0-77ed-11f1-910c-57c17856fa99'
+    calls = []
+
+    def _resolve(jwt, guids, installation_id, api_url, api_version):
+        calls.append((jwt, guids, installation_id, api_url, api_version))
+        return [mod.delivery_row_from_id('123456')]
+
+    monkeypatch.setattr(mod, 'resolve_delivery_guid_rows', _resolve)
+
+    rows = mod.delivery_rows(
+        {'github_delivery': guid},
+        'jwt-token',
+        'https://api.github.test',
+        '2022-11-28',
+        'installation-1',
+    )
+
+    assert [row['id'] for row in rows] == ['123456']
+    assert calls == [
+        (
+            'jwt-token',
+            [guid],
+            'installation-1',
+            'https://api.github.test',
+            '2022-11-28',
+        ),
+    ]
 
 
 def test_resolve_tenant_config_uses_matching_tenant_and_region(
@@ -228,6 +268,59 @@ def test_resolve_tenant_config_rejects_ambiguous_matches(monkeypatch, aws):
             'tenant': 'acgw',
             'aws_region': 'us-west-2',
         })
+
+
+def test_resolve_delivery_guid_rows_pages_and_filters_installation(
+    monkeypatch, aws
+):
+    mod = _load_worker(monkeypatch)
+    first_guid = '9fff76f0-77ed-11f1-910c-57c17856fa99'
+    second_guid = '9ffedab0-77ed-11f1-9fd6-73ef58d799b3'
+    calls = []
+
+    def _github_request(_jwt, method, path, **_kwargs):
+        calls.append((method, path))
+        if len(calls) == 1:
+            return 200, {
+                'link': (
+                    '<https://api.github.test/app/hook/deliveries?'
+                    'cursor=next-page>; rel="next"'
+                ),
+            }, json.dumps([
+                {
+                    'id': '11',
+                    'guid': first_guid,
+                    'installation_id': 'wrong-installation',
+                },
+                {
+                    'id': '12',
+                    'guid': first_guid,
+                    'installation_id': 'installation-1',
+                },
+            ]).encode()
+        return 200, {}, json.dumps([
+            {
+                'id': '13',
+                'guid': second_guid,
+                'installation_id': 'installation-1',
+            },
+        ]).encode()
+
+    monkeypatch.setattr(mod, 'github_request', _github_request)
+
+    rows = mod.resolve_delivery_guid_rows(
+        'jwt-token',
+        [first_guid, second_guid],
+        'installation-1',
+        'https://api.github.test',
+        '2022-11-28',
+    )
+
+    assert [row['id'] for row in rows] == ['12', '13']
+    assert calls == [
+        ('GET', '/app/hook/deliveries?per_page=100'),
+        ('GET', '/app/hook/deliveries?per_page=100&cursor=next-page'),
+    ]
 
 
 def test_process_rows_redelivers_each_candidate(monkeypatch, aws):

--- a/tests/lambdas/splunk_stuck_worker_test.py
+++ b/tests/lambdas/splunk_stuck_worker_test.py
@@ -7,6 +7,7 @@ import importlib
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import boto3
 import pytest
@@ -54,7 +55,7 @@ def test_create_github_app_jwt_uses_pyjwt_rs256(monkeypatch, aws):
         calls.append((payload, key, algorithm))
         return 'jwt-token'
 
-    monkeypatch.setattr(mod.jwt, 'encode', _encode)
+    monkeypatch.setitem(sys.modules, 'jwt', SimpleNamespace(encode=_encode))
 
     assert mod.create_github_app_jwt('app-client-id', 'pem-key') == 'jwt-token'
     assert calls == [
@@ -62,6 +63,50 @@ def test_create_github_app_jwt_uses_pyjwt_rs256(monkeypatch, aws):
             {'iat': 1940, 'exp': 2540, 'iss': 'app-client-id'},
             'pem-key',
             'RS256',
+        ),
+    ]
+
+
+def test_github_request_uses_requests(monkeypatch, aws):
+    mod = _load_worker(monkeypatch)
+    calls = []
+
+    def _request(method, url, headers, json, timeout):
+        calls.append((method, url, headers, json, timeout))
+        return SimpleNamespace(
+            status_code=404,
+            headers={'X-GitHub-Request-Id': 'abc123'},
+            content=b'not found',
+        )
+
+    monkeypatch.setitem(sys.modules, 'requests',
+                        SimpleNamespace(request=_request))
+
+    status, headers, body = mod.github_request(
+        'jwt-token',
+        'POST',
+        '/app/hook/deliveries/1/attempts',
+        body={'redeliver': True},
+        api_url='https://api.github.test',
+        api_version='2022-11-28',
+    )
+
+    assert status == 404
+    assert headers == {'x-github-request-id': 'abc123'}
+    assert body == b'not found'
+    assert calls == [
+        (
+            'POST',
+            'https://api.github.test/app/hook/deliveries/1/attempts',
+            {
+                'Accept': 'application/vnd.github+json',
+                'Authorization': 'Bearer jwt-token',
+                'Content-Type': 'application/json',
+                'User-Agent': 'forge-stuck-workflow-job-redelivery',
+                'X-GitHub-Api-Version': '2022-11-28',
+            },
+            {'redeliver': True},
+            30,
         ),
     ]
 

--- a/tests/lambdas/splunk_stuck_worker_test.py
+++ b/tests/lambdas/splunk_stuck_worker_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import importlib
 import json
 import sys
@@ -29,6 +30,40 @@ def _load_worker(monkeypatch):
     monkeypatch.setenv('DEDUPE_TABLE', 'splunk-worker-test')
     sys.modules.pop('worker', None)
     return importlib.import_module('worker')
+
+
+def test_normalize_private_key_decodes_base64_pem(monkeypatch, aws):
+    mod = _load_worker(monkeypatch)
+    key_label = 'PRIVATE KEY'
+    pem = (
+        f'-----BEGIN {key_label}-----\n'
+        'abc123\n'
+        f'-----END {key_label}-----'
+    )
+    encoded = base64.b64encode(pem.encode()).decode()
+
+    assert mod.normalize_private_key(encoded) == pem
+
+
+def test_create_github_app_jwt_uses_pyjwt_rs256(monkeypatch, aws):
+    mod = _load_worker(monkeypatch)
+    calls = []
+    monkeypatch.setattr(mod.time, 'time', lambda: 2000)
+
+    def _encode(payload, key, algorithm):
+        calls.append((payload, key, algorithm))
+        return 'jwt-token'
+
+    monkeypatch.setattr(mod.jwt, 'encode', _encode)
+
+    assert mod.create_github_app_jwt('app-client-id', 'pem-key') == 'jwt-token'
+    assert calls == [
+        (
+            {'iat': 1940, 'exp': 2540, 'iss': 'app-client-id'},
+            'pem-key',
+            'RS256',
+        ),
+    ]
 
 
 def test_normalize_delivery_references_dedupes_ids_and_guids(


### PR DESCRIPTION
## Description

Uses PyJWT and cryptography for the Splunk stuck workflow worker GitHub App JWT path instead of the local DER/RSA signing implementation.

This also adds the required Lambda layers for `PyJWT` and `cryptography`, keeps base64 PEM and DER key normalization in the worker, and adds focused unit coverage for the JWT encoding path.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- Commit hook pre-commit run passed, including Tofu/Terraform validation.
- `terraform fmt -check modules/integrations/splunk_stuck_workflow_job_dispatcher`
- `PYTHONPYCACHEPREFIX=/private/tmp/forge-pycache python3 -m py_compile modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py`
- `git diff --check -- modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py tests/lambdas/splunk_stuck_worker_test.py`

Not run locally:

- `python3 -m pytest tests/lambdas/splunk_stuck_worker_test.py` because this shell has no `pytest` module and `uv` is not installed.
