### PR TITLE
feat(runners): expose runner label maps

### DIFF
--- a/modules/platform/arc_deployment/outputs.tf
+++ b/modules/platform/arc_deployment/outputs.tf
@@ -5,6 +5,14 @@ output "arc_runners_arn_map" {
   description = "Map of ARC runner keys to their IAM role ARNs."
 }
 
+output "arc_runners_labels_map" {
+  value = {
+    for runner_key, spec in var.runner_configs.runner_specs :
+    runner_key => spec.scale_set_labels
+  }
+  description = "Map of ARC runner keys to their GitHub scale set labels."
+}
+
 output "subnet_cidr_blocks" {
   value       = module.arc.subnet_cidr_blocks
   description = "Map of ARC runner subnet IDs to their CIDR blocks."

--- a/modules/platform/arc_deployment/tests/platform_arc_deployment_interface_contract.tftest.hcl
+++ b/modules/platform/arc_deployment/tests/platform_arc_deployment_interface_contract.tftest.hcl
@@ -16,6 +16,7 @@ run "platform_arc_deployment_interface_contract" {
     expected_output_values = [
       "arc_cluster_name",
       "arc_runners_arn_map",
+      "arc_runners_labels_map",
       "subnet_cidr_blocks",
     ]
     expected_interface_literals = [
@@ -68,6 +69,9 @@ run "platform_arc_deployment_interface_contract" {
       "value = {",
       "for runner_key, runner in module.arc.runners_map : runner_key => runner.runner_role_arn",
       "description = \"Map of ARC runner keys to their IAM role ARNs.\"",
+      "output \"arc_runners_labels_map\"",
+      "runner_key => spec.scale_set_labels",
+      "description = \"Map of ARC runner keys to their GitHub scale set labels.\"",
       "output \"subnet_cidr_blocks\"",
       "value       = module.arc.subnet_cidr_blocks",
       "description = \"Map of ARC runner subnet IDs to their CIDR blocks.\"",
@@ -102,8 +106,8 @@ run "platform_arc_deployment_interface_contract" {
   assert {
     condition = (
       output.expected_input_variable_count == 4
-      && output.expected_output_value_count == 3
-      && output.expected_interface_literal_count == 52
+      && output.expected_output_value_count == 4
+      && output.expected_interface_literal_count == 55
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/platform/arc_deployment/tests/platform_arc_deployment_source_inventory.tftest.hcl
+++ b/modules/platform/arc_deployment/tests/platform_arc_deployment_source_inventory.tftest.hcl
@@ -10,6 +10,7 @@ run "platform_arc_deployment_contract" {
     expected_literals = [
       "module \"arc\"",
       "output \"arc_runners_arn_map\"",
+      "output \"arc_runners_labels_map\"",
       "output \"subnet_cidr_blocks\"",
       "output \"arc_cluster_name\"",
     ]

--- a/modules/platform/ec2_deployment/outputs.tf
+++ b/modules/platform/ec2_deployment/outputs.tf
@@ -17,6 +17,14 @@ output "ec2_runners_ami_name_map" {
   description = "Map of EC2 runner keys to the AMI names used for each runner."
 }
 
+output "ec2_runners_labels_map" {
+  value = {
+    for runner_key, spec in var.runner_configs.runner_specs :
+    runner_key => concat(spec.runner_labels, spec.extra_labels)
+  }
+  description = "Map of EC2 runner keys to their base and extra GitHub labels."
+}
+
 output "subnet_cidr_blocks" {
   value       = { for id, subnet in data.aws_subnet.runner_subnet : id => subnet.cidr_block }
   description = "Map of EC2 runner subnet IDs to their CIDR blocks."

--- a/modules/platform/ec2_deployment/tests/platform_ec2_deployment_interface_contract.tftest.hcl
+++ b/modules/platform/ec2_deployment/tests/platform_ec2_deployment_interface_contract.tftest.hcl
@@ -16,6 +16,7 @@ run "platform_ec2_deployment_interface_contract" {
     expected_output_values = [
       "ec2_runners_ami_name_map",
       "ec2_runners_arn_map",
+      "ec2_runners_labels_map",
       "event_bus_name",
       "subnet_cidr_blocks",
       "webhook_endpoint",
@@ -104,6 +105,9 @@ run "platform_ec2_deployment_interface_contract" {
       "output \"ec2_runners_arn_map\"",
       "for runner_key, runner in module.runners.runners_map : runner_key => runner.role_runner[0].arn",
       "description = \"Map of EC2 runner keys to their IAM role ARNs.\"",
+      "output \"ec2_runners_labels_map\"",
+      "runner_key => concat(spec.runner_labels, spec.extra_labels)",
+      "description = \"Map of EC2 runner keys to their base and extra GitHub labels.\"",
       "output \"event_bus_name\"",
       "value       = module.runners.webhook.eventbridge.event_bus.name",
       "description = \"Name of the EventBridge event bus used by the webhook relay.\"",
@@ -144,8 +148,8 @@ run "platform_ec2_deployment_interface_contract" {
   assert {
     condition = (
       output.expected_input_variable_count == 4
-      && output.expected_output_value_count == 5
-      && output.expected_interface_literal_count == 92
+      && output.expected_output_value_count == 6
+      && output.expected_interface_literal_count == 95
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/platform/ec2_deployment/tests/platform_ec2_deployment_source_inventory.tftest.hcl
+++ b/modules/platform/ec2_deployment/tests/platform_ec2_deployment_source_inventory.tftest.hcl
@@ -29,6 +29,7 @@ run "platform_ec2_deployment_contract" {
       "output \"webhook_endpoint\"",
       "output \"ec2_runners_arn_map\"",
       "output \"ec2_runners_ami_name_map\"",
+      "output \"ec2_runners_labels_map\"",
       "output \"subnet_cidr_blocks\"",
       "output \"event_bus_name\"",
     ]

--- a/modules/platform/forge_runners/outputs.tf
+++ b/modules/platform/forge_runners/outputs.tf
@@ -13,11 +13,13 @@ output "forge_runners" {
       runners_arn_map    = try(module.ec2_runners[0].ec2_runners_arn_map, {})
       ami_name_map       = try(module.ec2_runners[0].ec2_runners_ami_name_map, {})
       subnet_cidr_blocks = try(module.ec2_runners[0].subnet_cidr_blocks, [])
+      runner_labels      = try(module.ec2_runners[0].ec2_runners_labels_map, {})
     }
     arc = {
       cluster_name       = try(module.arc_runners.arc_cluster_name, {})
       runners_arn_map    = try(module.arc_runners.arc_runners_arn_map, {})
       subnet_cidr_blocks = try(module.arc_runners.subnet_cidr_blocks, [])
+      runner_labels      = try(module.arc_runners.arc_runners_labels_map, {})
     }
   }
 }

--- a/modules/platform/forge_runners/tests/platform_forge_runners_interface_contract.tftest.hcl
+++ b/modules/platform/forge_runners/tests/platform_forge_runners_interface_contract.tftest.hcl
@@ -262,10 +262,12 @@ run "platform_forge_runners_interface_contract" {
       "runners_arn_map    = try(module.ec2_runners[0].ec2_runners_arn_map, {})",
       "ami_name_map       = try(module.ec2_runners[0].ec2_runners_ami_name_map, {})",
       "subnet_cidr_blocks = try(module.ec2_runners[0].subnet_cidr_blocks, [])",
+      "runner_labels      = try(module.ec2_runners[0].ec2_runners_labels_map, {})",
       "arc = {",
       "cluster_name       = try(module.arc_runners.arc_cluster_name, {})",
       "runners_arn_map    = try(module.arc_runners.arc_runners_arn_map, {})",
       "subnet_cidr_blocks = try(module.arc_runners.subnet_cidr_blocks, [])",
+      "runner_labels      = try(module.arc_runners.arc_runners_labels_map, {})",
       "output \"forge_webhook_relay\"",
       "description = \"Webhook relay integration outputs.\"",
       "source_secret_arn      = try(module.github_webhook_relay[0].source_secret_arn, null)",
@@ -303,7 +305,7 @@ run "platform_forge_runners_interface_contract" {
     condition = (
       output.expected_input_variable_count == 10
       && output.expected_output_value_count == 5
-      && output.expected_interface_literal_count == 244
+      && output.expected_interface_literal_count == 246
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }


### PR DESCRIPTION
## Description

Expose runner label maps from the EC2 and ARC deployment modules and include them in the combined `forge_runners` output.

- Combine each EC2 runner type's base `runner_labels` and `extra_labels`.
- Expose each ARC runner type's `scale_set_labels`.
- Consume both deployment outputs through `forge_runners.ec2.runner_labels` and `forge_runners.arc.runner_labels`.
- Extend the deployment and Forge runner interface contracts for the new outputs.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

Reviewers can validate the output contracts with:

```shell
cd modules/platform/ec2_deployment
tofu test -test-directory=tests

cd ../arc_deployment
tofu test -test-directory=tests

cd ../forge_runners
tofu test -test-directory=tests -filter=tests/platform_forge_runners_interface_contract.tftest.hcl
```

The repository pre-commit hook suite also passes for commit `936fc32`.
