### PR TITLE
feat(observability): improve Forge detector signal quality

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
@@ -2,7 +2,7 @@ resource "signalfx_time_chart" "write_throttle_events" {
   name         = "Write throttle events"
   description  = "Requests to DynamoDB that exceed the provisioned write capacity units for a table or a global secondary index."
   program_text = <<-EOF
-A = data('WriteThrottleEvents', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').publish(label='A')
+A = data('WriteThrottleEvents', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'TableName']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -32,7 +32,7 @@ resource "signalfx_time_chart" "system_errors_ts" {
   name         = "System errors"
   description  = "Requests to DynamoDB or Amazon DynamoDB streams that generate an HTTP 500 status code during the specified time period."
   program_text = <<-EOF
-A = data('SystemErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum').publish(label='A')
+A = data('SystemErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'TableName', 'Operation']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -59,8 +59,8 @@ resource "signalfx_time_chart" "read_capacity_percentage" {
   name         = "Percentage of read capacity consumed"
   description  = "The percentage of read capacity units consumed over the specified time period, so you can track how much of your provisioned throughput is used."
   program_text = <<-EOF
-A = data('ProvisionedReadCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).publish(label='A', enable=False)
-B = data('ConsumedReadCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).publish(label='B', enable=False)
+A = data('ProvisionedReadCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).mean(by=['aws_tag_TenantName', 'TableName']).publish(label='A', enable=False)
+B = data('ConsumedReadCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).mean(by=['aws_tag_TenantName', 'TableName']).publish(label='B', enable=False)
 C = ((B/A)*100).publish(label='C')
 EOF
 
@@ -124,7 +124,7 @@ resource "signalfx_time_chart" "returned_item_count" {
   name         = "Returned item count"
   description  = "The number of items returned by query or scan operations during the specified time period."
   program_text = <<-EOF
-A = data('ReturnedItemCount', filter=filter('namespace', 'AWS/DynamoDB') and filter('TableName', '*') and filter('Operation', '*') and filter('stat', 'count'), rollup='sum').publish(label='A')
+A = data('ReturnedItemCount', filter=filter('namespace', 'AWS/DynamoDB') and filter('TableName', '*') and filter('Operation', '*') and filter('stat', 'count'), rollup='sum').sum(by=['aws_tag_TenantName', 'TableName', 'Operation']).publish(label='A')
 EOF
 
   plot_type   = "LineChart"
@@ -201,7 +201,7 @@ resource "signalfx_time_chart" "avg_request_latency_ts" {
   name         = "Average request latency (ms)"
   description  = "Successful requests to DynamoDB or Amazon DynamoDB streams during the specified time period."
   program_text = <<-EOF
-A = data('SuccessfulRequestLatency', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean')).publish(label='A')
+A = data('SuccessfulRequestLatency', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*') and filter('Operation', '*')).mean(by=['aws_tag_TenantName', 'TableName', 'Operation']).publish(label='A')
 EOF
 
   axes_precision = 0
@@ -279,7 +279,7 @@ resource "signalfx_single_value_chart" "system_errors_single" {
   color_by    = "Dimension"
 
   program_text = <<-EOF
-A = data('SystemErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum').publish(label='A')
+A = data('SystemErrors', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'TableName', 'Operation']).publish(label='A')
 EOF
 
   viz_options {
@@ -323,7 +323,7 @@ resource "signalfx_time_chart" "read_throttle_events" {
   name         = "Read throttle events"
   description  = "Requests to DynamoDB that exceed the provisioned read capacity units for a table or a global secondary index."
   program_text = <<-EOF
-A = data('ReadThrottleEvents', filter=filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').publish(label='A')
+A = data('ReadThrottleEvents', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'TableName']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -351,7 +351,7 @@ resource "signalfx_time_chart" "throttled_requests_ts" {
   name         = "Throttled requests"
   description  = "Requests to DynamoDB that exceed the provisioned throughput limits on a resource (such as a table or an index)."
   program_text = <<-EOF
-A = data('ThrottledRequests', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum'), rollup='sum').publish(label='A')
+A = data('ThrottledRequests', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'TableName']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -411,8 +411,8 @@ resource "signalfx_time_chart" "write_capacity_percentage" {
   name         = "Percentage of write capacity consumed"
   description  = "The percentage of write capacity units consumed over the specified time period, so you can track how much of your provisioned throughput is used."
   program_text = <<-EOF
-A = data('ProvisionedWriteCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).publish(label='A', enable=False)
-B = data('ConsumedWriteCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).publish(label='B', enable=False)
+A = data('ProvisionedWriteCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).mean(by=['aws_tag_TenantName', 'TableName']).publish(label='A', enable=False)
+B = data('ConsumedWriteCapacityUnits', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'mean') and filter('TableName', '*')).mean(by=['aws_tag_TenantName', 'TableName']).publish(label='B', enable=False)
 C = ((B/A)*100).publish(label='C')
 EOF
 
@@ -504,8 +504,8 @@ resource "signalfx_dashboard" "dynamodb" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = []
-    value_required         = false
+    values                 = sort(var.tenant_names)
+    value_required         = length(var.tenant_names) > 0
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/dynamodb_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/dynamodb_dashboard_behavior.tftest.hcl
@@ -28,6 +28,8 @@ run "dynamodb_dashboard_contract" {
       && strcontains(signalfx_time_chart.read_capacity_percentage.program_text, "ConsumedReadCapacityUnits")
       && signalfx_single_value_chart.throttled_requests_single.name == "Throttled requests"
       && strcontains(signalfx_time_chart.throttled_requests_ts.program_text, "ThrottledRequests")
+      && strcontains(signalfx_time_chart.throttled_requests_ts.program_text, ".sum(by=['aws_tag_TenantName', 'TableName'])")
+      && strcontains(signalfx_time_chart.system_errors_ts.program_text, ".sum(by=['aws_tag_TenantName', 'TableName', 'Operation'])")
     )
     error_message = "DynamoDB charts must keep one-hour capacity, error, and throttling visibility."
   }
@@ -40,6 +42,8 @@ run "dynamodb_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.dynamodb.name == "DynamoDBs"
       && signalfx_dashboard.dynamodb.dashboard_group == "forge-dashboard-group"
+      && signalfx_dashboard.dynamodb.variable[0].values == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.dynamodb.variable[0].value_required
       && length(signalfx_dashboard.dynamodb.chart) == 13
     )
     error_message = "DynamoDB dashboard must keep its name, group input, and chart count."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/README.md
@@ -10,6 +10,7 @@ ARC runners and EKS infrastructure depend on storage behaving predictably. This 
 
 - Read/write throughput, operations, and latency charts.
 - Queue length, idle time, byte utilization, and state views.
+- Provisioned IOPS exceeded visibility by tenant and volume.
 - Read/write breakdowns for EBS-backed runner or platform volumes.
 - Dashboard placement in the shared Forge O11y group.
 
@@ -54,6 +55,7 @@ No modules.
 | [signalfx_time_chart.rw_bytes_breakdown](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.total_read_time](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.total_write_time](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.volume_iops_exceeded](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.write_latency](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.write_ops](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.write_throughput](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
@@ -1,3 +1,9 @@
+locals {
+  ebs_tenant_filter = length(var.tenant_names) > 0 ? join(" or ", [
+    for tenant_name in sort(var.tenant_names) : "filter('aws_tag_TenantName', '${tenant_name}')"
+  ]) : "filter('aws_tag_TenantName', '__forge_tenant_scope_not_configured__')"
+}
+
 resource "signalfx_time_chart" "byte_utilization_pct" {
   name = "Byte utilization %"
 
@@ -301,12 +307,12 @@ EOF
 
 resource "signalfx_time_chart" "latency_op" {
   name         = "Latency/op (ms)"
-  description  = ""
+  description  = "Compares average read and write latency by Forge tenant and EBS volume."
   program_text = <<-EOF
-A = data('VolumeWriteOps', filter=filter('namespace', 'AWS/EBS') and filter('VolumeId', 'vol-46dcc55f') and filter('stat', 'sum'), extrapolation='zero', rollup='rate').scale(60).publish(label='A')
-B = data('VolumeTotalWriteTime', filter=filter('namespace', 'AWS/EBS') and filter('VolumeId', 'vol-46dcc55f') and filter('stat', 'sum'), extrapolation='zero', rollup='rate').scale(60).publish(label='B', enable=False)
-C = data('VolumeReadOps', filter=filter('namespace', 'AWS/EBS') and filter('VolumeId', 'vol-46dcc55f') and filter('stat', 'sum'), extrapolation='zero', rollup='rate').scale(60).publish(label='C')
-D = data('VolumeTotalReadTime', filter=filter('namespace', 'AWS/EBS') and filter('VolumeId', 'vol-46dcc55f') and filter('stat', 'sum'), extrapolation='zero', rollup='rate').scale(60).publish(label='D', enable=False)
+A = data('VolumeWriteOps', filter=(${local.ebs_tenant_filter}) and filter('namespace', 'AWS/EBS') and filter('VolumeId', '*') and filter('stat', 'sum'), extrapolation='zero', rollup='rate').sum(by=['aws_tag_TenantName', 'aws_region', 'VolumeId']).scale(60).publish(label='A')
+B = data('VolumeTotalWriteTime', filter=(${local.ebs_tenant_filter}) and filter('namespace', 'AWS/EBS') and filter('VolumeId', '*') and filter('stat', 'sum'), extrapolation='zero', rollup='rate').sum(by=['aws_tag_TenantName', 'aws_region', 'VolumeId']).scale(60).publish(label='B', enable=False)
+C = data('VolumeReadOps', filter=(${local.ebs_tenant_filter}) and filter('namespace', 'AWS/EBS') and filter('VolumeId', '*') and filter('stat', 'sum'), extrapolation='zero', rollup='rate').sum(by=['aws_tag_TenantName', 'aws_region', 'VolumeId']).scale(60).publish(label='C')
+D = data('VolumeTotalReadTime', filter=(${local.ebs_tenant_filter}) and filter('namespace', 'AWS/EBS') and filter('VolumeId', '*') and filter('stat', 'sum'), extrapolation='zero', rollup='rate').sum(by=['aws_tag_TenantName', 'aws_region', 'VolumeId']).scale(60).publish(label='D', enable=False)
 E = (B/A).scale(1000).publish(label='E')
 F = (D/C).scale(1000).publish(label='F')
 EOF
@@ -334,6 +340,23 @@ EOF
 
   histogram_options {
     color_theme = "gold"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "VolumeId"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "sf_metric"
   }
 
   viz_options {
@@ -524,6 +547,31 @@ EOF
     value_suffix = "No of ops"
   }
 }
+
+resource "signalfx_time_chart" "volume_iops_exceeded" {
+  name        = "Volume IOPS exceeded"
+  description = "Shows EBS volumes that exceeded their provisioned IOPS performance during the selected interval."
+
+  program_text = <<-EOF
+A = data('VolumeIOPSExceededCheck', filter=(${local.ebs_tenant_filter}) and filter('namespace', 'AWS/EBS') and filter('stat', 'upper'), rollup='latest').max(by=['aws_tag_TenantName', 'aws_region', 'VolumeId']).publish(label='A')
+EOF
+
+  plot_type                 = "ColumnChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "VolumeId"
+  time_range                = 86400
+
+  axis_left {
+    label = "Exceeded"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}} - {{VolumeId}}"
+    label        = "A"
+  }
+}
+
 resource "signalfx_dashboard" "ebs" {
   name            = "EBS"
   description     = "EC2/EBS volume throughput, IOPS, and latency for Forge runners."
@@ -533,8 +581,8 @@ resource "signalfx_dashboard" "ebs" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = []
-    value_required         = false
+    values                 = sort(var.tenant_names)
+    value_required         = length(var.tenant_names) > 0
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }
@@ -671,6 +719,14 @@ resource "signalfx_dashboard" "ebs" {
     column   = 4
     row      = 4
     width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.volume_iops_exceeded.id
+    column   = 0
+    row      = 5
+    width    = 12
     height   = 1
   }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/ebs_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/ebs_dashboard_behavior.tftest.hcl
@@ -26,7 +26,12 @@ run "ebs_dashboard_contract" {
       && strcontains(signalfx_time_chart.byte_utilization_pct.program_text, "EBSByteBalance%")
       && signalfx_time_chart.latency_op.name == "Latency/op (ms)"
       && signalfx_time_chart.latency_op.time_range == 7200
+      && !strcontains(signalfx_time_chart.latency_op.program_text, "vol-46dcc55f")
+      && strcontains(signalfx_time_chart.latency_op.program_text, ".sum(by=['aws_tag_TenantName', 'aws_region', 'VolumeId'])")
       && signalfx_single_value_chart.state.name == "State"
+      && strcontains(signalfx_time_chart.volume_iops_exceeded.program_text, "VolumeIOPSExceededCheck")
+      && strcontains(signalfx_time_chart.volume_iops_exceeded.program_text, "filter('aws_tag_TenantName', 'tenant-a') or filter('aws_tag_TenantName', 'tenant-b')")
+      && strcontains(signalfx_time_chart.volume_iops_exceeded.program_text, "filter('stat', 'upper')")
     )
     error_message = "EBS charts must keep one-hour utilization visibility, latency, and volume state behavior."
   }
@@ -39,7 +44,9 @@ run "ebs_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.ebs.name == "EBS"
       && signalfx_dashboard.ebs.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.ebs.chart) == 15
+      && signalfx_dashboard.ebs.variable[0].values == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.ebs.variable[0].value_required
+      && length(signalfx_dashboard.ebs.chart) == 16
     )
     error_message = "EBS dashboard must keep its name, group input, and chart count."
   }
@@ -48,6 +55,7 @@ run "ebs_dashboard_wiring_contract" {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.ebs.chart : chart.chart_id], signalfx_single_value_chart.state.id),
       contains([for chart in signalfx_dashboard.ebs.chart : chart.chart_id], signalfx_time_chart.avg_queue_length.id),
+      contains([for chart in signalfx_dashboard.ebs.chart : chart.chart_id], signalfx_time_chart.volume_iops_exceeded.id),
     ])
     error_message = "EBS dashboard must keep its first and final chart wiring."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/integrations_splunk_o11y_conf_shared_dashboards_ebs_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/integrations_splunk_o11y_conf_shared_dashboards_ebs_source_inventory.tftest.hcl
@@ -23,6 +23,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_ebs_source_inventory" {
       "resource \"signalfx_time_chart\" \"avg_queue_length\"",
       "resource \"signalfx_time_chart\" \"idle_time\"",
       "resource \"signalfx_time_chart\" \"write_ops\"",
+      "resource \"signalfx_time_chart\" \"volume_iops_exceeded\"",
       "resource \"signalfx_dashboard\" \"ebs\"",
     ]
   }
@@ -33,7 +34,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_ebs_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 16
-    error_message = "Source inventory must keep 16 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 17
+    error_message = "Source inventory must keep 17 module-specific Terraform blocks pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
@@ -1,7 +1,10 @@
 locals {
   k8s_tenant_namespace_filter = length(var.tenant_names) > 0 ? join(" or ", [
     for namespace in sort(var.tenant_names) : "filter('k8s.namespace.name', '${namespace}')"
-  ]) : "filter('k8s.namespace.name', '*')"
+  ]) : "filter('k8s.namespace.name', '__forge_tenant_scope_not_configured__')"
+  ec2_tenant_filter = length(var.tenant_names) > 0 ? join(" or ", [
+    for tenant_name in sort(var.tenant_names) : "filter('aws_tag_TenantName', '${tenant_name}')"
+  ]) : "filter('aws_tag_TenantName', '__forge_tenant_scope_not_configured__')"
 
   k8s_runner_container_filter  = "filter('k8s.container.name', 'runner') and (${local.k8s_tenant_namespace_filter})"
   k8s_runner_pod_dimensions    = "['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']"
@@ -16,7 +19,7 @@ resource "signalfx_list_chart" "runner_totals_by_runtime" {
   description = "Counts EC2 runner instances and K8S runner pods that reported during the selected dashboard time window."
 
   program_text = <<-EOF
-A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id']).count(over=${local.dashboard_window}).above(0, inclusive=False).count().publish(label='EC2 runners')
+A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id']).count(over=${local.dashboard_window}).above(0, inclusive=False).count().publish(label='EC2 runners')
 B = ${local.k8s_runner_container_runtime}.count(over=${local.dashboard_window}).above(0, inclusive=False).count().publish(label='K8S runner pods')
 EOF
 
@@ -47,7 +50,7 @@ resource "signalfx_list_chart" "runner_minutes_by_runtime" {
   description = "Estimates total EC2 and K8S runner runtime minutes during the selected dashboard time window. EC2 instances must have aws_tag_TenantName."
 
   program_text = <<-EOF
-A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean') and filter('aws_tag_TenantName', '*'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id']).count().fill(value=0, duration=${local.runner_usage_window}).integrate().sum(over=${local.runner_usage_window}).scale(${local.runner_minutes_scale}).publish(label='EC2 runner-minutes')
+A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id']).count().fill(value=0, duration=${local.runner_usage_window}).integrate().sum(over=${local.runner_usage_window}).scale(${local.runner_minutes_scale}).publish(label='EC2 runner-minutes')
 B = ${local.k8s_runner_container_runtime}.count().fill(value=0, duration=${local.runner_usage_window}).integrate().sum(over=${local.runner_usage_window}).scale(${local.runner_minutes_scale}).publish(label='K8S runner-minutes')
 EOF
 
@@ -78,7 +81,7 @@ resource "signalfx_time_chart" "active_ec2_runners_by_tenant_and_instance_type" 
   description = "Tracks active EC2 runner instance count over time by tenant and instance type."
 
   program_text = <<-EOF
-A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName', 'aws_instance_type']).count(by=['aws_tag_TenantName', 'aws_instance_type']).publish(label='A')
+A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName', 'aws_instance_type']).count(by=['aws_tag_TenantName', 'aws_instance_type']).publish(label='A')
 EOF
 
   plot_type        = "LineChart"
@@ -114,7 +117,7 @@ resource "signalfx_list_chart" "active_ec2_runners_by_tenant" {
   name        = "Active EC2 runners by tenant"
   description = "Counts currently active EC2 runner instances by tenant."
 
-  program_text = "A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName']).count(by=['aws_tag_TenantName']).publish(label='A')"
+  program_text = "A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName']).count(by=['aws_tag_TenantName']).publish(label='A')"
 
   sort_by = "-value"
 
@@ -142,7 +145,7 @@ resource "signalfx_list_chart" "active_ec2_runners_by_tenant_and_instance_type" 
   name        = "Active EC2 runners by tenant and instance type"
   description = "Counts currently active EC2 runner instances by tenant and EC2 instance type."
 
-  program_text = "A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName', 'aws_instance_type']).count(by=['aws_tag_TenantName', 'aws_instance_type']).publish(label='A')"
+  program_text = "A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName', 'aws_instance_type']).count(by=['aws_tag_TenantName', 'aws_instance_type']).publish(label='A')"
 
   sort_by = "-value"
 
@@ -174,7 +177,7 @@ resource "signalfx_list_chart" "total_ec2_runners_by_tenant" {
   name        = "Total EC2 runners by tenant over selected window"
   description = "Counts EC2 runner instances that reported during the selected dashboard time window by tenant."
 
-  program_text = "A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName']).count(over=${local.dashboard_window}).above(0, inclusive=False).count(by=['aws_tag_TenantName']).publish(label='A')"
+  program_text = "A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName']).count(over=${local.dashboard_window}).above(0, inclusive=False).count(by=['aws_tag_TenantName']).publish(label='A')"
 
   sort_by = "-value"
 
@@ -202,7 +205,7 @@ resource "signalfx_list_chart" "ec2_runner_hours_by_tenant" {
   name        = "EC2 runner-minutes by tenant"
   description = "Estimates EC2 runner running minutes by tenant over the selected dashboard time window."
 
-  program_text = "A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName']).count(by=['aws_tag_TenantName']).fill(value=0, duration=${local.runner_usage_window}).integrate().sum(over=${local.runner_usage_window}).scale(${local.runner_minutes_scale}).publish(label='A')"
+  program_text = "A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName']).count(by=['aws_tag_TenantName']).fill(value=0, duration=${local.runner_usage_window}).integrate().sum(over=${local.runner_usage_window}).scale(${local.runner_minutes_scale}).publish(label='A')"
 
   sort_by = "-value"
 
@@ -230,7 +233,7 @@ resource "signalfx_list_chart" "ec2_runner_hours_by_tenant_and_instance_type" {
   name        = "EC2 runner-minutes by tenant and instance type"
   description = "Estimates EC2 runner running minutes by tenant and instance type over the selected dashboard time window."
 
-  program_text = "A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName', 'aws_instance_type']).count(by=['aws_tag_TenantName', 'aws_instance_type']).fill(value=0, duration=${local.runner_usage_window}).integrate().sum(over=${local.runner_usage_window}).scale(${local.runner_minutes_scale}).publish(label='A')"
+  program_text = "A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=2).max(by=['aws_instance_id', 'aws_tag_TenantName', 'aws_instance_type']).count(by=['aws_tag_TenantName', 'aws_instance_type']).fill(value=0, duration=${local.runner_usage_window}).integrate().sum(over=${local.runner_usage_window}).scale(${local.runner_minutes_scale}).publish(label='A')"
 
   sort_by = "-value"
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -30,6 +30,7 @@ run "forge_impact_dashboard_contract" {
     condition = (
       signalfx_list_chart.runner_totals_by_runtime.name == "Total runners by runtime over selected window"
       && strcontains(signalfx_list_chart.runner_totals_by_runtime.program_text, "CPUUtilization")
+      && strcontains(signalfx_list_chart.runner_totals_by_runtime.program_text, "filter('aws_tag_TenantName', 'tenant-a') or filter('aws_tag_TenantName', 'tenant-b')")
       && strcontains(signalfx_list_chart.runner_totals_by_runtime.program_text, "filter('k8s.namespace.name', 'tenant-a') or filter('k8s.namespace.name', 'tenant-b')")
       && signalfx_list_chart.active_ec2_runners_by_tenant.name == "Active EC2 runners by tenant"
       && strcontains(signalfx_list_chart.k8s_runners_by_tenant.program_text, "container.memory.usage")

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
@@ -2,7 +2,7 @@ resource "signalfx_time_chart" "provisioned_concurrent_executions_by_version" {
   name         = "Provisioned concurrent executions by version"
   description  = "The number of events that are being processed on provisioned concurrency. For each invocation of an alias or version with provisioned concurrency, Lambda emits the current count."
   program_text = <<-EOF
-A = data('ProvisionedConcurrentExecutions', filter=filter('stat', 'upper') and filter('Resource', '*') and filter('ExecutedVersion', '*')).sum(by=['ExecutedVersion']).publish(label='A')
+A = data('ProvisionedConcurrentExecutions', filter=filter('stat', 'upper') and filter('Resource', '*') and filter('ExecutedVersion', '*')).sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -28,7 +28,7 @@ resource "signalfx_time_chart" "provisioned_concurrency_invocations_by_version" 
   name         = "Provisioned concurrency invocations by version"
   description  = "The number of invocations that are run on provisioned concurrency. Lambda increments the count once for each invocation that runs on provisioned concurrency."
   program_text = <<-EOF
-A = data('ProvisionedConcurrencyInvocations', filter=filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='rate').sum(by=['ExecutedVersion']).publish(label='A')
+A = data('ProvisionedConcurrencyInvocations', filter=filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='rate').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -54,6 +54,14 @@ EOF
     property = "FunctionName"
   }
   legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
     enabled  = false
     property = "sf_originatingMetric"
   }
@@ -66,7 +74,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "Resource"
   }
   legend_options_fields {
@@ -85,7 +93,7 @@ resource "signalfx_time_chart" "provisioned_concurrency_spillover_invocations_by
   name         = "Provisioned concurrency spillover invocations by version"
   description  = "The number of invocations that are run on nonprovisioned concurrency, when all provisioned concurrency is in use. For a version or alias that is configured to use provisioned concurrency, Lambda increments the count once for each invocation that runs on non-provisioned concurrency."
   program_text = <<-EOF
-A = data('ProvisionedConcurrencySpilloverInvocations', filter=filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='rate').sum(by=['ExecutedVersion']).publish(label='A')
+A = data('ProvisionedConcurrencySpilloverInvocations', filter=filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='rate').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -111,6 +119,10 @@ EOF
     property = "FunctionName"
   }
   legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
     enabled  = false
     property = "sf_originatingMetric"
   }
@@ -123,7 +135,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "Resource"
   }
   legend_options_fields {
@@ -163,9 +175,9 @@ resource "signalfx_list_chart" "percent_invocations_by_version" {
   sort_by                 = "-value"
 
   program_text = <<-EOF
+A = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).publish(label='A', enable=False)
+B = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='B', enable=False)
 C = (B/A).scale(100).publish(label='C')
-A = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum', extrapolation='zero').sum().publish(label='A', enable=False)
-B = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum', extrapolation='zero').sum(by=['ExecutedVersion']).publish(label='B', enable=False)
 EOF
 
   time_range = 3600
@@ -177,6 +189,10 @@ EOF
   legend_options_fields {
     enabled  = true
     property = "ExecutedVersion"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
   }
   legend_options_fields {
     enabled  = false
@@ -195,7 +211,7 @@ EOF
     property = "namespace"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "Resource"
   }
   legend_options_fields {
@@ -226,7 +242,7 @@ resource "signalfx_time_chart" "errors_by_version" {
   name         = "Errors by version"
   description  = "The number of invocations that failed due to errors in the function (response code 4XX)."
   program_text = <<-EOF
-A = data('Errors', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('ExecutedVersion', '*') and filter('Resource', '*'), rollup='sum').sum(by=['ExecutedVersion']).publish(label='A')
+A = data('Errors', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('ExecutedVersion', '*') and filter('Resource', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -249,6 +265,10 @@ EOF
     property = "FunctionName"
   }
   legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
     enabled  = false
     property = "sf_originatingMetric"
   }
@@ -261,7 +281,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "Resource"
   }
   legend_options_fields {
@@ -312,7 +332,7 @@ resource "signalfx_list_chart" "avg_duration_by_version" {
   disable_sampling = true
 
   program_text = <<-EOF
-A = data('Duration', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='average').sum(by=['ExecutedVersion']).publish(label='A')
+A = data('Duration', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='average').mean(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
 EOF
 
   time_range = 3600
@@ -322,8 +342,12 @@ EOF
     property = "AWSUniqueId"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "FunctionName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
   }
   legend_options_fields {
     enabled  = false
@@ -338,7 +362,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "Resource"
   }
   legend_options_fields {
@@ -383,7 +407,7 @@ resource "signalfx_time_chart" "throttles_by_version" {
   name         = "Throttles by version"
   description  = "The number of Lambda function invocation attempts that were throttled due to invocation rates exceeding the customer’s concurrent limits (error code 429)."
   program_text = <<-EOF
-A = data('Throttles', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum').sum(by=['ExecutedVersion']).publish(label='A')
+A = data('Throttles', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -406,6 +430,10 @@ EOF
     property = "FunctionName"
   }
   legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
     enabled  = false
     property = "sf_originatingMetric"
   }
@@ -418,7 +446,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "Resource"
   }
   legend_options_fields {
@@ -446,7 +474,7 @@ resource "signalfx_time_chart" "invocations_by_version" {
   name         = "Invocations by version"
   description  = "The number of times a function is invoked in response to an event or invocation API call."
   program_text = <<-EOF
-A = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum').sum(by=['ExecutedVersion']).publish(label='A')
+A = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -485,7 +513,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "Resource"
   }
   legend_options_fields {
@@ -679,8 +707,8 @@ resource "signalfx_dashboard" "lambda" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = []
-    value_required         = false
+    values                 = sort(var.tenant_names)
+    value_required         = length(var.tenant_names) > 0
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
@@ -29,6 +29,8 @@ run "lambda_dashboard_contract" {
       && strcontains(signalfx_single_value_chart.total_throttles.program_text, ".sum(over='30m')")
       && strcontains(signalfx_single_value_chart.total_invocations.program_text, ".sum(over='30m')")
       && strcontains(signalfx_time_chart.errors_by_version.program_text, "Errors")
+      && strcontains(signalfx_time_chart.errors_by_version.program_text, ".sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion'])")
+      && strcontains(signalfx_list_chart.avg_duration_by_version.program_text, ".mean(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion'])")
     )
     error_message = "Lambda charts must keep one-hour visibility and ingestion-delay-safe invocation, error, and throttle behavior."
   }
@@ -41,6 +43,8 @@ run "lambda_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.lambda.name == "Lambdas"
       && signalfx_dashboard.lambda.dashboard_group == "forge-dashboard-group"
+      && signalfx_dashboard.lambda.variable[0].values == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.lambda.variable[0].value_required
       && length(signalfx_dashboard.lambda.chart) == 15
     )
     error_message = "Lambda dashboard must keep its name, group input, and chart count."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
@@ -1,12 +1,18 @@
 locals {
   opencost_tenant_namespace_filter = length(var.tenant_names) > 0 ? join(" or ", [
     for namespace in sort(var.tenant_names) : "filter('namespace', '${namespace}')"
-  ]) : "filter('namespace', '*')"
+  ]) : "filter('namespace', '__forge_tenant_scope_not_configured__')"
   opencost_cluster_variables = [
     for var_def in var.dynamic_variables : var_def
     if var_def.property == "k8s.cluster.name"
   ]
   opencost_cluster_variable = length(local.opencost_cluster_variables) > 0 ? local.opencost_cluster_variables[0] : null
+  opencost_cluster_names = distinct(flatten([
+    for var_def in local.opencost_cluster_variables : var_def.values_suggested
+  ]))
+  opencost_cluster_filter = length(local.opencost_cluster_names) > 0 ? join(" or ", [
+    for cluster_name in local.opencost_cluster_names : "filter('k8s.cluster.name', '${cluster_name}')"
+  ]) : "filter('k8s.cluster.name', '__forge_cluster_scope_not_configured__')"
 }
 
 resource "signalfx_list_chart" "tenant_hourly_compute_cost" {
@@ -14,12 +20,12 @@ resource "signalfx_list_chart" "tenant_hourly_compute_cost" {
   description = "Estimates current OpenCost CPU and memory allocation cost by tenant namespace."
 
   program_text = <<-EOF
-cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node'])
-cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*')).sum(by=['k8s.cluster.name', 'namespace', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 cpu_cost = (cpu_allocation * cpu_price).sum(by=['namespace'])
 
-memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node']).scale(0.0000000009313225746154785)
-memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*')).sum(by=['k8s.cluster.name', 'namespace', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 memory_cost = (memory_allocation * memory_price).sum(by=['namespace'])
 
 A = (cpu_cost + memory_cost).publish(label='A')
@@ -52,12 +58,12 @@ resource "signalfx_list_chart" "tenant_monthly_compute_run_rate" {
   description = "Projects current OpenCost CPU and memory allocation cost to a 730-hour month by tenant namespace."
 
   program_text = <<-EOF
-cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node'])
-cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*')).sum(by=['k8s.cluster.name', 'namespace', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 cpu_cost = (cpu_allocation * cpu_price).sum(by=['namespace'])
 
-memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node']).scale(0.0000000009313225746154785)
-memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*')).sum(by=['k8s.cluster.name', 'namespace', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 memory_cost = (memory_allocation * memory_price).sum(by=['namespace'])
 
 A = (cpu_cost + memory_cost).scale(730).publish(label='A')
@@ -90,12 +96,12 @@ resource "signalfx_time_chart" "tenant_compute_cost_trend" {
   description = "Tracks OpenCost CPU and memory allocation cost by tenant namespace over time."
 
   program_text = <<-EOF
-cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node'])
-cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*')).sum(by=['k8s.cluster.name', 'namespace', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 cpu_cost = (cpu_allocation * cpu_price).sum(by=['namespace'])
 
-memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node']).scale(0.0000000009313225746154785)
-memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*')).sum(by=['k8s.cluster.name', 'namespace', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 memory_cost = (memory_allocation * memory_price).sum(by=['namespace'])
 
 A = (cpu_cost + memory_cost).publish(label='A')
@@ -125,8 +131,8 @@ resource "signalfx_time_chart" "tenant_cpu_cost" {
   description = "Tracks OpenCost CPU allocation cost by tenant namespace."
 
   program_text = <<-EOF
-cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node'])
-cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*')).sum(by=['k8s.cluster.name', 'namespace', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 A = (cpu_allocation * cpu_price).sum(by=['namespace']).publish(label='A')
 EOF
 
@@ -154,8 +160,8 @@ resource "signalfx_time_chart" "tenant_memory_cost" {
   description = "Tracks OpenCost memory allocation cost by tenant namespace."
 
   program_text = <<-EOF
-memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*')).sum(by=['cluster_id', 'namespace', 'node']).scale(0.0000000009313225746154785)
-memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*')).sum(by=['k8s.cluster.name', 'namespace', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 A = (memory_allocation * memory_price).sum(by=['namespace']).publish(label='A')
 EOF
 
@@ -183,12 +189,12 @@ resource "signalfx_list_chart" "top_pod_compute_cost" {
   description = "Ranks pods by current OpenCost CPU and memory allocation cost."
 
   program_text = <<-EOF
-cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*') and filter('pod', '*')).sum(by=['cluster_id', 'namespace', 'pod', 'node'])
-cpu_price = data('node_cpu_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+cpu_allocation = data('container_cpu_allocation', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*') and filter('pod', '*')).sum(by=['k8s.cluster.name', 'namespace', 'pod', 'node'])
+cpu_price = data('node_cpu_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 cpu_cost = (cpu_allocation * cpu_price).sum(by=['namespace', 'pod'])
 
-memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and filter('cluster_id', '*') and filter('node', '*') and filter('pod', '*')).sum(by=['cluster_id', 'namespace', 'pod', 'node']).scale(0.0000000009313225746154785)
-memory_price = data('node_ram_hourly_cost', filter=filter('cluster_id', '*') and filter('node', '*')).mean(by=['cluster_id', 'node'])
+memory_allocation = data('container_memory_allocation_bytes', filter=(${local.opencost_tenant_namespace_filter}) and (${local.opencost_cluster_filter}) and filter('node', '*') and filter('pod', '*')).sum(by=['k8s.cluster.name', 'namespace', 'pod', 'node']).scale(0.0000000009313225746154785)
+memory_price = data('node_ram_hourly_cost', filter=(${local.opencost_cluster_filter}) and filter('node', '*')).mean(by=['k8s.cluster.name', 'node'])
 memory_cost = (memory_allocation * memory_price).sum(by=['namespace', 'pod'])
 
 A = (cpu_cost + memory_cost).top(count=20).publish(label='A')
@@ -238,7 +244,7 @@ resource "signalfx_dashboard" "opencost" {
   }
 
   variable {
-    property               = "cluster_id"
+    property               = "k8s.cluster.name"
     alias                  = "Forge Cluster"
     description            = ""
     values                 = local.opencost_cluster_variable == null ? [] : local.opencost_cluster_variable.values

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/tests/opencost_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/tests/opencost_dashboard_behavior.tftest.hcl
@@ -23,6 +23,8 @@ run "opencost_dashboard_contract" {
     condition = (
       signalfx_list_chart.tenant_hourly_compute_cost.name == "Tenant hourly compute cost"
       && strcontains(signalfx_list_chart.tenant_hourly_compute_cost.program_text, "filter('namespace', 'tenant-a') or filter('namespace', 'tenant-b')")
+      && strcontains(signalfx_list_chart.tenant_hourly_compute_cost.program_text, "filter('k8s.cluster.name', 'forge-euw1-dev') or filter('k8s.cluster.name', 'forge-use1-prod')")
+      && !strcontains(signalfx_list_chart.tenant_hourly_compute_cost.program_text, "cluster_id")
       && strcontains(signalfx_list_chart.tenant_hourly_compute_cost.program_text, "node_cpu_hourly_cost")
       && signalfx_time_chart.tenant_cpu_cost.name == "Tenant CPU cost"
       && strcontains(signalfx_time_chart.tenant_memory_cost.program_text, "node_ram_hourly_cost")
@@ -38,6 +40,7 @@ run "opencost_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.opencost.name == "OpenCost Tenant Cost"
       && signalfx_dashboard.opencost.dashboard_group == "forge-dashboard-group"
+      && signalfx_dashboard.opencost.variable[1].property == "k8s.cluster.name"
       && length(signalfx_dashboard.opencost.chart) == 6
     )
     error_message = "OpenCost dashboard must keep its name, group input, and chart count."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -1575,8 +1575,8 @@ resource "signalfx_dashboard" "runner_ec2" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = []
-    value_required         = false
+    values                 = sort(var.tenant_names)
+    value_required         = length(var.tenant_names) > 0
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -44,6 +44,8 @@ run "runner_ec2_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.runner_ec2.name == "EC2 Runners"
       && signalfx_dashboard.runner_ec2.dashboard_group == "forge-dashboard-group"
+      && signalfx_dashboard.runner_ec2.variable[0].values == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.runner_ec2.variable[0].value_required
       && length(signalfx_dashboard.runner_ec2.chart) == 23
     )
     error_message = "EC2 runner dashboard must keep its name, group input, and chart count."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
@@ -11,7 +11,8 @@ Kubernetes runner failures often show up as pending pods, restarts, resource pre
 - Active, desired, available, and phase-based pod charts.
 - CPU, memory, network, and restart views.
 - Top pod lists for resource usage.
-- OTel collector pod visibility.
+- Node pressure and tenant pod shutdown/termination diagnostics.
+- OTel collector pod, exporter queue, and telemetry-loss visibility.
 - Dashboard placement in the shared Forge O11y group.
 
 ## Operational Notes
@@ -54,8 +55,12 @@ No modules.
 | [signalfx_time_chart.k8s_memory_usage_bytes](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.k8s_memory_usage_pct](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.k8s_network_bytes_per_sec](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.k8s_node_pressure](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.k8s_otel_collector_pods](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.k8s_otel_exporter_queue_utilization](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.k8s_otel_telemetry_loss](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.k8s_pod_phase_trend](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.k8s_pod_status_reasons](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 
 ## Inputs
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
@@ -1,3 +1,19 @@
+locals {
+  k8s_dashboard_cluster_names = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "k8s.cluster.name"
+  ]))
+  k8s_cluster_filter = length(local.k8s_dashboard_cluster_names) > 0 ? join(" or ", [
+    for cluster_name in local.k8s_dashboard_cluster_names : "filter('k8s.cluster.name', '${cluster_name}')"
+  ]) : "filter('k8s.cluster.name', '__forge_cluster_scope_not_configured__')"
+
+  k8s_tenant_namespace_filter = length(var.tenant_names) > 0 ? join(" or ", [
+    for namespace in sort(var.tenant_names) : "filter('k8s.namespace.name', '${namespace}')"
+  ]) : "filter('k8s.namespace.name', '__forge_tenant_scope_not_configured__')"
+  k8s_tenant_filter         = "(${local.k8s_cluster_filter}) and (${local.k8s_tenant_namespace_filter})"
+  k8s_otel_collector_filter = "(${local.k8s_cluster_filter}) and filter('k8s.namespace.name', 'splunk-otel-collector') and filter('k8s.pod.name', 'splunk-otel-collector*')"
+}
+
 resource "signalfx_single_value_chart" "k8s_available_pods_by_deployments" {
   name        = "# Available pods by deployments"
   description = "Number of pods ready by deployments"
@@ -535,6 +551,104 @@ EOF
   }
 }
 
+resource "signalfx_time_chart" "k8s_node_pressure" {
+  name        = "Node pressure conditions"
+  description = "Shows active PID, memory, disk, or network pressure conditions by Kubernetes node."
+
+  program_text = <<-EOF
+A = data('k8s.node.condition', filter=(${local.k8s_cluster_filter}) and (filter('condition', 'PIDPressure') or filter('condition', 'MemoryPressure') or filter('condition', 'DiskPressure') or filter('condition', 'NetworkUnavailable')), rollup='latest').max(by=['k8s.cluster.name', 'k8s.node.name', 'condition']).publish(label='A')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "condition"
+  time_range                = 86400
+
+  axis_left {
+    label = "Active condition"
+  }
+
+  viz_options {
+    display_name = "{{k8s.node.name}} - {{condition}}"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "k8s_otel_exporter_queue_utilization" {
+  name        = "OTel exporter queue utilization"
+  description = "Shows exporter queue size as a percentage of capacity. Sustained growth can precede telemetry loss."
+
+  program_text = <<-EOF
+queue_size = data('otelcol_exporter_queue_size', filter=(${local.k8s_otel_collector_filter}), rollup='latest').mean(by=['k8s.cluster.name', 'k8s.pod.name', 'exporter', 'data_type'])
+queue_capacity = data('otelcol_exporter_queue_capacity', filter=(${local.k8s_otel_collector_filter}), rollup='latest').mean(by=['k8s.cluster.name', 'k8s.pod.name', 'exporter', 'data_type'])
+queue_utilization = ((queue_size / queue_capacity) * 100).top(count=20).publish(label='A')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 2
+  disable_sampling          = true
+  on_chart_legend_dimension = "exporter"
+  time_range                = 86400
+
+  axis_left {
+    label     = "Percent"
+    max_value = 100
+    min_value = 0
+  }
+
+  viz_options {
+    display_name = "{{exporter}} {{data_type}} on {{k8s.pod.name}}"
+    label        = "A"
+    value_suffix = "%"
+  }
+}
+
+resource "signalfx_time_chart" "k8s_otel_telemetry_loss" {
+  name        = "OTel refused and failed metric points"
+  description = "Shows metric points refused or failed by receivers and errored by scrapers."
+
+  program_text = <<-EOF
+refused = data('otelcol_receiver_refused_metric_points', filter=(${local.k8s_otel_collector_filter}), rollup='rate').sum(by=['k8s.cluster.name', 'receiver']).publish(label='Refused')
+failed = data('otelcol_receiver_failed_metric_points', filter=(${local.k8s_otel_collector_filter}), rollup='rate').sum(by=['k8s.cluster.name', 'receiver']).publish(label='Failed')
+scraper_errors = data('otelcol_scraper_errored_metric_points', filter=(${local.k8s_otel_collector_filter}), rollup='rate').sum(by=['k8s.cluster.name', 'scraper']).publish(label='Scraper errors')
+EOF
+
+  plot_type                 = "ColumnChart"
+  axes_precision            = 2
+  disable_sampling          = true
+  on_chart_legend_dimension = "plot_label"
+  time_range                = 604800
+
+  axis_left {
+    label = "Metric points / sec"
+  }
+}
+
+resource "signalfx_time_chart" "k8s_pod_status_reasons" {
+  name        = "Pod termination and shutdown reasons"
+  description = "Diagnostic view of tenant pod status reasons such as Terminated and NodeShutdown."
+
+  program_text = <<-EOF
+A = data('k8s.pod.status_reason', filter=(${local.k8s_tenant_filter}), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.status_reason']).publish(label='A')
+EOF
+
+  plot_type                 = "ColumnChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "k8s.pod.status_reason"
+  time_range                = 86400
+
+  axis_left {
+    label = "Pods"
+  }
+
+  viz_options {
+    display_name = "{{k8s.namespace.name}} - {{k8s.pod.status_reason}}"
+    label        = "A"
+  }
+}
+
 resource "signalfx_dashboard" "runner_k8s" {
   name            = "K8S Runners"
   description     = "Kubernetes-based runners: pod states, CPU, memory, and network health."
@@ -544,8 +658,8 @@ resource "signalfx_dashboard" "runner_k8s" {
     property               = "k8s.namespace.name"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = []
-    value_required         = false
+    values                 = sort(var.tenant_names)
+    value_required         = length(var.tenant_names) > 0
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }
@@ -675,6 +789,38 @@ resource "signalfx_dashboard" "runner_k8s" {
     row      = 3
     column   = 9
     width    = 3
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.k8s_node_pressure.id
+    row      = 4
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.k8s_otel_exporter_queue_utilization.id
+    row      = 4
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.k8s_otel_telemetry_loss.id
+    row      = 5
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.k8s_pod_status_reasons.id
+    row      = 5
+    column   = 6
+    width    = 6
     height   = 1
   }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory.tftest.hcl
@@ -21,6 +21,10 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory
       "resource \"signalfx_time_chart\" \"k8s_pod_phase_trend\"",
       "resource \"signalfx_time_chart\" \"k8s_container_restarts\"",
       "resource \"signalfx_time_chart\" \"k8s_otel_collector_pods\"",
+      "resource \"signalfx_time_chart\" \"k8s_node_pressure\"",
+      "resource \"signalfx_time_chart\" \"k8s_otel_exporter_queue_utilization\"",
+      "resource \"signalfx_time_chart\" \"k8s_otel_telemetry_loss\"",
+      "resource \"signalfx_time_chart\" \"k8s_pod_status_reasons\"",
       "resource \"signalfx_dashboard\" \"runner_k8s\"",
     ]
   }
@@ -31,7 +35,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory
   }
 
   assert {
-    condition     = output.expected_literal_count == 14
-    error_message = "Source inventory must keep 14 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 18
+    error_message = "Source inventory must keep 18 module-specific Terraform blocks pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
@@ -26,6 +26,10 @@ run "runner_k8s_dashboard_contract" {
       && signalfx_list_chart.k8s_top_10_cpu_usage_per_pod.sort_by == "-value"
       && signalfx_time_chart.k8s_memory_usage_pct.name == "Memory usage (%)"
       && strcontains(signalfx_time_chart.k8s_otel_collector_pods.program_text, "splunk-otel-collector")
+      && strcontains(signalfx_time_chart.k8s_node_pressure.program_text, "k8s.node.condition")
+      && strcontains(signalfx_time_chart.k8s_otel_exporter_queue_utilization.program_text, "otelcol_exporter_queue_capacity")
+      && strcontains(signalfx_time_chart.k8s_otel_telemetry_loss.program_text, "otelcol_receiver_refused_metric_points")
+      && strcontains(signalfx_time_chart.k8s_pod_status_reasons.program_text, "filter('k8s.namespace.name', 'tenant-a') or filter('k8s.namespace.name', 'tenant-b')")
     )
     error_message = "K8S runner charts must keep active pod, top CPU, memory percentage, and OTel collector health behavior."
   }
@@ -38,7 +42,9 @@ run "runner_k8s_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.runner_k8s.name == "K8S Runners"
       && signalfx_dashboard.runner_k8s.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.runner_k8s.chart) == 13
+      && signalfx_dashboard.runner_k8s.variable[0].values == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.runner_k8s.variable[0].value_required
+      && length(signalfx_dashboard.runner_k8s.chart) == 17
     )
     error_message = "K8S runner dashboard must keep its name, group input, and chart count."
   }
@@ -47,6 +53,8 @@ run "runner_k8s_dashboard_wiring_contract" {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.runner_k8s.chart : chart.chart_id], signalfx_single_value_chart.k8s_active_pods.id),
       contains([for chart in signalfx_dashboard.runner_k8s.chart : chart.chart_id], signalfx_time_chart.k8s_otel_collector_pods.id),
+      contains([for chart in signalfx_dashboard.runner_k8s.chart : chart.chart_id], signalfx_time_chart.k8s_otel_exporter_queue_utilization.id),
+      contains([for chart in signalfx_dashboard.runner_k8s.chart : chart.chart_id], signalfx_time_chart.k8s_pod_status_reasons.id),
     ])
     error_message = "K8S runner dashboard must keep its first and final chart wiring."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/main.tf
@@ -19,7 +19,7 @@ resource "signalfx_list_chart" "top_queues_by_message_sent" {
   name        = "Top  queues by message sent"
   description = "Ranks queues by messages sent over the last 30 minutes"
 
-  program_text = "A = data('NumberOfMessagesSent', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='30m').sum(by=['QueueName']).top(count=5).publish(label='A')"
+  program_text = "A = data('NumberOfMessagesSent', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='30m').sum(by=['aws_tag_TenantName', 'QueueName']).top(count=5).publish(label='A')"
   sort_by      = "-value"
 
   disable_sampling        = false
@@ -32,6 +32,10 @@ resource "signalfx_list_chart" "top_queues_by_message_sent" {
   legend_options_fields {
     enabled  = true
     property = "QueueName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
   }
   legend_options_fields {
     enabled  = false
@@ -53,7 +57,7 @@ resource "signalfx_time_chart" "sent_message_size" {
   description = "Tracks the size of sent messages over time."
 
   program_text = <<-EOF
-A = data('SentMessageSize', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'mean'), rollup='average').mean(by=['QueueName']).publish(label='A')
+A = data('SentMessageSize', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'mean'), rollup='average').mean(by=['aws_tag_TenantName', 'QueueName']).publish(label='A')
 EOF
 
   plot_type        = "LineChart"
@@ -92,6 +96,10 @@ EOF
   legend_options_fields {
     enabled  = true
     property = "QueueName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
   }
   legend_options_fields {
     enabled  = false
@@ -160,7 +168,7 @@ resource "signalfx_list_chart" "oldest_message_age" {
   name        = "Oldest message age"
   description = "Displays the max age of the oldest unprocessed message in seconds"
 
-  program_text = "A = data('ApproximateAgeOfOldestMessage', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'mean'), rollup='latest').max(by=['QueueName']).publish(label='A')"
+  program_text = "A = data('ApproximateAgeOfOldestMessage', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'mean'), rollup='latest').max(by=['aws_tag_TenantName', 'QueueName']).publish(label='A')"
 
   disable_sampling    = false
   hide_missing_values = true
@@ -185,6 +193,10 @@ resource "signalfx_list_chart" "oldest_message_age" {
   legend_options_fields {
     enabled  = true
     property = "QueueName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
   }
   legend_options_fields {
     enabled  = false
@@ -231,7 +243,7 @@ resource "signalfx_list_chart" "top_queues_by_message_received" {
   name        = "Top queues by message received"
   description = "Ranks queues by messages received over the last 30 minutes"
 
-  program_text = "A = data('NumberOfMessagesReceived', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='30m').sum(by=['QueueName']).top(count=5).publish(label='A')"
+  program_text = "A = data('NumberOfMessagesReceived', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='30m').sum(by=['aws_tag_TenantName', 'QueueName']).top(count=5).publish(label='A')"
 
   sort_by = "-value"
 
@@ -245,6 +257,10 @@ resource "signalfx_list_chart" "top_queues_by_message_received" {
   legend_options_fields {
     enabled  = true
     property = "QueueName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
   }
   legend_options_fields {
     enabled  = false
@@ -339,6 +355,34 @@ resource "signalfx_time_chart" "messages_deleted" {
     display_name = "Number of messages deleted"
     label        = "A"
     value_suffix = "No of messages"
+  }
+}
+
+resource "signalfx_list_chart" "visible_backlog_by_tenant" {
+  name        = "Visible backlog by tenant"
+  description = "Ranks Forge tenants by messages currently waiting for processing."
+
+  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'mean'), rollup='latest').sum(by=['aws_tag_TenantName']).publish(label='A')"
+  sort_by      = "-value"
+
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "sf_metric"
+  }
+
+  viz_options {
+    display_name = "Visible messages"
+    label        = "A"
   }
 }
 
@@ -455,8 +499,8 @@ resource "signalfx_dashboard" "sqs" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = []
-    value_required         = false
+    values                 = sort(var.tenant_names)
+    value_required         = length(var.tenant_names) > 0
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }
@@ -542,9 +586,17 @@ resource "signalfx_dashboard" "sqs" {
 
   chart {
     chart_id = signalfx_time_chart.empty_receives.id
+    column   = 6
+    row      = 4
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.visible_backlog_by_tenant.id
     column   = 0
     row      = 4
-    width    = 12
+    width    = 6
     height   = 1
   }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/integrations_splunk_o11y_conf_shared_dashboards_sqs_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/integrations_splunk_o11y_conf_shared_dashboards_sqs_source_inventory.tftest.hcl
@@ -17,6 +17,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_sqs_source_inventory" {
       "resource \"signalfx_list_chart\" \"top_queues_by_message_received\"",
       "resource \"signalfx_time_chart\" \"message_processing_trend\"",
       "resource \"signalfx_time_chart\" \"messages_deleted\"",
+      "resource \"signalfx_list_chart\" \"visible_backlog_by_tenant\"",
       "resource \"signalfx_time_chart\" \"dead_letter_backlog_trend\"",
       "resource \"signalfx_list_chart\" \"dead_letter_oldest_message_age\"",
       "resource \"signalfx_list_chart\" \"dead_letter_visible_messages\"",
@@ -30,7 +31,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_sqs_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 13
-    error_message = "Source inventory must keep 13 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 14
+    error_message = "Source inventory must keep 14 module-specific Terraform blocks pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/sqs_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/sqs_dashboard_behavior.tftest.hcl
@@ -29,8 +29,9 @@ run "sqs_dashboard_contract" {
       && signalfx_time_chart.message_processing_trend.time_range == 3600
       && strcontains(signalfx_list_chart.top_queues_by_message_sent.program_text, ".sum(over='30m')")
       && strcontains(signalfx_list_chart.top_queues_by_message_received.program_text, ".sum(over='30m')")
-      && strcontains(signalfx_list_chart.oldest_message_age.program_text, ".max(by=['QueueName'])")
+      && strcontains(signalfx_list_chart.oldest_message_age.program_text, ".max(by=['aws_tag_TenantName', 'QueueName'])")
       && signalfx_time_chart.message_processing_trend.name == "Message processing trend"
+      && strcontains(signalfx_list_chart.visible_backlog_by_tenant.program_text, ".sum(by=['aws_tag_TenantName'])")
       && strcontains(signalfx_time_chart.dead_letter_backlog_trend.program_text, "ApproximateNumberOfMessagesVisible")
       && signalfx_list_chart.dead_letter_visible_messages.sort_by == "-value"
     )
@@ -45,7 +46,9 @@ run "sqs_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.sqs.name == "SQS"
       && signalfx_dashboard.sqs.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.sqs.chart) == 12
+      && signalfx_dashboard.sqs.variable[0].values == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.sqs.variable[0].value_required
+      && length(signalfx_dashboard.sqs.chart) == 13
     )
     error_message = "SQS dashboard must keep its name, group input, and chart count."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
@@ -8,7 +8,8 @@ A small platform team cannot watch every tenant manually. These detectors conver
 
 ## What It Manages
 
-- No-data and collector-health detectors for the OTel path.
+- No-data, exporter queue, and telemetry-loss detectors for the OTel path.
+- Kubernetes node pressure detection.
 - Platform namespace health detectors.
 - Tenant pending-pod, failed-pod, and restart detectors.
 - Notification and team routing configuration.
@@ -43,10 +44,7 @@ No modules.
 | ---- | ---- |
 | [signalfx_detector.k8s_otel_collector_health](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
 | [signalfx_detector.k8s_otel_no_data](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
-| [signalfx_detector.k8s_other_namespace_pods_unhealthy](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
 | [signalfx_detector.k8s_platform_pods_unhealthy](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
-| [signalfx_detector.k8s_tenant_container_restarts](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
-| [signalfx_detector.k8s_tenant_pods_failed](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
 | [signalfx_detector.k8s_tenant_pods_pending](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
 
 ## Inputs

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/main.tf
@@ -19,15 +19,12 @@ locals {
   ])
   k8s_platform_filter = "(${local.k8s_cluster_filter}) and (${local.k8s_platform_namespace_filter})"
 
-  k8s_other_namespace_exclusions = distinct(concat(var.k8s_platform_namespaces, [var.k8s_otel_collector_config.namespace], var.tenant_names))
-  k8s_other_namespace_filter     = "(${local.k8s_cluster_filter}) and filter('k8s.namespace.name', '*') and not filter('k8s.namespace.name', '${join("', '", local.k8s_other_namespace_exclusions)}')"
-
   k8s_otel_collector_filter = "(${local.k8s_cluster_filter}) and filter('k8s.namespace.name', '${var.k8s_otel_collector_config.namespace}') and filter('k8s.pod.name', '${var.k8s_otel_collector_config.pod_name_filter}')"
 }
 
 resource "signalfx_detector" "k8s_otel_no_data" {
   name        = "${var.detector_name_prefix} K8S OTel no data"
-  description = "Detects when Kubernetes pod phase metrics stop arriving from a Forge cluster, which usually means the Splunk OpenTelemetry Collector is down or not sending data."
+  description = "Warns when Kubernetes pod phase metrics stop arriving from a Forge cluster. Investigate collector and ingestion health; missing telemetry alone does not prove Forge service impact."
   max_delay   = 120
   tags        = local.detector_tags
   teams       = [var.team]
@@ -40,7 +37,7 @@ EOF
 
   rule {
     description   = "No Kubernetes pod metrics for ${var.k8s_detector_config.otel_no_data_duration}"
-    severity      = "Critical"
+    severity      = "Warning"
     detect_label  = "No Kubernetes pod metrics"
     notifications = var.detector_notifications
   }
@@ -48,7 +45,7 @@ EOF
 
 resource "signalfx_detector" "k8s_otel_collector_health" {
   name        = "${var.detector_name_prefix} K8S Splunk OTel collector health"
-  description = "Detects missing, pending, failed, unknown, or restarting Splunk OpenTelemetry Collector pods. These issues can mean the collector is not installed, is unhealthy, or is unable to send Kubernetes metrics."
+  description = "Detects sustained Splunk OpenTelemetry Collector unavailability or degradation by cluster. Restore collector capacity and confirm metric ingestion before treating downstream no-data as a Forge outage."
   max_delay   = 120
   tags        = local.detector_tags
   teams       = [var.team]
@@ -56,9 +53,9 @@ resource "signalfx_detector" "k8s_otel_collector_health" {
 
   program_text = <<-EOF
 running_collector_pods = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).fill(value=0, duration='${var.k8s_otel_collector_config.stale_metrics_duration}')
-pending_collector_pods = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']).fill(value=0, duration='${var.k8s_otel_collector_config.pod_issue_duration}')
-unhealthy_collector_pods = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']).fill(value=0, duration='${var.k8s_otel_collector_config.pod_issue_duration}')
-collector_restarts = data('k8s.container.restarts', filter=(${local.k8s_otel_collector_filter}), rollup='latest').delta().sum(over='${var.k8s_otel_collector_config.restart_duration}').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name', 'k8s.container.name']).fill(value=0, duration='${var.k8s_otel_collector_config.restart_duration}')
+pending_collector_pods = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name']).fill(value=0, duration='${var.k8s_otel_collector_config.pod_issue_duration}')
+unhealthy_collector_pods = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name']).fill(value=0, duration='${var.k8s_otel_collector_config.pod_issue_duration}')
+collector_restarts = data('k8s.container.restarts', filter=(${local.k8s_otel_collector_filter}), rollup='latest').delta().sum(over='${var.k8s_otel_collector_config.restart_duration}').sum(by=['k8s.cluster.name']).fill(value=0, duration='${var.k8s_otel_collector_config.restart_duration}')
 detect(when(running_collector_pods < ${var.k8s_otel_collector_config.min_running_pods}, '${var.k8s_otel_collector_config.no_running_duration}')).publish('No running Splunk OTel collector pods')
 detect(when(pending_collector_pods > 0, '${var.k8s_otel_collector_config.pod_issue_duration}')).publish('Splunk OTel collector pod pending')
 detect(when(unhealthy_collector_pods > 0, '${var.k8s_otel_collector_config.pod_issue_duration}')).publish('Splunk OTel collector pod failed or unknown')
@@ -67,82 +64,43 @@ EOF
 
   rule {
     description   = "No running Splunk OpenTelemetry Collector pods for ${var.k8s_otel_collector_config.no_running_duration}"
-    severity      = "Critical"
+    severity      = "Major"
     detect_label  = "No running Splunk OTel collector pods"
     notifications = var.detector_notifications
   }
 
   rule {
     description   = "Splunk OpenTelemetry Collector pod pending for ${var.k8s_otel_collector_config.pod_issue_duration}"
-    severity      = "Major"
+    severity      = "Warning"
     detect_label  = "Splunk OTel collector pod pending"
     notifications = var.detector_notifications
   }
 
   rule {
     description   = "Splunk OpenTelemetry Collector pod failed or unknown for ${var.k8s_otel_collector_config.pod_issue_duration}"
-    severity      = "Critical"
+    severity      = "Major"
     detect_label  = "Splunk OTel collector pod failed or unknown"
     notifications = var.detector_notifications
   }
 
   rule {
     description   = "Splunk OpenTelemetry Collector container restarts for ${var.k8s_otel_collector_config.restart_duration}"
-    severity      = "Major"
-    detect_label  = "Splunk OTel collector container restarting"
-    notifications = var.detector_notifications
-  }
-}
-
-resource "signalfx_detector" "k8s_other_namespace_pods_unhealthy" {
-  name        = "${var.detector_name_prefix} K8S other namespace pods unhealthy"
-  description = "Detects pending, failed, unknown, or restarting pods in namespaces outside the platform and Splunk OpenTelemetry Collector namespaces."
-  max_delay   = 120
-  tags        = local.detector_tags
-  teams       = [var.team]
-  time_range  = 3600
-
-  program_text = <<-EOF
-other_pending_pods = data('k8s.pod.phase', filter=(${local.k8s_other_namespace_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']).fill(value=0, duration='${var.k8s_detector_config.pending_pods_duration}')
-other_unhealthy_pods = data('k8s.pod.phase', filter=(${local.k8s_other_namespace_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']).fill(value=0, duration='${var.k8s_detector_config.failed_pods_duration}')
-other_container_restarts = data('k8s.container.restarts', filter=(${local.k8s_other_namespace_filter}), rollup='latest').delta().sum(over='${var.k8s_detector_config.container_restarts_duration}').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name', 'k8s.container.name']).fill(value=0, duration='${var.k8s_detector_config.container_restarts_duration}')
-detect(when(other_pending_pods > ${var.k8s_detector_config.pending_pods_threshold}, '${var.k8s_detector_config.pending_pods_duration}')).publish('Other namespace pod pending')
-detect(when(other_unhealthy_pods > ${var.k8s_detector_config.failed_pods_threshold}, '${var.k8s_detector_config.failed_pods_duration}')).publish('Other namespace pod failed or unknown')
-detect(when(other_container_restarts > ${var.k8s_detector_config.container_restarts_threshold})).publish('Other namespace container restarting')
-EOF
-
-  rule {
-    description   = "Pod pending outside platform namespaces for ${var.k8s_detector_config.pending_pods_duration}"
     severity      = "Warning"
-    detect_label  = "Other namespace pod pending"
-    notifications = var.detector_notifications
-  }
-
-  rule {
-    description   = "Pod failed or unknown outside platform namespaces for ${var.k8s_detector_config.failed_pods_duration}"
-    severity      = "Major"
-    detect_label  = "Other namespace pod failed or unknown"
-    notifications = var.detector_notifications
-  }
-
-  rule {
-    description   = "Container restarts outside platform namespaces for ${var.k8s_detector_config.container_restarts_duration}"
-    severity      = "Major"
-    detect_label  = "Other namespace container restarting"
+    detect_label  = "Splunk OTel collector container restarting"
     notifications = var.detector_notifications
   }
 }
 
 resource "signalfx_detector" "k8s_tenant_pods_pending" {
   name        = "${var.detector_name_prefix} K8S tenant pods pending"
-  description = "Detects tenant pods stuck in Pending, which is the main signal for pods that are not scheduling."
+  description = "Warns when tenant runner pods remain Pending, grouped by tenant and cluster. Check cluster capacity, node pressure, quotas, and scheduling events before escalating."
   max_delay   = 120
   tags        = local.detector_tags
   teams       = [var.team]
   time_range  = 3600
 
   program_text = <<-EOF
-pending_pods = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']).fill(value=0, duration='${var.k8s_detector_config.pending_pods_duration}')
+pending_pods = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name']).fill(value=0, duration='${var.k8s_detector_config.pending_pods_duration}')
 detect(when(pending_pods > ${var.k8s_detector_config.pending_pods_threshold}, '${var.k8s_detector_config.pending_pods_duration}')).publish('Tenant pod pending')
 EOF
 
@@ -154,73 +112,22 @@ EOF
   }
 }
 
-resource "signalfx_detector" "k8s_tenant_pods_failed" {
-  name        = "${var.detector_name_prefix} K8S tenant pods failed"
-  description = "Detects tenant pods in Failed phase, grouped by cluster, namespace, and pod."
-  max_delay   = 120
-  tags        = local.detector_tags
-  teams       = [var.team]
-  time_range  = 3600
-
-  program_text = <<-EOF
-failed_pods = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']).fill(value=0, duration='${var.k8s_detector_config.failed_pods_duration}')
-detect(when(failed_pods > ${var.k8s_detector_config.failed_pods_threshold}, '${var.k8s_detector_config.failed_pods_duration}')).publish('Tenant pod failed')
-EOF
-
-  rule {
-    description   = "Tenant pod failed for ${var.k8s_detector_config.failed_pods_duration}"
-    severity      = "Major"
-    detect_label  = "Tenant pod failed"
-    notifications = var.detector_notifications
-  }
-}
-
-resource "signalfx_detector" "k8s_tenant_container_restarts" {
-  name        = "${var.detector_name_prefix} K8S tenant container restarts"
-  description = "Detects restarted containers in tenant namespaces, grouped by cluster, namespace, pod, and container."
-  max_delay   = 120
-  tags        = local.detector_tags
-  teams       = [var.team]
-  time_range  = 3600
-
-  program_text = <<-EOF
-container_restarts = data('k8s.container.restarts', filter=(${local.k8s_tenant_filter}), rollup='latest').delta().sum(over='${var.k8s_detector_config.container_restarts_duration}').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name', 'k8s.container.name']).fill(value=0, duration='${var.k8s_detector_config.container_restarts_duration}')
-detect(when(container_restarts > ${var.k8s_detector_config.container_restarts_threshold})).publish('Tenant container restarting')
-EOF
-
-  rule {
-    description   = "Tenant container restarts for ${var.k8s_detector_config.container_restarts_duration}"
-    severity      = "Major"
-    detect_label  = "Tenant container restarting"
-    notifications = var.detector_notifications
-  }
-}
-
 resource "signalfx_detector" "k8s_platform_pods_unhealthy" {
   name        = "${var.detector_name_prefix} K8S platform pods unhealthy"
-  description = "Detects unhealthy platform pods in kube-system, Karpenter, Calico, and Tigera namespaces."
+  description = "Detects sustained failed or unknown pods in Forge platform namespaces, grouped by cluster and namespace. Restore the affected scheduling or networking component and verify runner capacity."
   max_delay   = 120
   tags        = local.detector_tags
   teams       = [var.team]
   time_range  = 3600
 
   program_text = <<-EOF
-platform_pending_pods = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']).fill(value=0, duration='${var.k8s_detector_config.platform_pods_duration}')
-platform_failed_pods = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']).fill(value=0, duration='${var.k8s_detector_config.platform_pods_duration}')
-detect(when(platform_pending_pods > ${var.k8s_detector_config.platform_unhealthy_threshold}, '${var.k8s_detector_config.platform_pods_duration}')).publish('Platform pod pending')
+platform_failed_pods = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name']).fill(value=0, duration='${var.k8s_detector_config.platform_pods_duration}')
 detect(when(platform_failed_pods > ${var.k8s_detector_config.platform_unhealthy_threshold}, '${var.k8s_detector_config.platform_pods_duration}')).publish('Platform pod failed or unknown')
 EOF
 
   rule {
-    description   = "Platform pod pending for ${var.k8s_detector_config.platform_pods_duration}"
-    severity      = "Critical"
-    detect_label  = "Platform pod pending"
-    notifications = var.detector_notifications
-  }
-
-  rule {
     description   = "Platform pod failed or unknown for ${var.k8s_detector_config.platform_pods_duration}"
-    severity      = "Critical"
+    severity      = "Major"
     detect_label  = "Platform pod failed or unknown"
     notifications = var.detector_notifications
   }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/integrations_splunk_o11y_conf_shared_detectors_k8s_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/integrations_splunk_o11y_conf_shared_detectors_k8s_source_inventory.tftest.hcl
@@ -10,10 +10,7 @@ run "integrations_splunk_o11y_conf_shared_detectors_k8s_contract" {
     expected_literals = [
       "resource \"signalfx_detector\" \"k8s_otel_no_data\"",
       "resource \"signalfx_detector\" \"k8s_otel_collector_health\"",
-      "resource \"signalfx_detector\" \"k8s_other_namespace_pods_unhealthy\"",
       "resource \"signalfx_detector\" \"k8s_tenant_pods_pending\"",
-      "resource \"signalfx_detector\" \"k8s_tenant_pods_failed\"",
-      "resource \"signalfx_detector\" \"k8s_tenant_container_restarts\"",
       "resource \"signalfx_detector\" \"k8s_platform_pods_unhealthy\"",
     ]
   }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/k8s_detector_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/k8s_detector_behavior.tftest.hcl
@@ -54,9 +54,9 @@ run "k8s_detector_scope_and_threshold_contract" {
       && contains(signalfx_detector.k8s_otel_no_data.tags, "forgecicd")
       && strcontains(signalfx_detector.k8s_otel_no_data.program_text, "filter('k8s.cluster.name', 'forge-euw1-dev')")
       && strcontains(signalfx_detector.k8s_otel_no_data.program_text, "20m")
-      && contains([for rule in signalfx_detector.k8s_otel_no_data.rule : rule.severity], "Critical")
+      && contains([for rule in signalfx_detector.k8s_otel_no_data.rule : rule.severity], "Warning")
     )
-    error_message = "K8s no-data detector must keep cluster scoping, fill duration, team, tags, and critical severity."
+    error_message = "K8s no-data detector must keep cluster scoping, fill duration, team, tags, and non-paging warning severity."
   }
 
   assert {
@@ -67,19 +67,25 @@ run "k8s_detector_scope_and_threshold_contract" {
       && strcontains(signalfx_detector.k8s_otel_collector_health.program_text, "running_collector_pods < 2")
       && strcontains(signalfx_detector.k8s_otel_collector_health.program_text, ".delta().sum(over='15m')")
       && strcontains(signalfx_detector.k8s_otel_collector_health.program_text, ".fill(value=0, duration='5m')")
+      && !strcontains(signalfx_detector.k8s_otel_collector_health.program_text, "'k8s.pod.name', 'k8s.container.name'")
       && length(signalfx_detector.k8s_otel_collector_health.rule) == 4
+      && length([for rule in signalfx_detector.k8s_otel_collector_health.rule : rule if rule.severity == "Major"]) == 2
+      && length([for rule in signalfx_detector.k8s_otel_collector_health.rule : rule if rule.severity == "Warning"]) == 2
     )
-    error_message = "K8s collector detector must keep collector namespace, pod filter, min-running threshold, and all collector rules."
+    error_message = "K8s collector detector must aggregate by cluster and keep two major availability rules plus two warning degradation rules."
   }
 
   assert {
     condition = (
       strcontains(signalfx_detector.k8s_tenant_pods_pending.program_text, "filter('k8s.namespace.name', 'tenant-a') or filter('k8s.namespace.name', 'tenant-b')")
+      && strcontains(signalfx_detector.k8s_tenant_pods_pending.program_text, "sum(by=['k8s.cluster.name', 'k8s.namespace.name'])")
+      && !strcontains(signalfx_detector.k8s_tenant_pods_pending.program_text, "'k8s.pod.name'")
       && strcontains(signalfx_detector.k8s_tenant_pods_pending.program_text, ".fill(value=0, duration='10m')")
-      && strcontains(signalfx_detector.k8s_tenant_container_restarts.program_text, ".delta().sum(over='10m')")
-      && strcontains(signalfx_detector.k8s_other_namespace_pods_unhealthy.program_text, "not filter('k8s.namespace.name', 'kube-system', 'karpenter', 'splunk-otel', 'tenant-a', 'tenant-b')")
       && strcontains(signalfx_detector.k8s_platform_pods_unhealthy.program_text, "filter('k8s.namespace.name', 'kube-system') or filter('k8s.namespace.name', 'karpenter')")
+      && !strcontains(signalfx_detector.k8s_platform_pods_unhealthy.program_text, "Platform pod pending")
+      && length(signalfx_detector.k8s_platform_pods_unhealthy.rule) == 1
+      && one(signalfx_detector.k8s_platform_pods_unhealthy.rule).severity == "Major"
     )
-    error_message = "K8s detectors must keep separate tenant, other-namespace, and platform namespace filters."
+    error_message = "K8s workload detectors must aggregate tenant pending pods by tenant and retain only the actionable platform failed-or-unknown rule."
   }
 }


### PR DESCRIPTION
## Description

- Refine Kubernetes detectors around stable cluster and tenant service boundaries.
- Evaluate restart counters as recent deltas, adjust severities, and remove overlapping pod-level rules.
- Expand Forge observability dashboards with operational context for DynamoDB, EBS, Lambda, OpenCost, runner, and SQS signals.
- Update focused behavior and source-inventory tests for the revised detector and dashboard contracts.

No PagerDuty or live Splunk configuration is changed by this PR.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: __________

## Testing

- Repository pre-commit suite: passed
- OpenTofu dashboard tests: 32 passed
- OpenTofu Kubernetes detector tests: 3 passed
- `git diff --check`: passed
- Branch is one commit ahead of current `main` and zero commits behind
