### PR TITLE
test(splunk-otel): allow chart version updates

### DIFF
--- a/modules/integrations/splunk_otel_eks/tests/splunk_otel_eks_behavior.tftest.hcl
+++ b/modules/integrations/splunk_otel_eks/tests/splunk_otel_eks_behavior.tftest.hcl
@@ -114,7 +114,6 @@ run "splunk_otel_eks_contract" {
     condition = (
       helm_release.splunk_otel_collector.name == "splunk-otel-collector"
       && helm_release.splunk_otel_collector.chart == "splunk-otel-collector"
-      && helm_release.splunk_otel_collector.version == "0.155.0"
       && helm_release.splunk_otel_collector.namespace == "splunk-otel-collector"
       && helm_release.splunk_otel_collector.create_namespace == true
       && contains([for item in helm_release.splunk_otel_collector.set : "${item.name}=${item.value}"], "clusterName=forge-euw1-dev")


### PR DESCRIPTION
## Description

Remove the exact Splunk OpenTelemetry Collector chart version assertion from the behavior test. The test continues to validate the Helm release identity, namespace, and configured values while allowing Renovate to update the version in `otel.tf` without requiring a matching test edit.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu -chdir=modules/integrations/splunk_otel_eks test -no-color` — 3 passed, 0 failed
- Repository pre-commit hooks passed; `pip-audit` was skipped because `uv` is not installed locally and this change does not modify Python dependencies
