### PR TITLE
fix(ec2): use instance profile for runner job-hooks and make them non-fatal

### DIFF
--- a/modules/platform/ec2_deployment/template_files/hook_job_completed_linux.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_completed_linux.tftpl
@@ -8,6 +8,15 @@
 # run it is logged but must never fail the runner job, so the wrapper always
 # exits 0 regardless of what happens below.
 set -uo pipefail
+
+# Ignore any AWS credential/profile env vars the workflow injected into the job
+# (e.g. AWS_PROFILE=default) so this wrapper authenticates with the runner's EC2
+# instance profile (IMDS), not the job's credentials. The real hook does the same.
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE AWS_DEFAULT_PROFILE
+export AWS_SHARED_CREDENTIALS_FILE=/dev/null
+export AWS_CONFIG_FILE=/dev/null
+export AWS_SDK_LOAD_CONFIG=0
+
 _hook="$(mktemp)"
 _err="$(mktemp)"
 trap 'rm -f "$_hook" "$_err"' EXIT

--- a/modules/platform/ec2_deployment/template_files/hook_job_completed_linux.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_completed_linux.tftpl
@@ -3,11 +3,24 @@
 # user_data (16 KB limit), so it is stored gzip+base64 in SSM. This wrapper is
 # what the runner actually invokes: it fetches the param, decompresses it, and
 # runs the real hook (inheriting the job's GITHUB_*/RUNNER_* environment).
+#
+# The hook is best-effort telemetry/bookkeeping: a failure to fetch, decode, or
+# run it is logged but must never fail the runner job, so the wrapper always
+# exits 0 regardless of what happens below.
 set -uo pipefail
 _hook="$(mktemp)"
-trap 'rm -f "$_hook"' EXIT
-if ! aws ssm get-parameter --name "${param_name}" --query Parameter.Value --output text --region ${region} | base64 -d | gunzip >"$_hook"; then
-  echo "job-hook: failed to fetch ${param_name} from SSM" >&2
-  exit 1
+_err="$(mktemp)"
+trap 'rm -f "$_hook" "$_err"' EXIT
+if ! aws ssm get-parameter --name "${param_name}" --query Parameter.Value --output text --region ${region} 2>"$_err" | base64 -d 2>/dev/null | gunzip 2>/dev/null >"$_hook"; then
+  echo "job-hook: WARNING: could not load hook from SSM parameter ${param_name}; skipping it (runner job not affected)" >&2
+  if [ -s "$_err" ]; then
+    sed 's/^/job-hook:   /' "$_err" >&2
+  fi
+  echo "job-hook:   caller identity used for the failed request:" >&2
+  aws sts get-caller-identity --output text --region ${region} 2>&1 | sed 's/^/job-hook:     /' >&2 || true
+  exit 0
 fi
-bash "$_hook"
+if ! bash "$_hook"; then
+  echo "job-hook: WARNING: hook from ${param_name} exited non-zero; ignoring (runner job not affected)" >&2
+fi
+exit 0

--- a/modules/platform/ec2_deployment/template_files/hook_job_completed_osx.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_completed_osx.tftpl
@@ -8,6 +8,15 @@
 # run it is logged but must never fail the runner job, so the wrapper always
 # exits 0 regardless of what happens below.
 set -uo pipefail
+
+# Ignore any AWS credential/profile env vars the workflow injected into the job
+# (e.g. AWS_PROFILE=default) so this wrapper authenticates with the runner's EC2
+# instance profile (IMDS), not the job's credentials. The real hook does the same.
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE AWS_DEFAULT_PROFILE
+export AWS_SHARED_CREDENTIALS_FILE=/dev/null
+export AWS_CONFIG_FILE=/dev/null
+export AWS_SDK_LOAD_CONFIG=0
+
 _hook="$(mktemp)"
 _err="$(mktemp)"
 trap 'rm -f "$_hook" "$_err"' EXIT

--- a/modules/platform/ec2_deployment/template_files/hook_job_completed_osx.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_completed_osx.tftpl
@@ -3,11 +3,24 @@
 # user_data (16 KB limit), so it is stored gzip+base64 in SSM. This wrapper is
 # what the runner actually invokes: it fetches the param, decompresses it, and
 # runs the real hook (inheriting the job's GITHUB_*/RUNNER_* environment).
+#
+# The hook is best-effort telemetry/bookkeeping: a failure to fetch, decode, or
+# run it is logged but must never fail the runner job, so the wrapper always
+# exits 0 regardless of what happens below.
 set -uo pipefail
 _hook="$(mktemp)"
-trap 'rm -f "$_hook"' EXIT
-if ! aws ssm get-parameter --name "${param_name}" --query Parameter.Value --output text --region ${region} | base64 -d | gunzip >"$_hook"; then
-  echo "job-hook: failed to fetch ${param_name} from SSM" >&2
-  exit 1
+_err="$(mktemp)"
+trap 'rm -f "$_hook" "$_err"' EXIT
+if ! aws ssm get-parameter --name "${param_name}" --query Parameter.Value --output text --region ${region} 2>"$_err" | base64 -d 2>/dev/null | gunzip 2>/dev/null >"$_hook"; then
+  echo "job-hook: WARNING: could not load hook from SSM parameter ${param_name}; skipping it (runner job not affected)" >&2
+  if [ -s "$_err" ]; then
+    sed 's/^/job-hook:   /' "$_err" >&2
+  fi
+  echo "job-hook:   caller identity used for the failed request:" >&2
+  aws sts get-caller-identity --output text --region ${region} 2>&1 | sed 's/^/job-hook:     /' >&2 || true
+  exit 0
 fi
-bash "$_hook"
+if ! bash "$_hook"; then
+  echo "job-hook: WARNING: hook from ${param_name} exited non-zero; ignoring (runner job not affected)" >&2
+fi
+exit 0

--- a/modules/platform/ec2_deployment/template_files/hook_job_completed_windows.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_completed_windows.tftpl
@@ -5,6 +5,14 @@
 # run it is logged but must never fail the runner job, so the wrapper always
 # exits 0 regardless of what happens below.
 $ErrorActionPreference = 'Stop'
+
+# Ignore any AWS credential/profile env vars the workflow injected into the job
+# (e.g. AWS_PROFILE=default) so this wrapper authenticates with the runner's EC2
+# instance profile (IMDS), not the job's credentials.
+foreach ($v in 'AWS_ACCESS_KEY_ID','AWS_SECRET_ACCESS_KEY','AWS_SESSION_TOKEN','AWS_PROFILE','AWS_DEFAULT_PROFILE') {
+    Remove-Item -Path "Env:$v" -ErrorAction SilentlyContinue
+}
+
 $hookFile = $null
 try {
     $enc = (Get-SSMParameter -Name '${param_name}' -Region '${region}').Value

--- a/modules/platform/ec2_deployment/template_files/hook_job_completed_windows.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_completed_windows.tftpl
@@ -1,9 +1,34 @@
 # Runtime job-hook wrapper. The real hook is stored gzip+base64 in SSM (too large
 # to inline in EC2 user_data). This wrapper fetches, decompresses, and runs it.
+#
+# The hook is best-effort telemetry/bookkeeping: a failure to fetch, decode, or
+# run it is logged but must never fail the runner job, so the wrapper always
+# exits 0 regardless of what happens below.
 $ErrorActionPreference = 'Stop'
-$enc = (Get-SSMParameter -Name '${param_name}' -Region '${region}').Value
-$gz = New-Object System.IO.Compression.GZipStream((New-Object System.IO.MemoryStream(, [Convert]::FromBase64String($enc))), [System.IO.Compression.CompressionMode]::Decompress)
-$body = (New-Object System.IO.StreamReader($gz)).ReadToEnd()
-$hookFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), 'ps1')
-Set-Content -Path $hookFile -Value $body -Encoding utf8
-try { & $hookFile } finally { Remove-Item $hookFile -ErrorAction SilentlyContinue }
+$hookFile = $null
+try {
+    $enc = (Get-SSMParameter -Name '${param_name}' -Region '${region}').Value
+    $gz = New-Object System.IO.Compression.GZipStream((New-Object System.IO.MemoryStream(, [Convert]::FromBase64String($enc))), [System.IO.Compression.CompressionMode]::Decompress)
+    $body = (New-Object System.IO.StreamReader($gz)).ReadToEnd()
+    $hookFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), 'ps1')
+    Set-Content -Path $hookFile -Value $body -Encoding utf8
+} catch {
+    Write-Warning "job-hook: could not load hook from SSM parameter '${param_name}'; skipping it (runner job not affected)"
+    Write-Warning "job-hook:   $($_.Exception.Message)"
+    try {
+        $id = Get-STSCallerIdentity -Region '${region}'
+        Write-Warning "job-hook:   caller identity used for the failed request: Account=$($id.Account) Arn=$($id.Arn) UserId=$($id.UserId)"
+    } catch {
+        Write-Warning "job-hook:   unable to determine caller identity: $($_.Exception.Message)"
+    }
+    exit 0
+}
+try {
+    & $hookFile
+} catch {
+    Write-Warning "job-hook: hook from '${param_name}' raised an error; ignoring (runner job not affected)"
+    Write-Warning "job-hook:   $($_.Exception.Message)"
+} finally {
+    if ($hookFile) { Remove-Item $hookFile -ErrorAction SilentlyContinue }
+}
+exit 0

--- a/modules/platform/ec2_deployment/template_files/hook_job_started_linux.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started_linux.tftpl
@@ -8,6 +8,15 @@
 # run it is logged but must never fail the runner job, so the wrapper always
 # exits 0 regardless of what happens below.
 set -uo pipefail
+
+# Ignore any AWS credential/profile env vars the workflow injected into the job
+# (e.g. AWS_PROFILE=default) so this wrapper authenticates with the runner's EC2
+# instance profile (IMDS), not the job's credentials. The real hook does the same.
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE AWS_DEFAULT_PROFILE
+export AWS_SHARED_CREDENTIALS_FILE=/dev/null
+export AWS_CONFIG_FILE=/dev/null
+export AWS_SDK_LOAD_CONFIG=0
+
 _hook="$(mktemp)"
 _err="$(mktemp)"
 trap 'rm -f "$_hook" "$_err"' EXIT

--- a/modules/platform/ec2_deployment/template_files/hook_job_started_linux.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started_linux.tftpl
@@ -3,11 +3,24 @@
 # user_data (16 KB limit), so it is stored gzip+base64 in SSM. This wrapper is
 # what the runner actually invokes: it fetches the param, decompresses it, and
 # runs the real hook (inheriting the job's GITHUB_*/RUNNER_* environment).
+#
+# The hook is best-effort telemetry/bookkeeping: a failure to fetch, decode, or
+# run it is logged but must never fail the runner job, so the wrapper always
+# exits 0 regardless of what happens below.
 set -uo pipefail
 _hook="$(mktemp)"
-trap 'rm -f "$_hook"' EXIT
-if ! aws ssm get-parameter --name "${param_name}" --query Parameter.Value --output text --region ${region} | base64 -d | gunzip >"$_hook"; then
-  echo "job-hook: failed to fetch ${param_name} from SSM" >&2
-  exit 1
+_err="$(mktemp)"
+trap 'rm -f "$_hook" "$_err"' EXIT
+if ! aws ssm get-parameter --name "${param_name}" --query Parameter.Value --output text --region ${region} 2>"$_err" | base64 -d 2>/dev/null | gunzip 2>/dev/null >"$_hook"; then
+  echo "job-hook: WARNING: could not load hook from SSM parameter ${param_name}; skipping it (runner job not affected)" >&2
+  if [ -s "$_err" ]; then
+    sed 's/^/job-hook:   /' "$_err" >&2
+  fi
+  echo "job-hook:   caller identity used for the failed request:" >&2
+  aws sts get-caller-identity --output text --region ${region} 2>&1 | sed 's/^/job-hook:     /' >&2 || true
+  exit 0
 fi
-bash "$_hook"
+if ! bash "$_hook"; then
+  echo "job-hook: WARNING: hook from ${param_name} exited non-zero; ignoring (runner job not affected)" >&2
+fi
+exit 0

--- a/modules/platform/ec2_deployment/template_files/hook_job_started_osx.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started_osx.tftpl
@@ -8,6 +8,15 @@
 # run it is logged but must never fail the runner job, so the wrapper always
 # exits 0 regardless of what happens below.
 set -uo pipefail
+
+# Ignore any AWS credential/profile env vars the workflow injected into the job
+# (e.g. AWS_PROFILE=default) so this wrapper authenticates with the runner's EC2
+# instance profile (IMDS), not the job's credentials. The real hook does the same.
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE AWS_DEFAULT_PROFILE
+export AWS_SHARED_CREDENTIALS_FILE=/dev/null
+export AWS_CONFIG_FILE=/dev/null
+export AWS_SDK_LOAD_CONFIG=0
+
 _hook="$(mktemp)"
 _err="$(mktemp)"
 trap 'rm -f "$_hook" "$_err"' EXIT

--- a/modules/platform/ec2_deployment/template_files/hook_job_started_osx.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started_osx.tftpl
@@ -3,11 +3,24 @@
 # user_data (16 KB limit), so it is stored gzip+base64 in SSM. This wrapper is
 # what the runner actually invokes: it fetches the param, decompresses it, and
 # runs the real hook (inheriting the job's GITHUB_*/RUNNER_* environment).
+#
+# The hook is best-effort telemetry/bookkeeping: a failure to fetch, decode, or
+# run it is logged but must never fail the runner job, so the wrapper always
+# exits 0 regardless of what happens below.
 set -uo pipefail
 _hook="$(mktemp)"
-trap 'rm -f "$_hook"' EXIT
-if ! aws ssm get-parameter --name "${param_name}" --query Parameter.Value --output text --region ${region} | base64 -d | gunzip >"$_hook"; then
-  echo "job-hook: failed to fetch ${param_name} from SSM" >&2
-  exit 1
+_err="$(mktemp)"
+trap 'rm -f "$_hook" "$_err"' EXIT
+if ! aws ssm get-parameter --name "${param_name}" --query Parameter.Value --output text --region ${region} 2>"$_err" | base64 -d 2>/dev/null | gunzip 2>/dev/null >"$_hook"; then
+  echo "job-hook: WARNING: could not load hook from SSM parameter ${param_name}; skipping it (runner job not affected)" >&2
+  if [ -s "$_err" ]; then
+    sed 's/^/job-hook:   /' "$_err" >&2
+  fi
+  echo "job-hook:   caller identity used for the failed request:" >&2
+  aws sts get-caller-identity --output text --region ${region} 2>&1 | sed 's/^/job-hook:     /' >&2 || true
+  exit 0
 fi
-bash "$_hook"
+if ! bash "$_hook"; then
+  echo "job-hook: WARNING: hook from ${param_name} exited non-zero; ignoring (runner job not affected)" >&2
+fi
+exit 0

--- a/modules/platform/ec2_deployment/template_files/hook_job_started_windows.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started_windows.tftpl
@@ -5,6 +5,14 @@
 # run it is logged but must never fail the runner job, so the wrapper always
 # exits 0 regardless of what happens below.
 $ErrorActionPreference = 'Stop'
+
+# Ignore any AWS credential/profile env vars the workflow injected into the job
+# (e.g. AWS_PROFILE=default) so this wrapper authenticates with the runner's EC2
+# instance profile (IMDS), not the job's credentials.
+foreach ($v in 'AWS_ACCESS_KEY_ID','AWS_SECRET_ACCESS_KEY','AWS_SESSION_TOKEN','AWS_PROFILE','AWS_DEFAULT_PROFILE') {
+    Remove-Item -Path "Env:$v" -ErrorAction SilentlyContinue
+}
+
 $hookFile = $null
 try {
     $enc = (Get-SSMParameter -Name '${param_name}' -Region '${region}').Value

--- a/modules/platform/ec2_deployment/template_files/hook_job_started_windows.tftpl
+++ b/modules/platform/ec2_deployment/template_files/hook_job_started_windows.tftpl
@@ -1,9 +1,34 @@
 # Runtime job-hook wrapper. The real hook is stored gzip+base64 in SSM (too large
 # to inline in EC2 user_data). This wrapper fetches, decompresses, and runs it.
+#
+# The hook is best-effort telemetry/bookkeeping: a failure to fetch, decode, or
+# run it is logged but must never fail the runner job, so the wrapper always
+# exits 0 regardless of what happens below.
 $ErrorActionPreference = 'Stop'
-$enc = (Get-SSMParameter -Name '${param_name}' -Region '${region}').Value
-$gz = New-Object System.IO.Compression.GZipStream((New-Object System.IO.MemoryStream(, [Convert]::FromBase64String($enc))), [System.IO.Compression.CompressionMode]::Decompress)
-$body = (New-Object System.IO.StreamReader($gz)).ReadToEnd()
-$hookFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), 'ps1')
-Set-Content -Path $hookFile -Value $body -Encoding utf8
-try { & $hookFile } finally { Remove-Item $hookFile -ErrorAction SilentlyContinue }
+$hookFile = $null
+try {
+    $enc = (Get-SSMParameter -Name '${param_name}' -Region '${region}').Value
+    $gz = New-Object System.IO.Compression.GZipStream((New-Object System.IO.MemoryStream(, [Convert]::FromBase64String($enc))), [System.IO.Compression.CompressionMode]::Decompress)
+    $body = (New-Object System.IO.StreamReader($gz)).ReadToEnd()
+    $hookFile = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), 'ps1')
+    Set-Content -Path $hookFile -Value $body -Encoding utf8
+} catch {
+    Write-Warning "job-hook: could not load hook from SSM parameter '${param_name}'; skipping it (runner job not affected)"
+    Write-Warning "job-hook:   $($_.Exception.Message)"
+    try {
+        $id = Get-STSCallerIdentity -Region '${region}'
+        Write-Warning "job-hook:   caller identity used for the failed request: Account=$($id.Account) Arn=$($id.Arn) UserId=$($id.UserId)"
+    } catch {
+        Write-Warning "job-hook:   unable to determine caller identity: $($_.Exception.Message)"
+    }
+    exit 0
+}
+try {
+    & $hookFile
+} catch {
+    Write-Warning "job-hook: hook from '${param_name}' raised an error; ignoring (runner job not affected)"
+    Write-Warning "job-hook:   $($_.Exception.Message)"
+} finally {
+    if ($hookFile) { Remove-Item $hookFile -ErrorAction SilentlyContinue }
+}
+exit 0


### PR DESCRIPTION
## Description

Self-hosted runner jobs were failing in the `job_completed` hook step with:

```
Error: aws: [ERROR]: An error occurred (ParameterNotFound) when calling the GetParameter operation:
gzip: stdin: unexpected end of file
job-hook: failed to fetch /forge/<prefix>/runner-hooks/linux/job-completed from SSM
Error: Process completed with exit code 1.
```

**Root cause:** the `job_started` / `job_completed` hook wrappers run inside the
job's environment. When a workflow sets `AWS_PROFILE` (e.g. `default`) or exports
AWS credentials, those leak into the wrapper's `aws ssm get-parameter` /
`Get-SSMParameter` call, so it authenticates with the job's profile instead of the
runner's EC2 instance profile — causing the SSM fetch to fail. On failure the
wrappers exited non-zero (`exit 1` on Linux/macOS, `$ErrorActionPreference='Stop'`
throw on Windows), which failed the whole job even though these hooks are
best-effort telemetry/bookkeeping.

**Changes (all six wrappers — `job_started`/`job_completed` × `linux`/`osx`/`windows`):**

- **Use the instance profile:** scrub workflow-injected AWS credential/profile env
  vars (`AWS_PROFILE`, `AWS_DEFAULT_PROFILE`, `AWS_ACCESS_KEY_ID`,
  `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`; plus `AWS_*_FILE`/`AWS_SDK_LOAD_CONFIG`
  on Linux/macOS) before any AWS call, so SSM/STS resolve via the EC2 instance
  profile (IMDS). This mirrors what the real hook scripts already do.
- **Never fail the job:** on any fetch/decode/run error the wrapper logs a warning
  and always `exit 0`.
- **Better diagnostics on failure:** log the actual AWS error and the
  `sts get-caller-identity` result (Account / Arn / UserId) so it's clear which
  credentials the runner used. `sts:GetCallerIdentity` requires no IAM permission.

No IAM changes are required (the runner role already has `ssm:GetParameter` for
these hook params). Because the wrapper is baked into EC2 `user_data`, this takes
effect on **newly launched runners**.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: _________
