### PR TITLE
chore(examples): move splunk cloud shared config

### DIFF
--- a/examples/deployments/integrations/terragrunt/_global_settings/splunk_cloud_conf_shared.hcl
+++ b/examples/deployments/integrations/terragrunt/_global_settings/splunk_cloud_conf_shared.hcl
@@ -14,6 +14,9 @@ locals {
   default_aws_region  = local.env_data.locals.default_aws_region
   default_aws_profile = local.env_data.locals.default_aws_profile
 
+  config_data = read_terragrunt_config(find_in_parent_folders("splunk_cloud_conf_shared/config.hcl"))
+  config      = local.config_data.locals.config
+
   # ─────────────────────────────────────────────────────────────────────────────
   # Tags
   # ─────────────────────────────────────────────────────────────────────────────
@@ -27,27 +30,11 @@ locals {
   }
 }
 
-inputs = {
+inputs = merge(local.config, {
   # Core Environment
   aws_profile = local.default_aws_profile
   aws_region  = local.default_aws_region
 
-  # Splunk Cloud Configuration
-  splunk_conf = {
-    splunk_cloud = "example-org.splunkcloud.com" # <REPLACE WITH YOUR VALUE>
-    tenant_names = ["acme"]                      # <REPLACE WITH YOUR VALUE>
-    acl = {
-      app     = "search_app_generic" # <REPLACE WITH YOUR VALUE>
-      owner   = "forge-generic-user" # <REPLACE WITH YOUR VALUE>
-      sharing = "global"             # <REPLACE WITH YOUR VALUE>
-      read    = ["*"]                # <REPLACE WITH YOUR VALUE>
-      write = [
-        "forge-generic-user-role" # <REPLACE WITH YOUR VALUE>
-      ]
-    }
-    index = "forge-index" # <REPLACE WITH YOUR VALUE>
-  }
-
   # Misc
   default_tags = local.default_tags
-}
+})

--- a/examples/deployments/integrations/terragrunt/environments/prod/splunk_cloud_conf_shared/config.hcl
+++ b/examples/deployments/integrations/terragrunt/environments/prod/splunk_cloud_conf_shared/config.hcl
@@ -1,0 +1,3 @@
+locals {
+  config = yamldecode(file("config.yml"))
+}

--- a/examples/deployments/integrations/terragrunt/environments/prod/splunk_cloud_conf_shared/config.yml
+++ b/examples/deployments/integrations/terragrunt/environments/prod/splunk_cloud_conf_shared/config.yml
@@ -1,0 +1,14 @@
+---
+splunk_conf:
+  splunk_cloud: example-org.splunkcloud.com
+  tenant_names:
+    - acme
+  acl:
+    app: search_app_generic
+    owner: forge-generic-user
+    sharing: global
+    read:
+      - '*'
+    write:
+      - forge-generic-user-role
+  index: forge-index

--- a/examples/templates/integrations/splunk_cloud_conf_shared/config.yml
+++ b/examples/templates/integrations/splunk_cloud_conf_shared/config.yml
@@ -1,0 +1,14 @@
+---
+splunk_conf:
+  splunk_cloud: <SPLUNK_CLOUD_HOST>  # e.g., example-org.splunkcloud.com
+  tenant_names:
+    - <TENANT_NAME>  # e.g., acme
+  acl:
+    app: <SPLUNK_APP>                      # e.g., search_app_generic
+    owner: <SPLUNK_OWNER>                  # e.g., forge-generic-user
+    sharing: global
+    read:
+      - '*'
+    write:
+      - <SPLUNK_WRITE_ROLE>  # e.g., forge-generic-user-role
+  index: <SPLUNK_INDEX>      # e.g., forge-index


### PR DESCRIPTION
## Description

Moves the `splunk_cloud_conf_shared` example values out of `_global_settings` and into module-specific config files, matching the pattern used by the other integration examples.

This adds the prod example `config.hcl`/`config.yml` pair and the corresponding template `config.yml`, while `_global_settings/splunk_cloud_conf_shared.hcl` now reads and merges that config.

Split from PR #437 so the examples-only change can be reviewed independently.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: examples

## Testing

- `ANSIBLE_LOCAL_TEMP=/private/tmp/forge-ansible-local TMPDIR=/private/tmp pre-commit run --files examples/deployments/integrations/terragrunt/_global_settings/splunk_cloud_conf_shared.hcl examples/deployments/integrations/terragrunt/environments/prod/splunk_cloud_conf_shared/config.hcl examples/deployments/integrations/terragrunt/environments/prod/splunk_cloud_conf_shared/config.yml examples/templates/integrations/splunk_cloud_conf_shared/config.yml`
- `git diff --check`
