### PR TITLE
fix(splunk): suppress AWS billing export drift

### DIFF
--- a/modules/integrations/splunk_aws_billing/billing_per_resource.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource.tf
@@ -119,4 +119,20 @@ resource "aws_bcmdataexports_export" "cur_per_resource" {
     }
   }
   tags = local.all_security_tags
+
+  # AWS BCM Data Exports API silently injects BILLING_VIEW_ARN (and other keys
+  # like INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY) into the response, which the
+  # AWS provider then reports as drift. Suppress the diff until the upstream
+  # fix ships.
+  #
+  # NOTE: this does NOT prevent the initial-create failure caused by the same
+  # bug ("Provider produced inconsistent result after apply"). On first apply,
+  # the export is created in AWS but state save fails; recover with
+  # `tofu import aws_bcmdataexports_export.cur_per_resource <arn>` and re-apply.
+  #
+  # Remove this lifecycle block once hashicorp/terraform-provider-aws#48807
+  # is fixed (PR #48809) and the released provider is picked up in versions.tf.
+  lifecycle {
+    ignore_changes = [export[0].data_query[0].table_configurations]
+  }
 }

--- a/modules/integrations/splunk_aws_billing/billing_per_service.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_service.tf
@@ -119,4 +119,11 @@ resource "aws_bcmdataexports_export" "cur_per_service" {
     }
   }
   tags = local.all_security_tags
+
+  # See billing_per_resource.tf for the full explanation; same upstream bug
+  # (hashicorp/terraform-provider-aws#48807, PR #48809). Remove the lifecycle
+  # block once the provider fix ships and versions.tf pins to a fixed version.
+  lifecycle {
+    ignore_changes = [export[0].data_query[0].table_configurations]
+  }
 }


### PR DESCRIPTION
## Description

Suppresses recurring drift on the Splunk AWS billing BCM Data Exports resources.

AWS injects additional `table_configurations` keys, including `BILLING_VIEW_ARN`,
into the Data Exports API response. The AWS provider then reports those injected
fields as Terraform/OpenTofu drift even though Forge did not configure them.

This PR adds `lifecycle.ignore_changes` for `export[0].data_query[0].table_configurations`
on both billing exports:

- `aws_bcmdataexports_export.cur_per_resource`
- `aws_bcmdataexports_export.cur_per_service`

The comments keep the upstream provider issue context in the module and note the
manual import recovery path still needed for the initial-create provider
inconsistent-result bug.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ________

## Testing

- `tofu fmt -check modules/integrations/splunk_aws_billing`
- `git diff --check -- modules/integrations/splunk_aws_billing`
- Pre-commit hooks passed during commit, including Terraform/OpenTofu fmt,
  validation, tflint, gitleaks, and repository file hygiene checks.
