### PR TITLE
test(tofu): add module validation contracts

### DIFF
--- a/modules/helpers/ecr/tests/ecr.tftest.hcl
+++ b/modules/helpers/ecr/tests/ecr.tftest.hcl
@@ -51,21 +51,3 @@ run "ecr_repository_contract" {
     error_message = "ECR helper lifecycle policy must keep untagged, release, and pre-release cleanup rules."
   }
 }
-
-run "rejects_unknown_ecr_mutability" {
-  command = plan
-
-  variables {
-    repositories = [
-      {
-        repo         = "forge/bad"
-        mutability   = "BROKEN"
-        scan_on_push = true
-      },
-    ]
-  }
-
-  expect_failures = [
-    var.repositories,
-  ]
-}

--- a/modules/helpers/ecr/tests/helpers_ecr_validation_contract.tftest.hcl
+++ b/modules/helpers/ecr/tests/helpers_ecr_validation_contract.tftest.hcl
@@ -1,0 +1,55 @@
+mock_provider "aws" {}
+
+variables {
+  aws_profile = "test"
+  aws_region  = "us-east-1"
+  default_tags = {
+    Product = "Forge"
+  }
+  tags = {
+    Env = "test"
+  }
+  repositories = [
+    {
+      repo         = "forge/runner"
+      mutability   = "IMMUTABLE"
+      scan_on_push = true
+    },
+  ]
+}
+
+run "rejects_unknown_ecr_mutability" {
+  command = plan
+
+  variables {
+    repositories = [
+      {
+        repo         = "forge/bad"
+        mutability   = "BROKEN"
+        scan_on_push = true
+      },
+    ]
+  }
+
+  expect_failures = [
+    var.repositories,
+  ]
+}
+
+run "rejects_lowercase_ecr_mutability" {
+  command = plan
+
+  variables {
+    repositories = [
+      {
+        repo         = "forge/lowercase"
+        mutability   = "mutable"
+        scan_on_push = true
+      },
+    ]
+  }
+
+  expect_failures = [
+    var.repositories,
+  ]
+}

--- a/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_validation_contract.tftest.hcl
+++ b/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_validation_contract.tftest.hcl
@@ -1,0 +1,27 @@
+run "iam_propagation_delay_validation_contract" {
+  command = plan
+
+  module {
+    source = "../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "validation {",
+      "var.iam_propagation_delay_seconds >= 0",
+      "var.iam_propagation_delay_seconds <= 900",
+      "error_message = \"iam_propagation_delay_seconds must be between 0 and 900.\"",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "Forge trust validator validation contract is missing expected literals: ${join(", ", output.missing_expected_literals)}"
+  }
+
+  assert {
+    condition     = output.expected_literal_count > 0
+    error_message = "Forge trust validator validation contract must pin at least one validation literal."
+  }
+}

--- a/modules/platform/forge_runners/github_app_runner_group/tests/platform_forge_runners_github_app_runner_group_validation_contract.tftest.hcl
+++ b/modules/platform/forge_runners/github_app_runner_group/tests/platform_forge_runners_github_app_runner_group_validation_contract.tftest.hcl
@@ -1,0 +1,64 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  mock_data "aws_region" {
+    defaults = {
+      description = "US East (N. Virginia)"
+      endpoint    = "ec2.us-east-1.amazonaws.com"
+      region      = "us-east-1"
+    }
+  }
+}
+
+variables {
+  prefix                    = "forge-test"
+  logging_retention_in_days = 30
+  log_level                 = "INFO"
+  github_api                = "https://api.github.com"
+  ghes_org                  = "forge"
+  runner_group_name         = "forge-runners"
+  repository_selection      = "selected"
+  tags = {
+    Product = "Forge"
+    Env     = "test"
+  }
+  github_app = {
+    key_base64_ssm = {
+      arn = "arn:aws:ssm:us-east-1:123456789012:parameter/github-app-key"
+    }
+    id_ssm = {
+      arn = "arn:aws:ssm:us-east-1:123456789012:parameter/github-app-id"
+    }
+    installation_id_ssm = {
+      arn = "arn:aws:ssm:us-east-1:123456789012:parameter/github-app-installation-id"
+    }
+  }
+}
+
+run "rejects_unknown_repository_selection" {
+  command = plan
+
+  variables {
+    repository_selection = "private"
+  }
+
+  expect_failures = [
+    var.repository_selection,
+  ]
+}
+
+run "rejects_uppercase_repository_selection" {
+  command = plan
+
+  variables {
+    repository_selection = "ALL"
+  }
+
+  expect_failures = [
+    var.repository_selection,
+  ]
+}

--- a/modules/platform/forge_runners/tests/platform_forge_runners_validation_contract.tftest.hcl
+++ b/modules/platform/forge_runners/tests/platform_forge_runners_validation_contract.tftest.hcl
@@ -1,0 +1,26 @@
+run "repository_selection_validation_contract" {
+  command = plan
+
+  module {
+    source = "../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "validation {",
+      "condition     = contains([\"all\", \"selected\"], var.deployment_config.github.repository_selection)",
+      "error_message = \"repository_selection must be 'all' or 'selected'.\"",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "Forge runners validation contract is missing expected literals: ${join(", ", output.missing_expected_literals)}"
+  }
+
+  assert {
+    condition     = output.expected_literal_count > 0
+    error_message = "Forge runners validation contract must pin at least one validation literal."
+  }
+}

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -17,6 +17,13 @@ def is_terraform_module(path: Path) -> bool:
     return any(path.glob('*.tf'))
 
 
+def module_has_variable_validation(path: Path) -> bool:
+    return any(
+        re.search(r'\bvalidation\s*\{', tf_file.read_text(encoding='utf-8'))
+        for tf_file in path.glob('*.tf')
+    )
+
+
 def dependency_group_names(group_name: str) -> set[str]:
     data = tomllib.loads(read('pyproject.toml'))
     dependencies = data['dependency-groups'][group_name]
@@ -57,6 +64,41 @@ def test_each_module_has_specific_native_test_file() -> None:
 
     assert missing_tests == []
     assert generic_tests == []
+
+
+def test_variable_validation_blocks_have_validation_contract_tests() -> None:
+    modules = sorted(
+        path
+        for path in (REPO_ROOT / 'modules').rglob('*')
+        if is_terraform_module(path)
+    )
+
+    missing_validation_contracts = []
+    unexpected_validation_contracts = []
+    duplicate_validation_contracts = []
+    for module in modules:
+        tests_dir = module / 'tests'
+        validation_contracts = (
+            sorted(tests_dir.glob('*_validation_contract.tftest.hcl'))
+            if tests_dir.exists()
+            else []
+        )
+        has_validation = module_has_variable_validation(module)
+        module_path = module.relative_to(REPO_ROOT).as_posix()
+
+        if has_validation and not validation_contracts:
+            missing_validation_contracts.append(module_path)
+        if not has_validation and validation_contracts:
+            unexpected_validation_contracts.extend(
+                path.relative_to(REPO_ROOT).as_posix()
+                for path in validation_contracts
+            )
+        if len(validation_contracts) > 1:
+            duplicate_validation_contracts.append(module_path)
+
+    assert missing_validation_contracts == []
+    assert unexpected_validation_contracts == []
+    assert duplicate_validation_contracts == []
 
 
 def test_pre_commit_covers_security_sca_and_secrets() -> None:


### PR DESCRIPTION
## Description

Adds validation-contract `.tftest.hcl` coverage for every module that defines Terraform variable validation blocks.

- Moves the ECR mutability negative test out of the behavior file into `helpers_ecr_validation_contract.tftest.hcl`.
- Adds invalid-value validation tests for `github_app_runner_group.repository_selection`.
- Pins the parent `forge_runners` repository-selection validation and `forge_trust_validator` IAM propagation-delay validation with source contracts, avoiding OpenTofu mock-provider issues in their Lambda-heavy child module graphs.
- Adds a quality gate so modules with `validation {}` blocks have exactly one `*_validation_contract.tftest.hcl`, and modules without validation blocks do not add that test type.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Test coverage

## Testing

- `tofu fmt -check -recursive modules tests/tofu`
- `/Users/elealcar/.pyenv/versions/3.11.4/bin/python -m pytest -q -o addopts='' tests/quality/automation_gates_test.py`
- `tofu -chdir=modules/helpers/ecr test -no-color`
- `tofu -chdir=modules/platform/forge_runners/github_app_runner_group test -no-color`
- `tofu -chdir=modules/platform/forge_runners/forge_trust_validator test -no-color`
- `tofu -chdir=modules/platform/forge_runners test -no-color`
- Commit hooks passed, including Tofu fmt/validate and security hooks.
