### PR TITLE
fix(helpers): add License Manager service role

### DIFF
--- a/examples/deployments/helpers/terragrunt/_global_settings/dedicated_mac_hosts.hcl
+++ b/examples/deployments/helpers/terragrunt/_global_settings/dedicated_mac_hosts.hcl
@@ -29,6 +29,12 @@ locals {
   }
 }
 
+dependencies {
+  paths = [
+    find_in_parent_folders("service_linked_roles")
+  ]
+}
+
 inputs = {
   aws_profile = local.default_aws_profile
   aws_region  = local.region

--- a/modules/helpers/service_linked_roles/README.md
+++ b/modules/helpers/service_linked_roles/README.md
@@ -9,11 +9,13 @@ EC2 runner pools can use Spot capacity and other AWS services that depend on acc
 ## What It Manages
 
 - The EC2 Spot service-linked role.
+- The License Manager core service-linked role used by dedicated Mac hosts.
 - Standard account and region inputs for bootstrap consistency.
 
 ## Operational Notes
 
 - Apply this before enabling Spot-backed EC2 runner pools.
+- Apply this before creating the License Manager configuration and resource group for dedicated Mac hosts.
 - AWS service-linked roles are account scoped and may already exist; Terraform should own them only where this module is the bootstrap authority.
 - This does not decide whether a runner pool uses Spot; that is configured in the EC2 deployment specs.
 
@@ -29,7 +31,7 @@ EC2 runner pools can use Spot capacity and other AWS services that depend on acc
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 
@@ -39,6 +41,7 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
+| [aws_iam_service_linked_role.license_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 | [aws_iam_service_linked_role.spot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 
 ## Inputs

--- a/modules/helpers/service_linked_roles/main.tf
+++ b/modules/helpers/service_linked_roles/main.tf
@@ -3,3 +3,9 @@ resource "aws_iam_service_linked_role" "spot" {
   tags             = local.all_security_tags
   tags_all         = local.all_security_tags
 }
+
+resource "aws_iam_service_linked_role" "license_manager" {
+  aws_service_name = "license-manager.amazonaws.com"
+  tags             = local.all_security_tags
+  tags_all         = local.all_security_tags
+}

--- a/modules/helpers/service_linked_roles/tests/helpers_service_linked_roles_source_inventory.tftest.hcl
+++ b/modules/helpers/service_linked_roles/tests/helpers_service_linked_roles_source_inventory.tftest.hcl
@@ -8,6 +8,7 @@ run "helpers_service_linked_roles_source_inventory" {
   variables {
     module_path = "."
     expected_literals = [
+      "resource \"aws_iam_service_linked_role\" \"license_manager\"",
       "resource \"aws_iam_service_linked_role\" \"spot\"",
       "provider \"aws\"",
     ]
@@ -19,7 +20,7 @@ run "helpers_service_linked_roles_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 2
-    error_message = "Source inventory must keep 2 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 3
+    error_message = "Source inventory must keep 3 module-specific Terraform blocks pinned."
   }
 }

--- a/modules/helpers/service_linked_roles/tests/service_linked_roles_behavior.tftest.hcl
+++ b/modules/helpers/service_linked_roles/tests/service_linked_roles_behavior.tftest.hcl
@@ -17,9 +17,12 @@ run "service_linked_role_contract" {
   assert {
     condition = (
       aws_iam_service_linked_role.spot.aws_service_name == "spot.amazonaws.com"
+      && aws_iam_service_linked_role.license_manager.aws_service_name == "license-manager.amazonaws.com"
       && aws_iam_service_linked_role.spot.tags.Product == "Forge"
       && aws_iam_service_linked_role.spot.tags.Env == "test"
+      && aws_iam_service_linked_role.license_manager.tags.Product == "Forge"
+      && aws_iam_service_linked_role.license_manager.tags.Env == "test"
     )
-    error_message = "Service-linked role helper must keep the Spot service-linked role and merged security tags."
+    error_message = "Service-linked role helper must keep the Spot and License Manager service-linked roles with merged security tags."
   }
 }


### PR DESCRIPTION
## Description

Add the AWS License Manager core service-linked role to the account bootstrap helper. This fixes dedicated Mac host deployments that fail when License Manager cannot find `AWSServiceRoleForAWSLicenseManagerRole`.

Make the dedicated Mac hosts Terragrunt configuration depend on `service_linked_roles` so the account-level role is created before the resource group and license configuration.

Update the module documentation and source/behavior contracts for the additional role.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

From `modules/helpers/service_linked_roles`, run:

```shell
tofu init -backend=false
tofu test -test-directory=tests
```

Confirm all three module contracts pass. Then verify the Terragrunt configuration is formatted:

```shell
terragrunt hcl format --check --file examples/deployments/helpers/terragrunt/_global_settings/dedicated_mac_hosts.hcl
```

The repository pre-commit suite also passes for the committed changes.
