### PR TITLE
chore(deps): ignore ubuntu docker update noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,6 +88,7 @@ updates:
       - dependency-name: ubuntu
         update-types:
           - version-update:semver-major
+          - version-update:semver-minor
     labels:
       - dependencies
       - docker

--- a/renovate.json
+++ b/renovate.json
@@ -229,6 +229,25 @@
             ]
         },
         {
+            "description": "Ignore Ubuntu Docker base image major and minor updates",
+            "matchManagers": [
+                "dockerfile"
+            ],
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "ubuntu",
+                "library/ubuntu",
+                "docker.io/library/ubuntu"
+            ],
+            "matchUpdateTypes": [
+                "major",
+                "minor"
+            ],
+            "enabled": false
+        },
+        {
             "description": "Docker images - grouped with digest pinning",
             "matchManagers": [
                 "docker-compose",


### PR DESCRIPTION
## Description

Prevent dependency automation from opening Ubuntu Docker base image major and minor update PRs, including noise like `ubuntu` `24.04` to `24.10`.

Updates both dependency bot configs:

- Dependabot now ignores `ubuntu` Docker major and minor updates.
- Renovate now disables Dockerfile `ubuntu` major and minor updates while keeping patch and digest updates eligible.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: dependency automation

## Testing

- `pre-commit run check-yaml --files .github/dependabot.yml`
- `pre-commit run yamllint --files .github/dependabot.yml`
- `pre-commit run check-dependabot --files .github/dependabot.yml`
- `pre-commit run check-renovate --files renovate.json`
- `jq . renovate.json`
- `renovate-config-validator renovate.json`
- `git diff --check -- .github/dependabot.yml renovate.json`
