### PR TITLE
chore(examples): standardize template placeholders

### DIFF
--- a/examples/deployments/integrations/terragrunt/environments/prod/github_webhook_relay_destination_receivers/config.yml
+++ b/examples/deployments/integrations/terragrunt/environments/prod/github_webhook_relay_destination_receivers/config.yml
@@ -1,4 +1,5 @@
 ---
+reader_role_name: forge-github-webhook-relay-secret-reader-with-receivers
 reader_config:
   enable_secret_fetch: false
   source_secret_role_arn: ''

--- a/examples/templates/helpers/ami_sharing/config.yml
+++ b/examples/templates/helpers/ami_sharing/config.yml
@@ -1,5 +1,5 @@
 ---
 account_ids:
-  - '123456789012'
+  - <AMI_SHARING_ACCOUNT_ID>  # e.g., "123456789012"
 ami_name_filters:
-  - forge-gh-runner-base-image-v*
+  - <AMI_NAME_FILTER>         # e.g., "forge-gh-runner-base-image-v*"

--- a/examples/templates/helpers/opt_in_regions/config.yml
+++ b/examples/templates/helpers/opt_in_regions/config.yml
@@ -1,15 +1,3 @@
 ---
 opt_in_regions:
-  - af-south-1
-  - ap-east-1
-  - ap-south-2
-  - ap-southeast-3
-  - ap-southeast-4
-  - ap-southeast-5
-  - ca-west-1
-  - eu-central-2
-  - eu-south-1
-  - eu-south-2
-  - il-central-1
-  - me-central-1
-  - me-south-1
+  - <OPT_IN_AWS_REGION>  # e.g., "af-south-1"

--- a/examples/templates/integrations/github_webhook_relay_destination/config.yml
+++ b/examples/templates/integrations/github_webhook_relay_destination/config.yml
@@ -1,14 +1,14 @@
 ---
 reader_config:
-  role_name: forge-github-webhook-relay-secret-reader
+  role_name: <READER_ROLE_NAME>                 # e.g., forge-github-webhook-relay-secret-reader
   role_trust_principals:
-    - arn:aws:iam::123456789012:root
+    - <ROLE_TRUST_PRINCIPAL_ARN>                # e.g., arn:aws:iam::123456789012:root
   source_secret_role_arn: ''
   enable_secret_fetch: false
   source_secret_arn: ''
-  source_secret_region: eu-west-1
+  source_secret_region: <SOURCE_SECRET_REGION>  # e.g., eu-west-1
 webhook_relay_destination_config:
-  name_prefix: forge-webhook-relay-destination
-  destination_event_bus_name: forge-webhook-relay-destination
-  source_account_id: '123456789012'
+  name_prefix: <NAME_PREFIX>                                # e.g., forge-webhook-relay-destination
+  destination_event_bus_name: <DESTINATION_EVENT_BUS_NAME>  # e.g., forge-webhook-relay-destination
+  source_account_id: <SOURCE_ACCOUNT_ID>                    # e.g., "123456789012"
   targets: []

--- a/examples/templates/integrations/github_webhook_relay_destination_receivers/config.yml
+++ b/examples/templates/integrations/github_webhook_relay_destination_receivers/config.yml
@@ -1,13 +1,14 @@
 ---
+reader_role_name: <READER_ROLE_NAME>           # e.g., forge-github-webhook-relay-secret-reader-with-receivers
 reader_config:
   enable_secret_fetch: false
   source_secret_role_arn: ''
   source_secret_arn: ''
-  source_secret_region: eu-west-1
+  source_secret_region: <SOURCE_SECRET_REGION>  # e.g., eu-west-1
 webhook_relay_destination_config:
-  name_prefix: forge-webhook-relay-receivers
-  destination_event_bus_name: forge-webhook-relay-receivers
-  source_account_id: '123456789012'
+  name_prefix: <NAME_PREFIX>                                # e.g., forge-webhook-relay-receivers
+  destination_event_bus_name: <DESTINATION_EVENT_BUS_NAME>  # e.g., forge-webhook-relay-receivers
+  source_account_id: <SOURCE_ACCOUNT_ID>                    # e.g., "123456789012"
 enable_webex_webhook_relay: false
 logging_retention_in_days: 3
 log_level: INFO

--- a/examples/templates/integrations/splunk_aws_billing/config.yml
+++ b/examples/templates/integrations/splunk_aws_billing/config.yml
@@ -1,7 +1,7 @@
 ---
 splunk_aws_billing_config:
-  splunk_hec_url: https://http-inputs-example.splunkcloud.com:443/services/collector
-  splunk_index: forge-billing
-  splunk_metrics_url: https://ingest.us0.signalfx.com/v2/datapoint
+  splunk_hec_url: <SPLUNK_HEC_URL>          # e.g., https://http-inputs-example.splunkcloud.com:443/services/collector
+  splunk_index: <SPLUNK_INDEX>              # e.g., forge-billing
+  splunk_metrics_url: <SPLUNK_METRICS_URL>  # e.g., https://ingest.us0.signalfx.com/v2/datapoint
 logging_retention_in_days: 3
 log_level: INFO

--- a/examples/templates/integrations/splunk_cloud_s3_runner_logs/config.yml
+++ b/examples/templates/integrations/splunk_cloud_s3_runner_logs/config.yml
@@ -1,4 +1,4 @@
 ---
-splunk_hec_endpoint: https://http-inputs-example.splunkcloud.com:443/services/collector
+splunk_hec_endpoint: <SPLUNK_HEC_ENDPOINT>  # e.g., https://http-inputs-example.splunkcloud.com:443/services/collector
 logging_retention_in_days: 3
 log_level: INFO

--- a/examples/templates/integrations/splunk_o11y_conf_shared/config.yml
+++ b/examples/templates/integrations/splunk_o11y_conf_shared/config.yml
@@ -1,32 +1,40 @@
 ---
-splunk_api_url: https://api.us0.signalfx.com
-splunk_organization_id: EXAMPLEORG
-team: example-team
+splunk_api_url: <SPLUNK_API_URL>                    # e.g., https://api.us0.signalfx.com
+splunk_organization_id: <SPLUNK_ORGANIZATION_ID>    # e.g., EXAMPLEORG
+team: <TEAM_NAME>                                   # e.g., example-team
 detector_notifications: []
 detector_name_prefix: ForgeCICD
 dashboard_group_name: ForgeCICD Dashboards
 dashboard_variables:
   runner_k8s:
-    tenant_names: [acme]
+    tenant_names:
+      - <TENANT_NAME>  # e.g., acme
     dynamic_variables: []
   runner_ec2:
-    tenant_names: [acme]
+    tenant_names:
+      - <TENANT_NAME>  # e.g., acme
     dynamic_variables: []
   billing:
-    tenant_names: [acme]
+    tenant_names:
+      - <TENANT_NAME>  # e.g., acme
     dynamic_variables: []
   sqs:
-    tenant_names: [acme]
+    tenant_names:
+      - <TENANT_NAME>  # e.g., acme
     dynamic_variables: []
   ebs:
-    tenant_names: [acme]
+    tenant_names:
+      - <TENANT_NAME>  # e.g., acme
     dynamic_variables: []
   lambda:
-    tenant_names: [acme]
+    tenant_names:
+      - <TENANT_NAME>  # e.g., acme
     dynamic_variables: []
   dynamodb:
-    tenant_names: [acme]
+    tenant_names:
+      - <TENANT_NAME>  # e.g., acme
     dynamic_variables: []
   forge_impact:
-    tenant_names: [acme]
+    tenant_names:
+      - <TENANT_NAME>  # e.g., acme
     dynamic_variables: []

--- a/examples/templates/integrations/splunk_stuck_workflow_job_dispatcher/config.yml
+++ b/examples/templates/integrations/splunk_stuck_workflow_job_dispatcher/config.yml
@@ -1,25 +1,27 @@
 ---
-name_prefix: forge-stuck-workflow-job-dispatcher
+name_prefix: <NAME_PREFIX>  # e.g., forge-stuck-workflow-job-dispatcher
 logging_retention_in_days: 3
 log_level: INFO
 splunk_conf:
-  splunk_cloud: example-org.splunkcloud.com
-  tenant_names: [acme]
+  splunk_cloud: <SPLUNK_CLOUD_HOSTNAME>  # e.g., example-org.splunkcloud.com
+  tenant_names:
+    - <TENANT_NAME>                      # e.g., acme
   acl:
-    app: search
-    owner: forge-generic-user
-    sharing: global
+    app: <SPLUNK_APP>                    # e.g., search
+    owner: <SPLUNK_OWNER>                # e.g., forge-generic-user
+    sharing: <SPLUNK_SHARING_MODE>       # e.g., global
     read: ['*']
-    write: [forge-generic-user-role]
-  index: forge-index
+    write:
+      - <SPLUNK_WRITE_ROLE>              # e.g., forge-generic-user-role
+  index: <SPLUNK_INDEX>                  # e.g., forge-index
 redelivery_config:
   tenant_configs:
-    - tenant: acme
+    - tenant: <TENANT_NAME>              # e.g., acme
       gh_config:
         ghes_url: ''
       prefixes:
-        - aws_region: eu-west-1
-          deployment_prefix: acme
+        - aws_region: <AWS_REGION>       # e.g., eu-west-1
+          deployment_prefix: <DEPLOYMENT_PREFIX>  # e.g., acme
 splunk_alert:
   disabled: true
 dedupe_ttl_seconds: 1800

--- a/examples/templates/integrations/teleport/config.yml
+++ b/examples/templates/integrations/teleport/config.yml
@@ -1,6 +1,6 @@
 ---
 tenants:
-  - acme
+  - <TENANT_NAME>  # e.g., acme
 teleport_config:
-  cluster_name: forge-euw1-prod
-  teleport_iam_role_to_assume: arn:aws:iam::123456789012:role/teleport-access
+  cluster_name: <CLUSTER_NAME>                              # e.g., forge-euw1-prod
+  teleport_iam_role_to_assume: <TELEPORT_IAM_ROLE_TO_ASSUME>  # e.g., arn:aws:iam::123456789012:role/teleport-access

--- a/modules/integrations/github_webhook_relay_destination_receivers/main.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/main.tf
@@ -14,7 +14,7 @@ module "webhook_relay_destination" {
   aws_region  = var.aws_region
 
   reader_config = {
-    role_name = "forge-github-webhook-relay-secret-reader"
+    role_name = var.reader_role_name
     role_trust_principals = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
     ]

--- a/modules/integrations/github_webhook_relay_destination_receivers/variables.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/variables.tf
@@ -28,6 +28,12 @@ variable "reader_config" {
   })
 }
 
+variable "reader_role_name" {
+  description = "IAM role name used by the destination reader to fetch secrets."
+  type        = string
+  default     = "forge-github-webhook-relay-secret-reader"
+}
+
 variable "webhook_relay_destination_config" {
   description = "Configuration for webhook relay destination."
   type = object({


### PR DESCRIPTION
## Description

Standardizes the remaining example templates so deploy-specific values are represented as named placeholders with inline examples. This covers helper and integration configs for AMI sharing, opt-in regions, webhook relay destinations, Splunk configs, and Teleport.

Also makes the GitHub webhook relay destination receivers example carry its own `reader_role_name`, and wires the module to use that configurable value.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Examples/template cleanup

## Testing

- `yq eval` on the changed template YAML files
- `git diff --check`
- Commit hooks from `git commit` passed, including YAML formatting/linting, Terragrunt/OpenTofu/Terraform formatting and validation, tflint, gitleaks, and ansible-lint
