### PR TITLE
fix(splunk-billing): add log group dependencies

### DIFF
--- a/modules/integrations/splunk_aws_billing/billing_per_resource.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource.tf
@@ -53,6 +53,8 @@ module "cur_per_resource" {
   s3_object_tags      = var.default_tags
   s3_bucket           = aws_s3_bucket.aws_billing_report.id
   s3_prefix           = "lambda/billing_per_resource"
+
+  depends_on = [aws_cloudwatch_log_group.cur_per_resource]
 }
 
 resource "aws_lambda_permission" "cur_per_resource" {

--- a/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
@@ -53,6 +53,8 @@ module "cur_per_resource_process" {
   s3_object_tags      = var.default_tags
   s3_bucket           = aws_s3_bucket.aws_billing_report.id
   s3_prefix           = "lambda/billing_per_resource_process"
+
+  depends_on = [aws_cloudwatch_log_group.cur_per_resource_process]
 }
 
 resource "aws_lambda_permission" "cur_per_resource_process" {

--- a/modules/integrations/splunk_aws_billing/billing_per_service.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_service.tf
@@ -54,6 +54,8 @@ module "cur_per_service" {
   s3_object_tags      = var.default_tags
   s3_bucket           = aws_s3_bucket.aws_billing_report.id
   s3_prefix           = "lambda/billing_per_service"
+
+  depends_on = [aws_cloudwatch_log_group.cur_per_service]
 }
 
 resource "aws_lambda_permission" "cur_per_service" {


### PR DESCRIPTION
## Description

Adds explicit dependencies from the three Splunk AWS billing Lambda packaging modules to their matching CloudWatch log groups.

This keeps the Lambda module packaging/evaluation ordered after the log groups that each billing path owns:

- `cur_per_resource` waits for `aws_cloudwatch_log_group.cur_per_resource`
- `cur_per_resource_process` waits for `aws_cloudwatch_log_group.cur_per_resource_process`
- `cur_per_service` waits for `aws_cloudwatch_log_group.cur_per_service`

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- `tofu fmt -check modules/integrations/splunk_aws_billing/billing_per_resource.tf modules/integrations/splunk_aws_billing/billing_per_resource_process.tf modules/integrations/splunk_aws_billing/billing_per_service.tf`
- `tofu -chdir=modules/integrations/splunk_aws_billing init -backend=false -input=false -no-color`
- `SKIP=tofu-validate,terraform_tflint,terraform_validate ANSIBLE_LOCAL_TEMP=/private/tmp/forge-ansible-local TMPDIR=/private/tmp pre-commit run --files modules/integrations/splunk_aws_billing/billing_per_resource.tf modules/integrations/splunk_aws_billing/billing_per_resource_process.tf modules/integrations/splunk_aws_billing/billing_per_service.tf`
- `git diff --check`

Local provider-backed validation was attempted after `tofu init`, but the macOS runtime failed to start the downloaded AWS provider plugin before schema loading. CI should run the Linux provider-backed validation path.
