### PR TITLE
fix(dispatcher): alias reserved result attribute

### DIFF
--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
@@ -480,8 +480,8 @@ def complete_work(key: str, status: str, result: Dict[str, Any]) -> None:
     dynamodb.update_item(
         TableName=os.environ['DEDUPE_TABLE'],
         Key={'dedupe_key': {'S': key}},
-        UpdateExpression='SET #status = :status, finished_at = :now, result = :result',
-        ExpressionAttributeNames={'#status': 'status'},
+        UpdateExpression='SET #status = :status, finished_at = :now, #result = :result',
+        ExpressionAttributeNames={'#status': 'status', '#result': 'result'},
         ExpressionAttributeValues={
             ':status': {'S': status},
             ':now': {'N': str(int(time.time()))},

--- a/tests/lambdas/splunk_stuck_worker_test.py
+++ b/tests/lambdas/splunk_stuck_worker_test.py
@@ -469,6 +469,27 @@ def test_claim_work_returns_false_when_already_claimed(monkeypatch, aws):
     assert not mod.claim_work('tenant#region#repo#job')
 
 
+def test_complete_work_aliases_reserved_result_attribute(monkeypatch, aws):
+    mod = _load_worker(monkeypatch)
+    updates = []
+
+    class _DynamoDB:
+        def update_item(self, **kwargs):
+            updates.append(kwargs)
+
+    monkeypatch.setattr(mod, 'dynamodb', _DynamoDB())
+
+    mod.complete_work('tenant#region#repo#job', 'completed', {'ok': True})
+
+    assert updates[0]['UpdateExpression'] == (
+        'SET #status = :status, finished_at = :now, #result = :result'
+    )
+    assert updates[0]['ExpressionAttributeNames'] == {
+        '#status': 'status',
+        '#result': 'result',
+    }
+
+
 def test_lambda_handler_completes_pending_stream_record(monkeypatch, aws):
     mod = _load_worker(monkeypatch)
     completed = []


### PR DESCRIPTION
## Description

Alias the DynamoDB `result` attribute in the stuck workflow dispatcher completion update because `result` is a reserved DynamoDB expression keyword.

This prevents successful or failed redelivery work from raising `ValidationException` while recording its final status and result. A focused regression test verifies the generated update expression and attribute-name aliases.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `pytest -q tests/lambdas/splunk_stuck_worker_test.py` — 21 passed
- Repository pre-commit hooks passed
