### PR TITLE
fix(lambda): prevent recurring deployment plans

### DIFF
--- a/modules/integrations/splunk_aws_billing/billing_per_resource.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource.tf
@@ -29,7 +29,7 @@ module "cur_per_resource" {
   logging_log_group                 = aws_cloudwatch_log_group.cur_per_resource.name
   use_existing_cloudwatch_log_group = true
 
-  trigger_on_package_timestamp = true
+  trigger_on_package_timestamp = false
 
   environment_variables = {
     SPLUNK_HEC_URL       = var.splunk_aws_billing_config.splunk_hec_url

--- a/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
@@ -29,7 +29,7 @@ module "cur_per_resource_process" {
   logging_log_group                 = aws_cloudwatch_log_group.cur_per_resource_process.name
   use_existing_cloudwatch_log_group = true
 
-  trigger_on_package_timestamp = true
+  trigger_on_package_timestamp = false
 
   environment_variables = {
     SPLUNK_HEC_URL       = var.splunk_aws_billing_config.splunk_hec_url

--- a/modules/integrations/splunk_aws_billing/billing_per_service.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_service.tf
@@ -30,7 +30,7 @@ module "cur_per_service" {
   logging_log_group                 = aws_cloudwatch_log_group.cur_per_service.name
   use_existing_cloudwatch_log_group = true
 
-  trigger_on_package_timestamp = true
+  trigger_on_package_timestamp = false
 
   environment_variables = {
     SPLUNK_HEC_URL       = var.splunk_aws_billing_config.splunk_hec_url

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
@@ -113,10 +113,7 @@ module "worker" {
   role_tags     = local.all_security_tags
   tags          = local.all_security_tags
 
-  depends_on = [
-    aws_cloudwatch_log_group.worker,
-    aws_ssm_parameter.tenant_configs,
-  ]
+  depends_on = [aws_cloudwatch_log_group.worker]
 }
 
 resource "aws_lambda_event_source_mapping" "worker_from_dedupe_stream" {

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/tenant_configs.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/tenant_configs.tf
@@ -5,8 +5,8 @@ resource "aws_ssm_parameter" "tenant_configs" {
     tostring(index) => chunk
   }
 
-  name  = "${local.redelivery_tenant_config_parameter_prefix}/${each.key}"
-  type  = "String"
-  value = each.value
-  tags  = local.all_security_tags
+  name           = "${local.redelivery_tenant_config_parameter_prefix}/${each.key}"
+  type           = "String"
+  insecure_value = each.value
+  tags           = local.all_security_tags
 }

--- a/tests/iac/terraform_contract_test.py
+++ b/tests/iac/terraform_contract_test.py
@@ -314,7 +314,10 @@ def test_splunk_stuck_dispatcher_worker_contract_is_offline_and_scoped() -> None
             'values   = ["ssm.*.amazonaws.com"]',
         ],
     )
-    assert 'type  = "String"' in tenant_configs_tf
+    assert 'type           = "String"' in tenant_configs_tf
+    assert 'insecure_value = each.value' in tenant_configs_tf
+    assert 'depends_on = [aws_cloudwatch_log_group.worker]' in worker_module
+    assert 'aws_ssm_parameter.tenant_configs' not in worker_module
 
 
 def test_redrive_deadletter_policy_scope_is_configured_from_sqs_map() -> None:

--- a/tests/iac/terraform_contract_test.py
+++ b/tests/iac/terraform_contract_test.py
@@ -143,6 +143,24 @@ def assert_contains_all(text: str, expected: Iterable[str]) -> None:
     assert not missing, f'missing expected Terraform contract text: {missing}'
 
 
+@pytest.mark.parametrize(
+    'filename',
+    [
+        'billing_per_resource_process.tf',
+        'billing_per_resource.tf',
+        'billing_per_service.tf',
+    ],
+)
+def test_splunk_aws_billing_packages_ignore_artifact_timestamps(
+    filename: str,
+) -> None:
+    module_tf = read_repo_file(
+        f'modules/integrations/splunk_aws_billing/{filename}'
+    )
+
+    assert 'trigger_on_package_timestamp = false' in module_tf
+
+
 def test_job_log_pipeline_wires_runtime_env_and_event_contract() -> None:
     dispatcher_tf = read_repo_file(
         'modules/platform/forge_runners/github_actions_job_logs/'


### PR DESCRIPTION
## Description

Prevent recurring Lambda-related plan changes across the stuck workflow job dispatcher and AWS billing integrations.

- Store non-secret dispatcher tenant routing chunks through the SSM parameter `insecure_value` argument.
- Keep the worker's explicit CloudWatch log-group dependency while removing the broad SSM dependency that caused updates to cascade into unknown Lambda package and IAM policy values.
- Ignore local package timestamps for the three AWS billing Lambdas so clean Terragrunt and CI workspaces do not trigger unchanged deployments.
- Add contract coverage for the SSM value argument, narrowed worker dependency, and billing package settings.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

1. Run `.venv/bin/pytest tests/iac/terraform_contract_test.py -q` and confirm all tests pass.
2. Run a Terragrunt apply for `splunk_stuck_workflow_job_dispatcher` to perform the one-time SSM argument migration.
3. Run Terragrunt plan again with unchanged tenant configuration and confirm it no longer proposes SSM tenant-value updates or cascading worker Lambda/IAM changes.
4. Run Terragrunt plan for `splunk_aws_billing` from a clean workspace and confirm unchanged Lambda sources do not produce package or function updates.
