### PR TITLE
docs(operations): add terraform terragrunt stuck runbook

### DIFF
--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -6,16 +6,17 @@ upgrades, and troubleshooting.
 
 ## Day-2 Loop
 
-| Cadence              | Action                                                                     | Doc                                                     |
-| -------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------- |
-| Every tenant request | Collect tenant values, add config, run plan, run smoke workflow.           | [Tenant Onboarding](tenant-onboarding.md)               |
-| Every image release  | Build base/custom images, share AMIs, update tenant runner specs.          | [Runner Images](runner-images.md)                       |
-| Weekly               | Run example apply/destroy for helpers, infra, platform, integrations.      | [Workflow Blueprints](workflows/index.md)               |
-| Weekly               | Run cleanup and policy jobs.                                               | [Cloud Custodian](cloud-custodian.md)                   |
-| Monthly              | Review module refs, Renovate output, AMI age, stale ECR tags, and secrets. | [Upgrades](upgrades.md)                                 |
-| Planned ARC upgrade  | Rebuild blue/green EKS clusters and move tenants one at a time.            | [Move ARC Tenants](move-arc-tenants.md)                 |
-| Incident             | Triage queued jobs, failed runner registration, IAM, webhooks, or ARC.     | [Troubleshooting](troubleshooting.md)                   |
-| Incident             | Use Splunk dashboards to identify the failing subsystem and severity.      | [Splunk Dashboard Runbook](splunk-dashboard-runbook.md) |
+| Cadence              | Action                                                                     | Doc                                                                         |
+| -------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Every tenant request | Collect tenant values, add config, run plan, run smoke workflow.           | [Tenant Onboarding](tenant-onboarding.md)                                   |
+| Every image release  | Build base/custom images, share AMIs, update tenant runner specs.          | [Runner Images](runner-images.md)                                           |
+| Weekly               | Run example apply/destroy for helpers, infra, platform, integrations.      | [Workflow Blueprints](workflows/index.md)                                   |
+| Weekly               | Run cleanup and policy jobs.                                               | [Cloud Custodian](cloud-custodian.md)                                       |
+| Monthly              | Review module refs, Renovate output, AMI age, stale ECR tags, and secrets. | [Upgrades](upgrades.md)                                                     |
+| Planned ARC upgrade  | Rebuild blue/green EKS clusters and move tenants one at a time.            | [Move ARC Tenants](move-arc-tenants.md)                                     |
+| Incident             | Triage queued jobs, failed runner registration, IAM, webhooks, or ARC.     | [Troubleshooting](troubleshooting.md)                                       |
+| Incident             | Debug Terraform, OpenTofu, or Terragrunt plan/apply that appears stuck.    | [Terraform/Terragrunt Stuck Runbook](terraform-terragrunt-stuck-runbook.md) |
+| Incident             | Use Splunk dashboards to identify the failing subsystem and severity.      | [Splunk Dashboard Runbook](splunk-dashboard-runbook.md)                     |
 
 ## Operating Repos
 

--- a/docs/operations/terraform-terragrunt-stuck-runbook.md
+++ b/docs/operations/terraform-terragrunt-stuck-runbook.md
@@ -1,0 +1,103 @@
+# Terraform/Terragrunt Stuck Runbook
+
+Use this helper when `terraform`, `tofu`, or `terragrunt` stops printing progress
+during `plan` or `apply`.
+
+Do not assume the last stdout line is the blocker. The provider can be retrying
+an AWS API while unrelated resources wait in the graph.
+
+## 1. Capture TRACE Logs
+
+Run from the stack directory. Default to `plan`; set `TF_COMMAND=apply` only when
+you intentionally want to apply. Replace `terragrunt` with `tofu` or
+`terraform` if running without Terragrunt.
+
+```bash
+export TF_COMMAND="${TF_COMMAND:-plan}"
+export TS="$(date +%Y%m%d-%H%M%S)"
+export TF_TRACE="/private/tmp/forge-${TF_COMMAND}-trace-${TS}.log"
+export TF_STDOUT="/private/tmp/forge-${TF_COMMAND}-stdout-${TS}.log"
+
+TF_LOG=TRACE \
+TF_LOG_PATH="$TF_TRACE" \
+TG_LOG_LEVEL=trace \
+terragrunt "$TF_COMMAND" 2>&1 | tee "$TF_STDOUT"
+```
+
+Let the command sit for a minute after it looks stuck so provider retries are
+written to the trace.
+
+## 2. Search For Common AWS And Wait Signals
+
+```bash
+rg -n "RequestLimitExceeded|Throttl|RequestTimeout|retrying request|http.status_code=5|Waiting for state lock|Acquiring state lock|local-exec|Still reading|Still creating|Still modifying" "$TF_TRACE"
+tail -n 120 "$TF_STDOUT"
+```
+
+| Signal                                                 | Meaning                                                     |
+| ------------------------------------------------------ | ----------------------------------------------------------- |
+| `Waiting for state lock` or `Acquiring state lock`     | Backend lock wait; check the lock owner first.              |
+| `local-exec`, `kubectl`, `helm`, or hook output        | Local command wait; debug that command directly.            |
+| `RequestLimitExceeded`, `Throttling`, `RequestTimeout` | AWS API throttling or instability may be the real blocker.  |
+| `http.status_code=5` or `operational issue`            | Check AWS Health before changing Terraform code.            |
+| No obvious signal                                      | Inspect provider TRACE lines near the last graph operation. |
+
+## 3. Check AWS Health Dashboard
+
+If the trace points to AWS throttling, timeouts, HTTP `5xx`, or an AWS
+operational issue, check the AWS Health Dashboard for the affected account,
+Region, and service:
+
+```text
+https://health.aws.amazon.com/health/home
+```
+
+Look for open or recent events matching the API in the trace. For example, if
+the trace shows `EC2/DescribeLaunchTemplates`, check EC2 and EKS health in that
+Region before investigating EKS, Karpenter, or module code.
+
+If AWS Health confirms an incident, pause code changes, attach the health event
+and TRACE evidence to the incident, and retry after AWS mitigation.
+
+## 4. Optional AWS Health API Check
+
+The dashboard is the default check. The AWS Health API is useful for automation,
+but it requires the account to have a qualifying AWS Support plan. Without that,
+the API returns `SubscriptionRequiredException`.
+
+```bash
+aws health describe-events \
+  --region us-east-1 \
+  --filter "services=EC2,EKS,regions=us-east-1,global,eventStatusCodes=open,upcoming,eventTypeCategories=issue" \
+  --output table
+```
+
+If an event matches the trace, get the detailed message:
+
+```bash
+aws health describe-event-details \
+  --region us-east-1 \
+  --event-arns "$HEALTH_EVENT_ARN" \
+  --output yaml
+```
+
+Minimum useful IAM actions:
+
+- `health:DescribeEvents`
+- `health:DescribeEventDetails`
+- `health:DescribeAffectedEntities`
+
+## 5. Keep Minimal Evidence
+
+- Stack path and command: `plan` or `apply`.
+- Account and Region from `aws sts get-caller-identity`.
+- TRACE log path and stdout log path.
+- First repeated AWS API call or state-lock message.
+- AWS Health Dashboard event title, Region, service, and timestamp if present.
+
+## 6. Go Deeper Only If Needed
+
+If AWS Health is clean but the trace still shows the same AWS API retry, then
+check API usage and callers for that exact API with CloudWatch Usage and
+CloudTrail. Do this after the trace identifies the service and API action, not
+before.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -2,18 +2,19 @@
 
 Start with the symptom and check the narrowest boundary first.
 
-| Symptom                            | Check                                                                                                                                    |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Job stays queued                   | GitHub App installation, runner group access, exact labels, tenant name.                                                                 |
-| EC2 runner starts then disappears  | Runner registration logs, GitHub token generation, instance profile, webhook delivery.                                                   |
-| ARC scale set does not create pods | Kubernetes provider auth, ARC controller, namespace, Helm release, Karpenter capacity.                                                   |
-| Docker build fails on ARC          | Use `type:dind`; `type:k8s` is not for Docker daemon workloads.                                                                          |
-| AWS assume role fails              | Tenant allowed role list, target role trust, role chaining, STS region.                                                                  |
-| Webhook signature fails            | GitHub webhook secret, header forwarding, relay configuration.                                                                           |
-| Splunk dashboards missing          | Deploy only if Splunk modules are enabled; then check Splunk API token and saved search module.                                          |
-| Splunk dashboard data missing      | Check [Splunk Dashboard Runbook](splunk-dashboard-runbook.md), then start with Forge Ingestion Quality before diagnosing Forge behavior. |
-| Unsure which dashboard to use      | Start with [Splunk Dashboard Runbook](splunk-dashboard-runbook.md), then move to the narrow subsystem dashboard.                         |
-| AMI not found                      | Region, account launch permission, AMI sharing helper, and runner architecture.                                                          |
+| Symptom                            | Check                                                                                                                                                                                     |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Job stays queued                   | Check workflow labels, runner group access, GitHub App installation, and `workflow_job` delivery. See [Troubleshooting Without Splunk](troubleshooting-without-splunk.md).                |
+| EC2 runner starts then disappears  | Check lifecycle logs, user data, runner service logs, instance profile, and GitHub registration. See [Troubleshooting Without Splunk](troubleshooting-without-splunk.md).                 |
+| ARC scale set does not create pods | Check `autoscalingrunnersets`, `ephemeralrunners`, Kubernetes events, Helm, and Karpenter. See [Troubleshooting Without Splunk](troubleshooting-without-splunk.md).                       |
+| Docker build fails on ARC          | Use `type:dind`; `type:k8s` is not for Docker daemon workloads.                                                                                                                           |
+| AWS assume role fails              | Check caller identity, tenant allowed role list, target role trust, session tags, and STS region. See [Tenant AWS Role Checks](troubleshooting-without-splunk.md#tenant-aws-role-checks). |
+| Webhook signature fails            | See [Webhook Signature Fails](#webhook-signature-fails).                                                                                                                                  |
+| Splunk dashboards missing          | Deploy only if Splunk modules are enabled; then check Splunk API token and saved search module.                                                                                           |
+| Splunk dashboard data missing      | Check [Splunk Dashboard Runbook](splunk-dashboard-runbook.md), then start with Forge Ingestion Quality before diagnosing Forge behavior.                                                  |
+| Unsure which dashboard to use      | Start with [Splunk Dashboard Runbook](splunk-dashboard-runbook.md), then move to the narrow subsystem dashboard.                                                                          |
+| AMI not found                      | See [AMI Not Found](#ami-not-found). Confirm Region, owner, name pattern, architecture, and launch permission.                                                                            |
+| Terraform/Terragrunt appears stuck | See [Terraform/Terragrunt Stuck Runbook](terraform-terragrunt-stuck-runbook.md).                                                                                                          |
 
 ## First Commands
 
@@ -32,3 +33,65 @@ helm list -A
 
 For GitHub, inspect the workflow run, runner group, and app installation before
 changing Terraform.
+
+## Webhook Signature Fails
+
+Start with the GitHub App webhook delivery, not Terraform.
+
+1. In the GitHub App webhook delivery view, confirm the failing delivery is a
+   `workflow_job` event and record the response code, response body, delivery
+   ID, and delivery timestamp.
+
+1. Confirm GitHub sent `X-Hub-Signature-256`, `X-GitHub-Event`, and
+   `X-GitHub-Delivery`.
+
+1. Confirm the webhook secret configured in GitHub matches the secret consumed by
+   Forge. If a relay is in the path, it must forward the raw request body and
+   signature header unchanged.
+
+1. Check recent webhook or relay logs:
+
+   ```bash
+   aws logs filter-log-events \
+     --log-group-name <webhook-or-relay-log-group> \
+     --start-time "$(date -u -v-1H +%s)000" \
+     --filter-pattern '"signature" "webhook" "ERROR"'
+   ```
+
+Signature validation uses the raw request body. Do not reformat or reserialize
+the JSON payload when testing the signature path.
+
+## AMI Not Found
+
+Start with the exact Region, AMI owner, and AMI name pattern used by the runner
+spec.
+
+```bash
+export AWS_REGION="<runner-region>"
+export AMI_OWNER="<ami-owner-account-id>"
+export AMI_NAME="<ami-name-pattern>"
+
+aws ec2 describe-images \
+  --region "$AWS_REGION" \
+  --owners "$AMI_OWNER" \
+  --filters "Name=name,Values=$AMI_NAME" "Name=state,Values=available" \
+  --query 'Images | sort_by(@, &CreationDate)[].{id:ImageId,name:Name,arch:Architecture,state:State,created:CreationDate}' \
+  --output table
+```
+
+If the AMI exists, confirm launch permission for the runner account:
+
+```bash
+export AMI_ID="<ami-id>"
+
+aws ec2 describe-image-attribute \
+  --region "$AWS_REGION" \
+  --image-id "$AMI_ID" \
+  --attribute launchPermission
+```
+
+If the AMI still does not resolve, compare the runner spec with
+[AMI Management](ami-management.md) and [Runner Images](runner-images.md). The
+usual causes are wrong Region, wrong owner account, stale name pattern, missing
+cross-account launch permission, architecture mismatch, or an AMI cleanup job
+removing an image still referenced by a tenant.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -76,6 +76,7 @@ nav:
       - Secrets: operations/secrets.md
       - Upgrades: operations/upgrades.md
       - Troubleshooting: operations/troubleshooting.md
+      - Terraform/Terragrunt Stuck Runbook: operations/terraform-terragrunt-stuck-runbook.md
       - Troubleshooting Without Splunk: operations/troubleshooting-without-splunk.md
       - Splunk Dashboard Runbook: operations/splunk-dashboard-runbook.md
       - Splunk Dashboard Panel Reference: operations/splunk-dashboard-panel-reference.md


### PR DESCRIPTION
## Description

Adds a dedicated Terraform/Terragrunt stuck runbook for diagnosing `plan` or `apply` commands that stop printing progress. The runbook covers TRACE log capture, common AWS/provider wait signals, AWS Health Dashboard checks, optional AWS Health API use, and minimal evidence to collect.

Also updates the operations troubleshooting index with clearer first checks for queued jobs, EC2 runners, ARC, AWS role assumption, webhook signatures, and AMI lookup.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing
N/A