### PR TITLE
chore(pre-commit): remove duplicate uv hook dependency

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     container:
-      image: ghcr.io/cisco-open/forge-pre-commit:main@sha256:51127f81bc41e09c6306822f6c81911abc51b6745d663d8d4af4683cde8415e7
+      image: ghcr.io/cisco-open/forge-pre-commit:main@sha256:0977ced8cd79d5b26a22ff39edd44469379d7e75642f66209a9df43e032a4116
 
     if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -295,8 +295,6 @@ repos:
           trap "rm -f \"$req\"" EXIT;
           uv export --project . --locked --only-group lambda-tests --format requirements-txt --no-hashes > "$req";
           pip-audit -r "$req" --strict --no-deps --disable-pip'
-        additional_dependencies:
-          - uv==0.11.26
         always_run: true
         pass_filenames: false
 

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -78,12 +78,17 @@ def test_pre_commit_covers_security_sca_and_secrets() -> None:
         '*/.terraform/*',
         'repo: https://github.com/pypa/pip-audit',
         'id: pip-audit',
-        'additional_dependencies:',
-        'uv==0.11.26',
         'uv export --project . --locked --only-group lambda-tests',
         'pip-audit -r "$req" --strict --no-deps --disable-pip',
     ]:
         assert required in pre_commit
+
+    pip_audit_block = pre_commit.split(
+        'repo: https://github.com/pypa/pip-audit',
+        1,
+    )[1].split('  # ---------------------', 1)[0]
+    assert 'additional_dependencies:' not in pip_audit_block
+    assert 'uv==' not in pip_audit_block
 
     assert 'pre-commit-image = [' in pyproject
     assert {'pre-commit', 'bandit', 'pip-audit', 'uv'} <= pre_commit_deps


### PR DESCRIPTION
## Description

Removes the duplicate `uv==0.11.26` hook-level dependency from the `pip-audit` pre-commit hook. The hook still exports the locked `lambda-tests` dependencies before running `pip-audit`, and the quality gate now asserts the `pip-audit` block does not carry a separate hook-local `uv` pin.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: dependency automation cleanup

## Testing

- [x] `/Users/elealcar/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile tests/quality/automation_gates_test.py`
- [x] Direct Python assertion that the `pip-audit` block keeps `uv export` and `pip-audit`, and does not contain `additional_dependencies:` or `uv==`
- [ ] `uv run --project .. --locked --only-group lambda-tests pytest -q quality/automation_gates_test.py` was not run because `uv` is not installed in this local shell
- [ ] Commit-time pre-commit failed locally at `Security · pip-audit` with `/opt/homebrew/bin/bash: line 1: uv: command not found`; this change intentionally relies on the pre-commit execution image providing `uv`
