### PR TITLE
fix(deps): update uv lockfile automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       - dependencies
       - github-actions
 
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directories:
       - /
     schedule:
@@ -84,6 +84,10 @@ updates:
       docker-dependencies:
         patterns:
           - '*'
+    ignore:
+      - dependency-name: ubuntu
+        update-types:
+          - version-update:semver-major
     labels:
       - dependencies
       - docker

--- a/docs/tenant-usage/dependency-management.md
+++ b/docs/tenant-usage/dependency-management.md
@@ -55,7 +55,7 @@ updates:
       - dependencies
       - docker
 
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly
@@ -81,7 +81,9 @@ updates:
 ```
 
 Remove ecosystems that do not exist in the repo. For monorepos, add one entry
-per directory that contains dependency files.
+per directory that contains dependency files. Use `uv` for repositories that
+commit `pyproject.toml` and `uv.lock`; use `pip` only for requirements-file
+projects.
 
 ______________________________________________________________________
 

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,9 @@
     "ignorePaths": [
         "**/.terraform/**"
     ],
+    "lockFileMaintenance": {
+        "enabled": true
+    },
     "customManagers": [
         {
             "customType": "regex",
@@ -193,11 +196,15 @@
         },
         {
             "description": "Python dependencies",
+            "matchManagers": [
+                "pep621"
+            ],
             "matchDatasources": [
                 "pypi"
             ],
             "matchFileNames": [
-                "pyproject.toml"
+                "pyproject.toml",
+                "uv.lock"
             ],
             "groupName": "Python dependencies",
             "groupSlug": "python-dependencies",

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -142,13 +142,16 @@ def test_github_app_register_image_uses_root_locked_dependencies() -> None:
     assert 'context: .' in workflow
     assert 'pyproject.toml' in workflow
     assert 'uv.lock' in workflow
-    pip_dependabot_block = dependabot.split(
-        '  - package-ecosystem: pip',
+    uv_dependabot_block = dependabot.split(
+        '  - package-ecosystem: uv',
         1,
     )[1].split('  - package-ecosystem: pre-commit', 1)[0]
-    assert '- /.docker/forge-github-app-register' not in pip_dependabot_block
+    assert '  - package-ecosystem: pip' not in dependabot
+    assert '- /.docker/forge-github-app-register' not in uv_dependabot_block
     assert '.docker/forge-github-app-register/requirements.txt' not in renovate
     assert 'requirements*.txt' not in renovate
+    assert 'uv.lock' in renovate
+    assert 'lockFileMaintenance' in renovate
 
 
 def test_test_suites_have_named_ci_jobs() -> None:


### PR DESCRIPTION
## Description

- Switch Dependabot Python dependency updates from `pip` to `uv` so root `pyproject.toml` updates are handled with the committed `uv.lock`.
- Enable Renovate lock file maintenance and scope the Python dependency rule to the PEP 621 manager across `pyproject.toml` and `uv.lock`.
- Update the automation gate and dependency-management guide to enforce and document the uv-backed setup.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: _________

## Testing

- `git diff --check -- .github/dependabot.yml renovate.json tests/quality/automation_gates_test.py docs/tenant-usage/dependency-management.md`
- `jq . renovate.json`
- `pre-commit run check-yaml --files .github/dependabot.yml`
- `pre-commit run yamllint --files .github/dependabot.yml`
- `pre-commit run check-dependabot --files .github/dependabot.yml`
- `pre-commit run check-renovate --files renovate.json`
- `renovate-config-validator renovate.json`
- `python3 -m py_compile tests/quality/automation_gates_test.py`
- `git commit` pre-commit hooks passed

Not run locally: `uv run --project . --locked --only-group lambda-tests pytest -q tests/quality/automation_gates_test.py` because `uv` is not installed on this host PATH.
