### PR TITLE
fix(splunk): fix query with breaking change in lambda logs

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/dashboard_forge_github_webhook_workflow_job_events.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/dashboard_forge_github_webhook_workflow_job_events.tf
@@ -222,7 +222,7 @@ locals {
           enableSmartSources = true
           query              = <<-EOT
             index="${var.splunk_conf.index}" ((forgecicd_log_type=webhook github.status=*) OR ("Successfully dispatched job for"))
-            | rex field=message "to the queue (?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+)"
+            | rex field=message "to the queue(s) (?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+)"
             | spath path=github.workflowJobId output=github_workflow_job_id
             | spath path=github.workflowJobUrl output=workflow_job_url
             | spath path=github.runId output=run_id

--- a/modules/integrations/splunk_cloud_conf_shared/dashboard_forge_github_webhook_workflow_job_events.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/dashboard_forge_github_webhook_workflow_job_events.tf
@@ -222,7 +222,7 @@ locals {
           enableSmartSources = true
           query              = <<-EOT
             index="${var.splunk_conf.index}" ((forgecicd_log_type=webhook github.status=*) OR ("Successfully dispatched job for"))
-            | rex field=message "to the queue(s) (?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+)"
+            | rex field=message "to the queue\(s\) ?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+"
             | spath path=github.workflowJobId output=github_workflow_job_id
             | spath path=github.workflowJobUrl output=workflow_job_url
             | spath path=github.runId output=run_id

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/splunk_alert.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/splunk_alert.tf
@@ -3,7 +3,7 @@ locals {
 
   stuck_workflow_job_search = <<-EOT
     index="${var.splunk_conf.index}" ((forgecicd_log_type=webhook github.status=*) OR ("Successfully dispatched job for"))
-    | rex field=message "to the queue (?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+)"
+    | rex field=message "to the queue(s) (?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+)"
     | spath path=github.workflowJobId output=github_workflow_job_id
     | spath path=github.workflowJobUrl output=workflow_job_url
     | spath path=github.runId output=run_id

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/splunk_alert.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/splunk_alert.tf
@@ -3,7 +3,7 @@ locals {
 
   stuck_workflow_job_search = <<-EOT
     index="${var.splunk_conf.index}" ((forgecicd_log_type=webhook github.status=*) OR ("Successfully dispatched job for"))
-    | rex field=message "to the queue(s) (?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+)"
+    | rex field=message "to the queue\(s\) (?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+)"
     | spath path=github.workflowJobId output=github_workflow_job_id
     | spath path=github.workflowJobUrl output=workflow_job_url
     | spath path=github.runId output=run_id


### PR DESCRIPTION
## Description
Fix queries to check for stuck jobs. 

Root cause:
dispatch lambda from repo terraform-aws-github-runner changed the log message and it broke the regex used in the query to send alerts about stuck jobs.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

<!-- Describe testing done if needed -->
