### PR TITLE
test(ci): improve Forge coverage gates

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -12,6 +12,7 @@ on:
       - modules/**/lambda/**
       - modules/**/*.tf
       - modules/**/*.tftest.hcl
+      - examples/**
       - tests/**
       - scripts/ci_summary.py
       - scripts/terragrunt-deps.py
@@ -36,6 +37,7 @@ on:
       - modules/**/lambda/**
       - modules/**/*.tf
       - modules/**/*.tftest.hcl
+      - examples/**
       - tests/**
       - scripts/ci_summary.py
       - scripts/terragrunt-deps.py

--- a/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_contract.tftest.hcl
+++ b/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_contract.tftest.hcl
@@ -24,6 +24,10 @@ run "platform_forge_runners_forge_trust_validator_contract" {
       "data \"aws_iam_policy_document\" \"forge_trust_preparer_lambda\"",
       "data \"aws_iam_policy_document\" \"forge_trust_validator_lambda\"",
     ]
+    forbidden_literals = [
+      "Principal = \"*\"",
+      "resources = [\"*\"]",
+    ]
   }
 
   assert {
@@ -34,5 +38,10 @@ run "platform_forge_runners_forge_trust_validator_contract" {
   assert {
     condition     = output.expected_literal_count > 0
     error_message = "Module contract must pin at least one module-specific literal."
+  }
+
+  assert {
+    condition     = length(output.present_forbidden_literals) == 0
+    error_message = "Module contract includes forbidden literals: ${join(", ", output.present_forbidden_literals)}"
   }
 }

--- a/modules/platform/forge_runners/github_actions_job_logs/tests/platform_forge_runners_github_actions_job_logs_contract.tftest.hcl
+++ b/modules/platform/forge_runners/github_actions_job_logs/tests/platform_forge_runners_github_actions_job_logs_contract.tftest.hcl
@@ -40,6 +40,10 @@ run "platform_forge_runners_github_actions_job_logs_contract" {
       "output \"s3_bucket_arn\"",
       "output \"internal_s3_reader_role_arn\"",
     ]
+    forbidden_literals = [
+      "Principal = \"*\"",
+      "resources = [\"*\"]",
+    ]
   }
 
   assert {
@@ -50,5 +54,10 @@ run "platform_forge_runners_github_actions_job_logs_contract" {
   assert {
     condition     = output.expected_literal_count > 0
     error_message = "Module contract must pin at least one module-specific literal."
+  }
+
+  assert {
+    condition     = length(output.present_forbidden_literals) == 0
+    error_message = "Module contract includes forbidden literals: ${join(", ", output.present_forbidden_literals)}"
   }
 }

--- a/modules/platform/forge_runners/github_webhook_relay/source/tests/platform_forge_runners_github_webhook_relay_source_contract.tftest.hcl
+++ b/modules/platform/forge_runners/github_webhook_relay/source/tests/platform_forge_runners_github_webhook_relay_source_contract.tftest.hcl
@@ -37,6 +37,12 @@ run "platform_forge_runners_github_webhook_relay_source_contract" {
       "output \"source_event_bus_arn\"",
       "output \"event_source\"",
     ]
+    forbidden_literals = [
+      "Principal = \"*\"",
+      "WEBHOOK_SECRET = \"\"",
+      "actions = [\"*\"]",
+      "resources = [\"*\"]",
+    ]
   }
 
   assert {
@@ -47,5 +53,10 @@ run "platform_forge_runners_github_webhook_relay_source_contract" {
   assert {
     condition     = output.expected_literal_count > 0
     error_message = "Module contract must pin at least one module-specific literal."
+  }
+
+  assert {
+    condition     = length(output.present_forbidden_literals) == 0
+    error_message = "Module contract includes forbidden literals: ${join(", ", output.present_forbidden_literals)}"
   }
 }

--- a/tests/quality/examples_contract_test.py
+++ b/tests/quality/examples_contract_test.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES = REPO_ROOT / 'examples'
+
+
+def release_module_blocks() -> dict[str, dict[str, str]]:
+    blocks: dict[str, dict[str, str]] = {}
+    for release_file in sorted(
+        (EXAMPLES / 'deployments').glob('*/release_versions.yml')
+    ):
+        current_key = ''
+        current_values: dict[str, str] = {}
+        for raw_line in release_file.read_text(encoding='utf-8').splitlines():
+            if raw_line.startswith('      ') and raw_line.endswith(':'):
+                if current_key:
+                    blocks[current_key] = current_values
+                current_key = raw_line.strip().removesuffix(':')
+                current_values = {'release_file': str(release_file)}
+                continue
+            if current_key and raw_line.startswith('        '):
+                key, sep, value = raw_line.strip().partition(':')
+                if sep:
+                    current_values[key] = value.strip()
+
+        if current_key:
+            blocks[current_key] = current_values
+
+    return blocks
+
+
+def template_module_key(template: Path) -> str:
+    family = template.relative_to(EXAMPLES / 'templates').parts[0]
+    name = template.parent.name
+    if family == 'platform' and name == 'tenant':
+        return 'forge_runners'
+    return name
+
+
+def test_release_versions_reference_existing_local_modules() -> None:
+    blocks = release_module_blocks()
+    assert blocks
+
+    for module_key, values in blocks.items():
+        module_path = values.get('module_path', '')
+        module_dir = REPO_ROOT / module_path
+        assert values.get('local_path') == '../forge', module_key
+        assert values.get('repo') == 'git@github.com:cisco-open/forge.git', (
+            module_key
+        )
+        assert values.get('ref') == 'main', module_key
+        assert module_path.startswith('modules/'), module_key
+        assert module_dir.is_dir(), module_key
+        assert any(module_dir.glob('*.tf')), module_key
+
+
+def test_config_templates_have_matching_release_version_entries() -> None:
+    blocks = release_module_blocks()
+    templates = sorted((EXAMPLES / 'templates').glob('*/*/config.yml'))
+    assert templates
+
+    missing = []
+    wrong_paths = []
+    for template in templates:
+        family = template.relative_to(EXAMPLES / 'templates').parts[0]
+        module_key = template_module_key(template)
+        block = blocks.get(module_key)
+        if block is None:
+            missing.append(str(template.relative_to(REPO_ROOT)))
+            continue
+
+        expected_path = (
+            'modules/platform/forge_runners'
+            if module_key == 'forge_runners'
+            else f'modules/{family}/{module_key}'
+        )
+        if block.get('module_path') != expected_path:
+            wrong_paths.append(
+                f'{module_key}: {block.get("module_path")} != {expected_path}'
+            )
+
+    assert missing == []
+    assert wrong_paths == []
+
+
+def test_platform_tenant_template_keeps_ec2_and_arc_runner_inputs() -> None:
+    template = (
+        EXAMPLES / 'templates' / 'platform' / 'tenant' / 'config.yml'
+    ).read_text(encoding='utf-8')
+    release = (
+        EXAMPLES / 'deployments' / 'platform' / 'release_versions.yml'
+    ).read_text(
+        encoding='utf-8'
+    )
+
+    for required in [
+        'ec2_runner_specs:',
+        'arc_runner_specs:',
+        'github_webhook_relay:',
+        'github_app:',
+        'module_path: modules/platform/forge_runners',
+    ]:
+        assert required in f'{template}\n{release}'

--- a/tests/smoke/tests/lambda_guard_exec_test.py
+++ b/tests/smoke/tests/lambda_guard_exec_test.py
@@ -22,10 +22,15 @@ pytestmark = pytest.mark.lambda_exec
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-def _zip_handler(source: Path) -> bytes:
+def _zip_handler(
+    source: Path,
+    extra_sources: dict[str, Path] | None = None,
+) -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, 'w') as z:
         z.writestr('handler.py', source.read_text())
+        for archive_name, extra_source in (extra_sources or {}).items():
+            z.writestr(archive_name, extra_source.read_text())
     return buf.getvalue()
 
 
@@ -39,16 +44,28 @@ def _wait_until_active(lam, function_name: str):
     raise AssertionError(f'Lambda {function_name} did not become active')
 
 
-def _deploy_handler(client, *, function_name: str, source: Path, env: dict[str, str]):
+def _deploy_handler(
+    client,
+    *,
+    function_name: str,
+    source: Path,
+    env: dict[str, str],
+    handler: str = 'handler.lambda_handler',
+    extra_sources: dict[str, Path] | None = None,
+):
     assert source.exists(), f'handler not found: {source}'
+    for extra_source in (extra_sources or {}).values():
+        assert extra_source.exists(), (
+            f'handler dependency not found: {extra_source}'
+        )
     lam = client('lambda')
     try:
         lam.create_function(
             FunctionName=function_name,
             Runtime='python3.12',
             Role='arn:aws:iam::000000000000:role/forge-smoke-lambda',
-            Handler='handler.lambda_handler',
-            Code={'ZipFile': _zip_handler(source)},
+            Handler=handler,
+            Code={'ZipFile': _zip_handler(source, extra_sources)},
             Timeout=30,
             Environment={'Variables': env},
         )
@@ -57,7 +74,7 @@ def _deploy_handler(client, *, function_name: str, source: Path, env: dict[str, 
             raise
         lam.update_function_code(
             FunctionName=function_name,
-            ZipFile=_zip_handler(source),
+            ZipFile=_zip_handler(source, extra_sources),
         )
         _wait_until_active(lam, function_name)
         lam.update_function_configuration(
@@ -244,6 +261,57 @@ CASES = [
         'event': {'detail': {'eventName': 'DescribeInstances'}},
         'expected': None,
     },
+    {
+        'id': 'trust-preparer-rejects-empty-role-config',
+        'function_name': 'forge-smoke-trust-preparer',
+        'source': Path(
+            'modules/platform/forge_runners/forge_trust_validator/lambda/'
+            'trust_preparer.py'
+        ),
+        'handler': 'handler.prepare_handler',
+        'extra_sources': {
+            'trust_common.py': Path(
+                'modules/platform/forge_runners/forge_trust_validator/lambda/'
+                'trust_common.py'
+            ),
+        },
+        'env': {
+            'LOG_LEVEL': 'INFO',
+            'FORGE_IAM_ROLES': '',
+            'TENANT_IAM_ROLES': '',
+            'VALIDATOR_LAMBDA_ROLE_ARN': (
+                'arn:aws:iam::000000000000:role/forge-smoke-validator'
+            ),
+            'VALIDATION_QUEUE_URL': (
+                'https://sqs.us-east-1.amazonaws.com/000000000000/unused'
+            ),
+            'VALIDATION_DELAY_SECONDS': '0',
+        },
+        'event': {},
+        'expected_function_error': 'Unhandled',
+        'expected_error_message': 'Missing forge_role_arns or tenant_role_arns',
+    },
+    {
+        'id': 'trust-validator-rejects-non-sqs-event',
+        'function_name': 'forge-smoke-trust-validator',
+        'source': Path(
+            'modules/platform/forge_runners/forge_trust_validator/lambda/'
+            'trust_validator.py'
+        ),
+        'handler': 'handler.validate_handler',
+        'extra_sources': {
+            'trust_common.py': Path(
+                'modules/platform/forge_runners/forge_trust_validator/lambda/'
+                'trust_common.py'
+            ),
+        },
+        'env': {'LOG_LEVEL': 'INFO'},
+        'event': {},
+        'expected_function_error': 'Unhandled',
+        'expected_error_message': (
+            'Validator Lambda only accepts SQS validation events'
+        ),
+    },
 ]
 
 
@@ -254,9 +322,19 @@ def test_lambda_handler_guard_path_executes_in_ministack(client, case):
         function_name=case['function_name'],
         source=_REPO_ROOT / case['source'],
         env=case['env'],
+        handler=case.get('handler', 'handler.lambda_handler'),
+        extra_sources={
+            name: _REPO_ROOT / source
+            for name, source in case.get('extra_sources', {}).items()
+        },
     )
 
     resp, payload = _invoke(lam, case['function_name'], case['event'])
+    if 'expected_function_error' in case:
+        assert resp.get('FunctionError') == case['expected_function_error']
+        assert case['expected_error_message'] in payload['errorMessage']
+        return
+
     assert 'FunctionError' not in resp
 
     expected = case['expected']

--- a/tests/tofu/module_contract/main.tf
+++ b/tests/tofu/module_contract/main.tf
@@ -13,6 +13,12 @@ variable "expected_literals" {
   description = "Module-specific Terraform source snippets that must remain present."
 }
 
+variable "forbidden_literals" {
+  type        = list(string)
+  description = "Module-specific Terraform source snippets that must not be introduced."
+  default     = []
+}
+
 locals {
   tf_files = sort(fileset(var.module_path, "*.tf"))
   tf_text = join("\n", [
@@ -23,6 +29,11 @@ locals {
     for literal in var.expected_literals : literal
     if !strcontains(local.tf_text, literal)
   ]
+
+  present_forbidden_literals = [
+    for literal in var.forbidden_literals : literal
+    if strcontains(local.tf_text, literal)
+  ]
 }
 
 output "expected_literal_count" {
@@ -31,4 +42,8 @@ output "expected_literal_count" {
 
 output "missing_expected_literals" {
   value = local.missing_expected_literals
+}
+
+output "present_forbidden_literals" {
+  value = local.present_forbidden_literals
 }


### PR DESCRIPTION
## Description

Adds CI-safe test coverage improvements for Forge:

- adds quality contracts for example release manifests and config templates, and runs Quality Gates when `examples/**` changes
- expands the MiniStack real-handler smoke harness to support alternate handler entrypoints and sibling source files, then exercises trust preparer and validator rejection paths
- extends the shared OpenTofu module contract helper with forbidden-literal checks and applies them to job-log, trust-validator, and webhook-source modules

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Test coverage

## Testing

- `python3 -m py_compile tests/quality/examples_contract_test.py`
- `python3 -m py_compile tests/smoke/tests/lambda_guard_exec_test.py`
- direct local invocation of the three new examples contract test functions
- `tofu fmt -check tests/tofu/module_contract/main.tf modules/platform/forge_runners/github_actions_job_logs/tests/platform_forge_runners_github_actions_job_logs_contract.tftest.hcl modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_contract.tftest.hcl modules/platform/forge_runners/github_webhook_relay/source/tests/platform_forge_runners_github_webhook_relay_source_contract.tftest.hcl`
- `tofu -chdir=modules/platform/forge_runners/github_actions_job_logs init -backend=false -input=false && tofu -chdir=modules/platform/forge_runners/github_actions_job_logs test -no-color`
- `tofu -chdir=modules/platform/forge_runners/forge_trust_validator init -backend=false -input=false && tofu -chdir=modules/platform/forge_runners/forge_trust_validator test -no-color`
- `tofu -chdir=modules/platform/forge_runners/github_webhook_relay/source init -backend=false -input=false && tofu -chdir=modules/platform/forge_runners/github_webhook_relay/source test -no-color`
- pre-commit hooks passed during each commit

Not run locally:

- full pytest suites because local `uv` and `pytest` are unavailable
- full MiniStack smoke run because it requires the Docker-backed emulator
