### PR TITLE
ci(tests): publish sticky test summaries

### DIFF
--- a/.github/workflows/iac-policy.yml
+++ b/.github/workflows/iac-policy.yml
@@ -16,6 +16,7 @@ on:
       - policy/**
       - tests/iac/**
       - tests/tofu/**
+      - scripts/ci_summary.py
       - pyproject.toml
       - uv.lock
       - .github/workflows/iac-policy.yml
@@ -30,6 +31,7 @@ on:
       - policy/**
       - tests/iac/**
       - tests/tofu/**
+      - scripts/ci_summary.py
       - pyproject.toml
       - uv.lock
       - .github/workflows/iac-policy.yml
@@ -47,6 +49,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -70,7 +74,22 @@ jobs:
 
       - name: Run offline IaC contract tests
         working-directory: tests
-        run: uv run --project .. --locked --only-group lambda-tests pytest -q iac
+        run: |
+          uv run --project .. --locked --only-group lambda-tests \
+            pytest -q iac --junitxml=iac-results.xml
+
+      - name: Write offline IaC contract summary
+        if: always()
+        working-directory: tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python ../scripts/ci_summary.py \
+            --title "Offline IaC contract tests" \
+            --junit "Offline IaC contracts=iac-results.xml" \
+            --coverage coverage.xml \
+            --output iac-contract-summary.md \
+            --comment-marker forge-ci-summary:offline-iac-contracts
 
   opentofu-tests:
     name: OpenTofu module tests (${{ matrix.opentofu.name }})
@@ -78,6 +97,8 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     env:
       TF_PLUGIN_CACHE_DIR: ${{ runner.temp }}/tofu-plugin-cache
     strategy:
@@ -197,14 +218,61 @@ jobs:
 
       - name: Run native OpenTofu tests
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENTOFU_NAME: ${{ matrix.opentofu.name }}
+          OPENTOFU_VERSION: ${{ steps.tofu-version.outputs.version }}
         run: |
           set -euo pipefail
 
+          summary_table="$(mktemp)"
+          failures=0
+          total=0
+
           while IFS= read -r module; do
             echo "::group::${module}"
-            tofu -chdir="${module}" test -no-color
+            total=$((total + 1))
+            log_file="${RUNNER_TEMP}/tofu-test-${total}.log"
+            if tofu -chdir="${module}" test -no-color > "${log_file}" 2>&1; then
+              result="passed"
+            else
+              result="failed"
+              failures=$((failures + 1))
+            fi
+            cat "${log_file}"
+            printf '| `%s` | %s |\n' "${module}" "${result}" >> "${summary_table}"
             echo "::endgroup::"
           done < .opentofu-test-modules
+
+          if (( failures == 0 )); then
+            result="passed"
+          else
+            result="failed"
+          fi
+
+          summary_file="opentofu-${OPENTOFU_NAME}-summary.md"
+          {
+            printf '## OpenTofu module tests (%s)\n\n' "${OPENTOFU_NAME}"
+            printf '**Result:** %s\n\n' "${result}"
+            printf '**OpenTofu version:** `%s`\n\n' "${OPENTOFU_VERSION}"
+            printf '| Metric | Count |\n'
+            printf '| --- | ---: |\n'
+            printf '| Passed modules | %s |\n' "$((total - failures))"
+            printf '| Failed modules | %s |\n' "${failures}"
+            printf '| Total modules | %s |\n\n' "${total}"
+            printf '| Module | Result |\n'
+            printf '| --- | --- |\n'
+            cat "${summary_table}"
+            printf '\n'
+          } > "${summary_file}"
+
+          python scripts/ci_summary.py \
+            --title "OpenTofu module tests (${OPENTOFU_NAME})" \
+            --input-markdown "${summary_file}" \
+            --output "${summary_file}" \
+            --comment-marker "forge-ci-summary:opentofu-${OPENTOFU_NAME}"
+
+          (( failures == 0 ))
 
   opa-policy:
     name: OPA/conftest tenant-isolation gate
@@ -212,6 +280,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -234,7 +304,36 @@ jobs:
           conftest --version
 
       - name: Verify policy logic (hard gate)
+        id: conftest-verify
         run: conftest verify --policy policy/opa
+
+      - name: Write OPA policy summary
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          VERIFY_OUTCOME: ${{ steps.conftest-verify.outcome }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${VERIFY_OUTCOME}" == "success" ]]; then
+            result="passed"
+          else
+            result="failed"
+          fi
+
+          {
+            printf '## OPA/conftest tenant-isolation gate\n\n'
+            printf '**Result:** %s\n\n' "${result}"
+            printf '| Gate | Result |\n'
+            printf '| --- | --- |\n'
+            printf '| `conftest verify --policy policy/opa` | %s |\n\n' "${result}"
+          } > opa-policy-summary.md
+
+          python scripts/ci_summary.py \
+            --title "OPA/conftest tenant-isolation gate" \
+            --input-markdown opa-policy-summary.md \
+            --output opa-policy-summary.md \
+            --comment-marker forge-ci-summary:opa-policy
 
   checkov:
     name: Checkov IaC scan (informational)

--- a/.github/workflows/lambda-tests.yml
+++ b/.github/workflows/lambda-tests.yml
@@ -14,6 +14,7 @@ on:
       - tests/pytest.ini
       - tests/lambdas/**
       - tests/support/**
+      - scripts/ci_summary.py
       - pyproject.toml
       - uv.lock
       - .github/workflows/lambda-tests.yml
@@ -26,6 +27,7 @@ on:
       - tests/pytest.ini
       - tests/lambdas/**
       - tests/support/**
+      - scripts/ci_summary.py
       - pyproject.toml
       - uv.lock
       - .github/workflows/lambda-tests.yml
@@ -43,6 +45,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -72,91 +76,15 @@ jobs:
       - name: Write unit test summary
         if: always()
         working-directory: tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          python - <<'PY'
-          import os
-          import xml.etree.ElementTree as ET
-          from pathlib import Path
-
-          summary_path = Path(os.environ['GITHUB_STEP_SUMMARY'])
-          lines = ['## Lambda unit tests', '']
-
-          junit_path = Path('pytest-results.xml')
-          if junit_path.exists():
-              root = ET.parse(junit_path).getroot()
-              suites = [root] if root.tag == 'testsuite' else root.findall('testsuite')
-              tests = sum(int(suite.get('tests', 0)) for suite in suites)
-              failures = sum(int(suite.get('failures', 0)) for suite in suites)
-              errors = sum(int(suite.get('errors', 0)) for suite in suites)
-              skipped = sum(int(suite.get('skipped', 0)) for suite in suites)
-              duration = sum(float(suite.get('time', 0.0)) for suite in suites)
-              passed = tests - failures - errors - skipped
-              result = 'passed' if failures == 0 and errors == 0 else 'failed'
-
-              lines.extend([
-                  f'**Result:** {result}',
-                  '',
-                  '| Metric | Count |',
-                  '| --- | ---: |',
-                  f'| Passed | {passed} |',
-                  f'| Failed | {failures} |',
-                  f'| Errors | {errors} |',
-                  f'| Skipped | {skipped} |',
-                  f'| Total | {tests} |',
-                  f'| Duration | {duration:.2f}s |',
-                  '',
-              ])
-          else:
-              lines.extend([
-                  '**Result:** pytest results were not generated.',
-                  '',
-              ])
-
-          coverage_path = Path('coverage.xml')
-          if coverage_path.exists():
-              root = ET.parse(coverage_path).getroot()
-              line_rate = float(root.get('line-rate', 0.0)) * 100
-              lines_covered = int(root.get('lines-covered', 0))
-              lines_valid = int(root.get('lines-valid', 0))
-              lines.extend([
-                  f'**Coverage:** {line_rate:.2f}% ({lines_covered}/{lines_valid} lines)',
-                  '',
-                  '### Lowest-covered Lambda files',
-                  '',
-                  '| File | Coverage | Missed lines |',
-                  '| --- | ---: | ---: |',
-              ])
-
-              files = []
-              for class_node in root.findall('.//class'):
-                  filename = class_node.get('filename', '')
-                  if '/modules/' in filename:
-                      display_filename = 'modules/' + filename.split('/modules/', 1)[1]
-                  else:
-                      display_filename = filename
-                  if not display_filename.startswith('modules/') or '/lambda/' not in display_filename:
-                      continue
-                  line_nodes = class_node.findall('lines/line')
-                  valid = len(line_nodes)
-                  if valid == 0:
-                      continue
-                  covered = sum(1 for line in line_nodes if int(line.get('hits', 0)) > 0)
-                  rate = covered / valid
-                  files.append((rate, valid - covered, display_filename))
-
-              for rate, missed, filename in sorted(files)[:8]:
-                  lines.append(f'| `{filename}` | {rate * 100:.2f}% | {missed} |')
-              lines.append('')
-          else:
-              lines.extend([
-                  '**Coverage:** coverage.xml was not generated.',
-                  '',
-              ])
-
-          with summary_path.open('a', encoding='utf-8') as summary:
-              summary.write('\n'.join(lines))
-              summary.write('\n')
-          PY
+          python ../scripts/ci_summary.py \
+            --title "Lambda unit tests" \
+            --junit "Lambda unit tests=pytest-results.xml" \
+            --coverage coverage.xml \
+            --output lambda-test-summary.md \
+            --comment-marker forge-ci-summary:lambda-unit-tests
 
       - name: Upload coverage
         if: always()
@@ -166,4 +94,5 @@ jobs:
           path: |
             tests/coverage.xml
             tests/pytest-results.xml
+            tests/lambda-test-summary.md
           if-no-files-found: ignore

--- a/.github/workflows/ministack-smoke.yml
+++ b/.github/workflows/ministack-smoke.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - modules/**/lambda/**
       - tests/smoke/**
+      - scripts/ci_summary.py
       - .github/workflows/ministack-smoke.yml
   push:
     branches:
@@ -19,6 +20,7 @@ on:
     paths:
       - modules/**/lambda/**
       - tests/smoke/**
+      - scripts/ci_summary.py
       - .github/workflows/ministack-smoke.yml
 
 permissions: {}
@@ -34,6 +36,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     env:
       AWS_ENDPOINT_URL: http://localhost:4566
       AWS_DEFAULT_REGION: us-east-1
@@ -71,11 +75,28 @@ jobs:
 
       - name: Smoke plumbing tests
         working-directory: tests/smoke
-        run: uv run --project ../.. --locked --only-group smoke-tests pytest -m smoke -q
+        run: |
+          uv run --project ../.. --locked --only-group smoke-tests \
+            pytest -m smoke -q --junitxml=smoke-results.xml
 
       - name: Real-handler lambda execution
         working-directory: tests/smoke
-        run: uv run --project ../.. --locked --only-group smoke-tests pytest -m lambda_exec -q
+        run: |
+          uv run --project ../.. --locked --only-group smoke-tests \
+            pytest -m lambda_exec -q --junitxml=lambda-exec-results.xml
+
+      - name: Write MiniStack smoke summary
+        if: always()
+        working-directory: tests/smoke
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python ../../scripts/ci_summary.py \
+            --title "MiniStack smoke + real-handler exec" \
+            --junit "Smoke plumbing tests=smoke-results.xml" \
+            --junit "Real-handler lambda execution=lambda-exec-results.xml" \
+            --output ministack-smoke-summary.md \
+            --comment-marker forge-ci-summary:ministack-smoke
 
       - name: MiniStack logs (on failure)
         if: failure()

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -13,6 +13,7 @@ on:
       - modules/**/*.tf
       - modules/**/*.tftest.hcl
       - tests/**
+      - scripts/ci_summary.py
       - .docker/pre-commit/Dockerfile
       - .docker/forge-github-app-register/Dockerfile
       - .github/dependabot.yml
@@ -35,6 +36,7 @@ on:
       - modules/**/*.tf
       - modules/**/*.tftest.hcl
       - tests/**
+      - scripts/ci_summary.py
       - .docker/pre-commit/Dockerfile
       - .docker/forge-github-app-register/Dockerfile
       - .github/dependabot.yml
@@ -63,6 +65,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -86,7 +90,22 @@ jobs:
 
       - name: Run automation gate tests
         working-directory: tests
-        run: uv run --project .. --locked --only-group lambda-tests pytest -q quality
+        run: |
+          uv run --project .. --locked --only-group lambda-tests \
+            pytest -q quality --junitxml=quality-results.xml
+
+      - name: Write automation gate summary
+        if: always()
+        working-directory: tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python ../scripts/ci_summary.py \
+            --title "Automation gate tests" \
+            --junit "Automation gate tests=quality-results.xml" \
+            --coverage coverage.xml \
+            --output quality-test-summary.md \
+            --comment-marker forge-ci-summary:automation-gates
 
   mutation:
     name: Mutation test critical Lambda boundaries
@@ -94,6 +113,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -119,4 +140,17 @@ jobs:
         working-directory: tests
         run: |
           uv run --project .. --locked --only-group lambda-tests \
-            pytest -q mutation
+            pytest -q mutation --junitxml=mutation-results.xml
+
+      - name: Write mutation test summary
+        if: always()
+        working-directory: tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python ../scripts/ci_summary.py \
+            --title "Mutation test critical Lambda boundaries" \
+            --junit "Mutation tests=mutation-results.xml" \
+            --coverage coverage.xml \
+            --output mutation-test-summary.md \
+            --comment-marker forge-ci-summary:mutation

--- a/scripts/ci_summary.py
+++ b/scripts/ci_summary.py
@@ -1,0 +1,303 @@
+"""Write deterministic CI test summaries for GitHub Actions.
+
+The workflows use this after test commands emit result files. It writes the same
+Markdown to the job summary, to a local summary file, and to a sticky PR comment
+identified by a hidden marker.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class JunitSummary:
+    label: str
+    tests: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+    duration: float = 0.0
+    missing: bool = False
+    parse_error: str | None = None
+
+    @property
+    def passed(self) -> int:
+        return self.tests - self.failures - self.errors - self.skipped
+
+    @property
+    def result(self) -> str:
+        if self.missing:
+            return 'missing'
+        if self.parse_error:
+            return 'invalid'
+        if self.failures or self.errors:
+            return 'failed'
+        return 'passed'
+
+
+def md_escape(value: str) -> str:
+    return value.replace('|', '\\|').replace('\n', ' ')
+
+
+def parse_junit_arg(value: str) -> tuple[str, Path]:
+    if '=' in value:
+        label, path = value.split('=', 1)
+        return label.strip() or Path(path).stem, Path(path)
+    path = Path(value)
+    return path.stem, path
+
+
+def summarize_junit(label: str, path: Path) -> JunitSummary:
+    if not path.exists():
+        return JunitSummary(label=label, missing=True)
+
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        return JunitSummary(label=label, parse_error=str(exc))
+
+    suites = list(root.iter('testsuite'))
+    if not suites and root.tag == 'testsuite':
+        suites = [root]
+
+    return JunitSummary(
+        label=label,
+        tests=sum(int(suite.get('tests', 0)) for suite in suites),
+        failures=sum(int(suite.get('failures', 0)) for suite in suites),
+        errors=sum(int(suite.get('errors', 0)) for suite in suites),
+        skipped=sum(int(suite.get('skipped', 0)) for suite in suites),
+        duration=sum(float(suite.get('time', 0.0)) for suite in suites),
+    )
+
+
+def add_coverage(lines: list[str], coverage_path: Path) -> None:
+    if not coverage_path.exists():
+        lines.extend(['**Coverage:** coverage.xml was not generated.', ''])
+        return
+
+    try:
+        root = ET.parse(coverage_path).getroot()
+    except ET.ParseError as exc:
+        lines.extend(
+            [f"**Coverage:** coverage.xml is invalid: `{md_escape(str(exc))}`", ''])
+        return
+
+    line_rate = float(root.get('line-rate', 0.0)) * 100
+    lines_covered = int(root.get('lines-covered', 0))
+    lines_valid = int(root.get('lines-valid', 0))
+    lines.extend(
+        [
+            f"**Coverage:** {line_rate:.2f}% ({lines_covered}/{lines_valid} lines)",
+            '',
+            '### Lowest-covered Lambda files',
+            '',
+            '| File | Coverage | Missed lines |',
+            '| --- | ---: | ---: |',
+        ]
+    )
+
+    files = []
+    for class_node in root.findall('.//class'):
+        filename = class_node.get('filename', '')
+        if '/modules/' in filename:
+            display_filename = 'modules/' + filename.split('/modules/', 1)[1]
+        else:
+            display_filename = filename
+        if not display_filename.startswith('modules/') or '/lambda/' not in display_filename:
+            continue
+        line_nodes = class_node.findall('lines/line')
+        valid = len(line_nodes)
+        if valid == 0:
+            continue
+        covered = sum(1 for line in line_nodes if int(line.get('hits', 0)) > 0)
+        files.append((covered / valid, valid - covered, display_filename))
+
+    for rate, missed, filename in sorted(files)[:8]:
+        lines.append(
+            f"| `{md_escape(filename)}` | {rate * 100:.2f}% | {missed} |")
+    lines.append('')
+
+
+def slugify(value: str) -> str:
+    return re.sub(r'[^a-z0-9]+', '-', value.lower()).strip('-') or 'test-summary'
+
+
+def build_summary(args: argparse.Namespace) -> str:
+    if args.input_markdown:
+        return Path(args.input_markdown).read_text(encoding='utf-8').rstrip() + '\n'
+
+    summaries = [summarize_junit(*parse_junit_arg(value))
+                 for value in args.junit]
+    result = 'passed'
+    if any(summary.result in {'failed', 'invalid'} for summary in summaries):
+        result = 'failed'
+    elif any(summary.result == 'missing' for summary in summaries):
+        result = 'incomplete'
+
+    lines = [f"## {args.title}", '', f"**Result:** {result}", '']
+    if summaries:
+        lines.extend(
+            [
+                '| Suite | Passed | Failed | Errors | Skipped | Total | Duration | Result |',
+                '| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |',
+            ]
+        )
+        for summary in summaries:
+            lines.append(
+                '| '
+                f"{md_escape(summary.label)} | "
+                f"{summary.passed} | "
+                f"{summary.failures} | "
+                f"{summary.errors} | "
+                f"{summary.skipped} | "
+                f"{summary.tests} | "
+                f"{summary.duration:.2f}s | "
+                f"{summary.result} |"
+            )
+        lines.append('')
+
+    missing = [summary.label for summary in summaries if summary.missing]
+    if missing:
+        missing_list = ', '.join(f"`{md_escape(label)}`" for label in missing)
+        lines.extend(
+            [
+                f"**Missing result files:** {missing_list}",
+                '',
+            ]
+        )
+
+    parse_errors = [summary for summary in summaries if summary.parse_error]
+    for summary in parse_errors:
+        lines.extend(
+            [
+                f"**Invalid JUnit XML for `{md_escape(summary.label)}`:** "
+                f"`{md_escape(summary.parse_error or '')}`",
+                '',
+            ]
+        )
+
+    if args.coverage:
+        add_coverage(lines, Path(args.coverage))
+
+    return '\n'.join(lines).rstrip() + '\n'
+
+
+def github_json(method: str, url: str, token: str, data: dict | None = None) -> tuple[object, str | None]:
+    body = None if data is None else json.dumps(data).encode('utf-8')
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method=method,
+        headers={
+            'Accept': 'application/vnd.github+json',
+            'Authorization': f"Bearer {token}",
+            'Content-Type': 'application/json',
+            'X-GitHub-Api-Version': '2022-11-28',
+        },
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        payload = response.read()
+        link = response.headers.get('Link')
+    if not payload:
+        return {}, link
+    return json.loads(payload), link
+
+
+def next_link(link_header: str | None) -> str | None:
+    if not link_header:
+        return None
+    for part in link_header.split(','):
+        if 'rel="next"' not in part:
+            continue
+        match = re.search(r'<([^>]+)>', part)
+        if match:
+            return match.group(1)
+    return None
+
+
+def pull_request_number() -> int | None:
+    event_path = os.environ.get('GITHUB_EVENT_PATH')
+    if not event_path:
+        return None
+    event = json.loads(Path(event_path).read_text(encoding='utf-8'))
+    pull_request = event.get('pull_request') or {}
+    number = pull_request.get('number')
+    return int(number) if number else None
+
+
+def upsert_pr_comment(marker: str, markdown: str) -> None:
+    token = os.environ.get('GITHUB_TOKEN')
+    repository = os.environ.get('GITHUB_REPOSITORY')
+    api_url = os.environ.get('GITHUB_API_URL', 'https://api.github.com')
+    pr_number = pull_request_number()
+
+    if not token or not repository or pr_number is None:
+        print(
+            'Skipping PR comment: not running in a pull_request context.', file=sys.stderr)
+        return
+
+    marker_line = f"<!-- {marker} -->"
+    body = f"{marker_line}\n{markdown}"
+    comments_url = f"{api_url}/repos/{repository}/issues/{pr_number}/comments?per_page=100"
+
+    try:
+        while comments_url:
+            comments, link = github_json('GET', comments_url, token)
+            for comment in comments:
+                if marker_line not in str(comment.get('body', '')):
+                    continue
+                github_json(
+                    'PATCH',
+                    f"{api_url}/repos/{repository}/issues/comments/{comment['id']}",
+                    token,
+                    {'body': body},
+                )
+                print(f"Updated PR summary comment for {marker}.")
+                return
+            comments_url = next_link(link)
+
+        github_json(
+            'POST',
+            f"{api_url}/repos/{repository}/issues/{pr_number}/comments",
+            token,
+            {'body': body},
+        )
+        print(f"Created PR summary comment for {marker}.")
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as exc:
+        print(
+            f"Warning: failed to upsert PR summary comment for {marker}: {exc}", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--title', required=True)
+    parser.add_argument('--input-markdown')
+    parser.add_argument('--junit', action='append', default=[])
+    parser.add_argument('--coverage')
+    parser.add_argument('--output')
+    parser.add_argument('--comment-marker')
+    args = parser.parse_args()
+
+    markdown = build_summary(args)
+    output_path = Path(args.output or f"{slugify(args.title)}.md")
+    output_path.write_text(markdown, encoding='utf-8')
+
+    summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
+    if summary_path:
+        with Path(summary_path).open('a', encoding='utf-8') as summary_file:
+            summary_file.write(markdown)
+
+    if args.comment_marker:
+        upsert_pr_comment(args.comment_marker, markdown)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/quality/ci_summary_test.py
+++ b/tests/quality/ci_summary_test.py
@@ -1,0 +1,83 @@
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SUMMARY_MODULE_PATH = Path(__file__).resolve(
+).parents[2] / 'scripts' / 'ci_summary.py'
+SUMMARY_SPEC = importlib.util.spec_from_file_location(
+    'forge_ci_summary', SUMMARY_MODULE_PATH)
+ci_summary = importlib.util.module_from_spec(SUMMARY_SPEC)
+sys.modules[SUMMARY_SPEC.name] = ci_summary
+SUMMARY_SPEC.loader.exec_module(ci_summary)
+
+
+def test_build_summary_counts_junit_results(tmp_path: Path) -> None:
+    junit = tmp_path / 'pytest-results.xml'
+    junit.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="4" failures="1" errors="0" skipped="1" time="1.25" />
+</testsuites>
+""",
+        encoding='utf-8',
+    )
+
+    markdown = ci_summary.build_summary(
+        argparse.Namespace(
+            title='Example tests',
+            input_markdown=None,
+            junit=[f"Example={junit}"],
+            coverage=None,
+        )
+    )
+
+    assert '**Result:** failed' in markdown
+    assert '| Example | 2 | 1 | 0 | 1 | 4 | 1.25s | failed |' in markdown
+
+
+def test_upsert_pr_comment_updates_existing_marker(
+    monkeypatch, tmp_path: Path
+) -> None:
+    event = tmp_path / 'event.json'
+    event.write_text(json.dumps(
+        {'pull_request': {'number': 437}}), encoding='utf-8')
+
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(event))
+    monkeypatch.setenv('GITHUB_TOKEN', 'token')
+    monkeypatch.setenv('GITHUB_REPOSITORY', 'cisco-open/forge')
+    monkeypatch.setenv('GITHUB_API_URL', 'https://api.github.test')
+
+    calls = []
+
+    class Response:
+        headers = {'Link': None}
+
+        def __init__(self, payload):
+            self.payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return json.dumps(self.payload).encode('utf-8')
+
+    def fake_urlopen(request, timeout):
+        calls.append((request.get_method(), request.full_url, request.data))
+        if request.get_method() == 'GET':
+            return Response([{'id': 123, 'body': '<!-- forge-ci-summary:test -->\nold'}])
+        if request.get_method() == 'PATCH':
+            return Response({})
+        raise AssertionError(f"unexpected method {request.get_method()}")
+
+    monkeypatch.setattr(ci_summary.urllib.request, 'urlopen', fake_urlopen)
+
+    ci_summary.upsert_pr_comment('forge-ci-summary:test', '## Updated\n')
+
+    assert [call[0] for call in calls] == ['GET', 'PATCH']
+    assert calls[1][1] == 'https://api.github.test/repos/cisco-open/forge/issues/comments/123'
+    assert b'## Updated' in calls[1][2]


### PR DESCRIPTION
## Description

Adds CI summaries for the Forge test workflows as a follow-up stacked on PR #437.

This adds `scripts/ci_summary.py`, a small standard-library helper that:

- parses pytest JUnit XML and optional coverage XML,
- writes Markdown to `$GITHUB_STEP_SUMMARY`,
- writes the same Markdown to a local summary file,
- upserts a sticky PR comment using a hidden marker.

The sticky markers make reruns and later commits update the existing suite
comment instead of creating a new comment each time.

Updated workflows:

- Lambda unit tests
- IaC policy: offline IaC contracts, OpenTofu module tests, OPA/conftest gate
- Quality gates: automation and mutation tests
- MiniStack smoke and real-handler lambda execution

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: CI test summaries

## Testing

- `pre-commit run --files .github/workflows/iac-policy.yml .github/workflows/lambda-tests.yml .github/workflows/ministack-smoke.yml .github/workflows/quality-gates.yml scripts/ci_summary.py tests/quality/ci_summary_test.py`
- `python3 -m py_compile scripts/ci_summary.py tests/quality/ci_summary_test.py`
- `python3 scripts/ci_summary.py --title "Example summary" --junit Example=/private/tmp/missing-junit.xml --output /private/tmp/example-summary-after-move.md --comment-marker forge-ci-summary:example`

Local focused pytest was not run because this host has no `pytest` in the
default Python and `uv` is not installed on PATH. CI will run the new helper
test through the locked `lambda-tests` dependency group.
