### PR TITLE
feat(observability): improve Forge operational dashboards

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
@@ -35,6 +35,18 @@ module "dashboard_runner_k8s" {
   dashboard_group   = signalfx_dashboard_group.forgecicd.id
 }
 
+module "dashboard_k8s_control_plane" {
+  source = "./dashboards/k8s_control_plane"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  dynamic_variables   = var.dashboard_variables.runner_k8s.dynamic_variables
+  platform_namespaces = var.k8s_platform_namespaces
+  dashboard_group     = signalfx_dashboard_group.forgecicd.id
+}
+
 module "dashboard_lambda" {
   source = "./dashboards/lambda"
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
@@ -567,7 +567,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}} - {{VolumeId}}"
+    display_name = "Volume IOPS exceeded"
     label        = "A"
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/README.md
@@ -1,13 +1,22 @@
 # Splunk Observability Forge Impact Dashboard
 
-This module creates the high-level Forge usage and impact dashboard.
+This module creates the high-level Forge tenant issue and usage dashboard.
 
 ## Why This Module Exists
 
-The platform needs to show adoption and workload shape across tenants, not just raw health. This dashboard summarizes EC2 and Kubernetes runner usage, active capacity, runner hours, and runtime distribution.
+Operators need one place to identify which tenants are most affected before
+opening a subsystem dashboard. The dashboard starts with top-10 tenant
+leaderboards for actionable Lambda, EC2, Kubernetes, SQS, DynamoDB, and EBS
+signals, then retains the adoption and workload-shape section.
 
 ## What It Manages
 
+- Top tenants by Lambda errors and throttles.
+- Top tenants by EC2 runner memory and CPU utilization.
+- Top tenant namespaces by pending, failed, or unknown Kubernetes pods.
+- Top tenants by SQS and dead-letter backlog.
+- Top tenants by DynamoDB throttles and system errors.
+- Top tenants by EBS queue length.
 - Runner totals and minutes by runtime.
 - Active EC2 runners by tenant and instance type.
 - EC2 runner hours and total runners by tenant.
@@ -16,9 +25,14 @@ The platform needs to show adoption and workload shape across tenants, not just 
 
 ## Operational Notes
 
-- Use this for capacity planning and stakeholder reporting.
+- Start here during incidents to identify affected tenants and the subsystem
+  that needs deeper investigation.
+- Tenant properties remain visible in each leaderboard so the same identity can
+  be used in the matching subsystem dashboard.
+- Use the lower section for capacity planning and stakeholder reporting.
 - Tenant names must be consistently emitted as dimensions.
-- This dashboard explains platform usage; use subsystem dashboards for incident triage.
+- Use subsystem dashboards for resource-level diagnosis after identifying the
+  tenant and issue category here.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -32,7 +46,7 @@ The platform needs to show adoption and workload shape across tenants, not just 
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.33.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -52,6 +66,17 @@ No modules.
 | [signalfx_list_chart.k8s_runners_by_tenant](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.runner_minutes_by_runtime](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.runner_totals_by_runtime](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_dynamodb_system_errors](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_dynamodb_throttles](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_ebs_queue_length](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_ec2_cpu](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_ec2_memory](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_k8s_failed_pods](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_k8s_pending_pods](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_lambda_errors](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_lambda_throttles](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_sqs_backlog](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_sqs_dlq_backlog](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.total_ec2_runners_by_tenant](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.total_k8s_runners_by_tenant](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_time_chart.active_ec2_runners_by_tenant_and_instance_type](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
@@ -62,6 +87,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_dashboard_group"></a> [dashboard\_group](#input\_dashboard\_group) | Dashboard group name for organizing dashboards. | `string` | n/a | yes |
+| <a name="input_dynamic_variables"></a> [dynamic\_variables](#input\_dynamic\_variables) | Additional dynamic variable definitions for the dashboard. | <pre>list(object({<br/>    property               = string<br/>    alias                  = string<br/>    description            = string<br/>    values                 = list(string)<br/>    value_required         = bool<br/>    values_suggested       = list(string)<br/>    restricted_suggestions = bool<br/>  }))</pre> | `[]` | no |
 | <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | Tenant namespaces that run Forge ARC runners. | `list(string)` | n/a | yes |
 
 ## Outputs

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
@@ -71,6 +71,10 @@ EOF
   unit_prefix             = "Metric"
 
   color_scale {
+    color = "green"
+    lt    = 90
+  }
+  color_scale {
     color = "orange"
     gte   = 90
     lt    = 99
@@ -106,6 +110,10 @@ resource "signalfx_list_chart" "top_tenants_ec2_cpu" {
   time_range              = 3600
   unit_prefix             = "Metric"
 
+  color_scale {
+    color = "green"
+    lt    = 90
+  }
   color_scale {
     color = "orange"
     gte   = 90

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
@@ -21,7 +21,7 @@ resource "signalfx_list_chart" "top_tenants_lambda_errors" {
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "Lambda errors"
     label        = "A"
     value_suffix = " errors"
   }
@@ -46,7 +46,7 @@ resource "signalfx_list_chart" "top_tenants_lambda_throttles" {
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "Lambda throttles"
     label        = "A"
     value_suffix = " throttles"
   }
@@ -86,7 +86,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "EC2 memory utilization"
     label        = "A"
     value_suffix = "%"
   }
@@ -122,7 +122,7 @@ resource "signalfx_list_chart" "top_tenants_ec2_cpu" {
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "EC2 CPU utilization"
     label        = "A"
     value_suffix = "%"
   }
@@ -147,7 +147,7 @@ resource "signalfx_list_chart" "top_tenants_k8s_pending_pods" {
   }
 
   viz_options {
-    display_name = "{{k8s.namespace.name}}"
+    display_name = "K8S pending pods"
     label        = "A"
     value_suffix = " pending"
   }
@@ -172,7 +172,7 @@ resource "signalfx_list_chart" "top_tenants_k8s_failed_pods" {
   }
 
   viz_options {
-    display_name = "{{k8s.namespace.name}}"
+    display_name = "K8S failed or unknown pods"
     label        = "A"
     value_suffix = " failed/unknown"
   }
@@ -197,7 +197,7 @@ resource "signalfx_list_chart" "top_tenants_sqs_backlog" {
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "SQS visible backlog"
     label        = "A"
     value_suffix = " messages"
   }
@@ -222,7 +222,7 @@ resource "signalfx_list_chart" "top_tenants_sqs_dlq_backlog" {
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "SQS dead-letter backlog"
     label        = "A"
     value_suffix = " DLQ messages"
   }
@@ -247,7 +247,7 @@ resource "signalfx_list_chart" "top_tenants_dynamodb_throttles" {
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "DynamoDB throttled requests"
     label        = "A"
     value_suffix = " throttled"
   }
@@ -272,7 +272,7 @@ resource "signalfx_list_chart" "top_tenants_dynamodb_system_errors" {
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "DynamoDB system errors"
     label        = "A"
     value_suffix = " errors"
   }
@@ -297,7 +297,7 @@ resource "signalfx_list_chart" "top_tenants_ebs_queue_length" {
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "EBS queue length"
     label        = "A"
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
@@ -62,6 +62,7 @@ total = data('system.memory.usage', filter=(${local.ec2_tenant_filter}) and filt
 A = ((used / total) * 100).max(by=['aws_tag_TenantName']).top(count=10).publish(label='A')
 EOF
 
+  color_by                = "Scale"
   hide_missing_values     = true
   max_precision           = 2
   secondary_visualization = "Sparkline"
@@ -97,6 +98,7 @@ resource "signalfx_list_chart" "top_tenants_ec2_cpu" {
 
   program_text = "A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), rollup='latest').mean(by=['aws_tag_TenantName', 'aws_instance_id']).max(by=['aws_tag_TenantName']).top(count=10).publish(label='A')"
 
+  color_by                = "Scale"
   hide_missing_values     = true
   max_precision           = 2
   secondary_visualization = "Sparkline"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
@@ -1,0 +1,301 @@
+locals {
+  issue_window = "Args.get('ui.dashboard_window', '1h')"
+}
+
+resource "signalfx_list_chart" "top_tenants_lambda_errors" {
+  name        = "Top 10 tenants: Lambda errors"
+  description = "Lambda errors over the selected window. Use the tenant property to continue investigation in the Lambdas dashboard."
+
+  program_text = "A = data('Errors', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = " errors"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_lambda_throttles" {
+  name        = "Top 10 tenants: Lambda throttles"
+  description = "Lambda throttles over the selected window. Use the tenant property to continue investigation in the Lambdas dashboard."
+
+  program_text = "A = data('Throttles', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = " throttles"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_ec2_memory" {
+  name        = "Top 10 tenants: EC2 memory utilization"
+  description = "Highest current runner-host memory utilization per tenant. Values at or above 99% are critical."
+
+  program_text = <<-EOF
+used = data('system.memory.usage', filter=(${local.ec2_tenant_filter}) and filter('cloud.platform', 'aws_ec2') and filter('state', 'used'), rollup='latest').sum(by=['aws_tag_TenantName', 'host.name'])
+total = data('system.memory.usage', filter=(${local.ec2_tenant_filter}) and filter('cloud.platform', 'aws_ec2') and filter('state', 'used', 'free', 'cached', 'buffered'), rollup='latest').sum(by=['aws_tag_TenantName', 'host.name'])
+A = ((used / total) * 100).max(by=['aws_tag_TenantName']).top(count=10).publish(label='A')
+EOF
+
+  hide_missing_values     = true
+  max_precision           = 2
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  color_scale {
+    color = "orange"
+    gte   = 90
+    lt    = 99
+  }
+  color_scale {
+    color = "red"
+    gte   = 99
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = "%"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_ec2_cpu" {
+  name        = "Top 10 tenants: EC2 CPU utilization"
+  description = "Highest current EC2 runner CPU utilization per tenant."
+
+  program_text = "A = data('CPUUtilization', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), rollup='latest').mean(by=['aws_tag_TenantName', 'aws_instance_id']).max(by=['aws_tag_TenantName']).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 2
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  color_scale {
+    color = "orange"
+    gte   = 90
+    lt    = 99
+  }
+  color_scale {
+    color = "red"
+    gte   = 99
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = "%"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_k8s_pending_pods" {
+  name        = "Top 10 tenants: K8S pending pods"
+  description = "Current pending pod count by Forge tenant namespace."
+
+  program_text = "A = data('k8s.pod.phase', filter=(${local.k8s_tenant_namespace_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).above(0).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "k8s.namespace.name"
+  }
+
+  viz_options {
+    display_name = "{{k8s.namespace.name}}"
+    label        = "A"
+    value_suffix = " pending"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_k8s_failed_pods" {
+  name        = "Top 10 tenants: K8S failed or unknown pods"
+  description = "Current failed or unknown pod count by Forge tenant namespace."
+
+  program_text = "A = data('k8s.pod.phase', filter=(${local.k8s_tenant_namespace_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).above(0).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "k8s.namespace.name"
+  }
+
+  viz_options {
+    display_name = "{{k8s.namespace.name}}"
+    label        = "A"
+    value_suffix = " failed/unknown"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_sqs_backlog" {
+  name        = "Top 10 tenants: SQS visible backlog"
+  description = "Current visible SQS messages summed by Forge tenant."
+
+  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/SQS') and filter('QueueName', '*') and filter('stat', 'mean'), rollup='latest').sum(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = " messages"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_sqs_dlq_backlog" {
+  name        = "Top 10 tenants: SQS dead-letter backlog"
+  description = "Current visible messages in dead-letter queues summed by Forge tenant."
+
+  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/SQS') and filter('QueueName', '*dead-letter*', '*dlq*', '*DLQ*') and filter('stat', 'mean'), rollup='latest').sum(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = " DLQ messages"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_dynamodb_throttles" {
+  name        = "Top 10 tenants: DynamoDB throttled requests"
+  description = "DynamoDB throttled requests over the selected window, summed by Forge tenant."
+
+  program_text = "A = data('ThrottledRequests', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = " throttled"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_dynamodb_system_errors" {
+  name        = "Top 10 tenants: DynamoDB system errors"
+  description = "DynamoDB HTTP 500 errors over the selected window, summed by Forge tenant."
+
+  program_text = "A = data('SystemErrors', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = " errors"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_ebs_queue_length" {
+  name        = "Top 10 tenants: EBS queue length"
+  description = "Highest current EBS volume queue length per Forge tenant."
+
+  program_text = "A = data('VolumeQueueLength', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EBS') and filter('stat', 'mean') and filter('VolumeId', '*'), rollup='latest').mean(by=['aws_tag_TenantName', 'VolumeId']).max(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')"
+
+  hide_missing_values     = true
+  max_precision           = 2
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
@@ -351,7 +351,7 @@ resource "terraform_data" "dashboard_parent" {
 
 resource "signalfx_dashboard" "forge_impact" {
   name            = "ForgeCICD Impact"
-  description     = "Forge adoption, runner inventory, and runner-minute usage."
+  description     = "Cross-service tenant issue leaderboards followed by Forge adoption and runner usage."
   dashboard_group = var.dashboard_group
 
   # Splunk O11y rejects moving an existing dashboard to a new parent group.
@@ -377,7 +377,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.active_ec2_runners_by_tenant.id
+    chart_id = signalfx_list_chart.top_tenants_lambda_errors.id
     row      = 0
     column   = 0
     width    = 4
@@ -385,7 +385,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.active_ec2_runners_by_tenant_and_instance_type.id
+    chart_id = signalfx_list_chart.top_tenants_lambda_throttles.id
     row      = 0
     column   = 4
     width    = 4
@@ -393,7 +393,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.k8s_runners_by_tenant.id
+    chart_id = signalfx_list_chart.top_tenants_ec2_memory.id
     row      = 0
     column   = 8
     width    = 4
@@ -401,7 +401,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.runner_totals_by_runtime.id
+    chart_id = signalfx_list_chart.top_tenants_ec2_cpu.id
     row      = 1
     column   = 0
     width    = 4
@@ -409,7 +409,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.total_ec2_runners_by_tenant.id
+    chart_id = signalfx_list_chart.top_tenants_k8s_pending_pods.id
     row      = 1
     column   = 4
     width    = 4
@@ -417,7 +417,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.total_k8s_runners_by_tenant.id
+    chart_id = signalfx_list_chart.top_tenants_k8s_failed_pods.id
     row      = 1
     column   = 8
     width    = 4
@@ -425,7 +425,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.runner_minutes_by_runtime.id
+    chart_id = signalfx_list_chart.top_tenants_sqs_backlog.id
     row      = 2
     column   = 0
     width    = 4
@@ -433,7 +433,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.ec2_runner_hours_by_tenant.id
+    chart_id = signalfx_list_chart.top_tenants_sqs_dlq_backlog.id
     row      = 2
     column   = 4
     width    = 4
@@ -441,7 +441,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.k8s_runner_hours_by_tenant.id
+    chart_id = signalfx_list_chart.top_tenants_dynamodb_throttles.id
     row      = 2
     column   = 8
     width    = 4
@@ -449,7 +449,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_time_chart.active_ec2_runners_by_tenant_and_instance_type.id
+    chart_id = signalfx_list_chart.top_tenants_dynamodb_system_errors.id
     row      = 3
     column   = 0
     width    = 6
@@ -457,8 +457,96 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.ec2_runner_hours_by_tenant_and_instance_type.id
+    chart_id = signalfx_list_chart.top_tenants_ebs_queue_length.id
     row      = 3
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.active_ec2_runners_by_tenant.id
+    row      = 4
+    column   = 0
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.active_ec2_runners_by_tenant_and_instance_type.id
+    row      = 4
+    column   = 4
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.k8s_runners_by_tenant.id
+    row      = 4
+    column   = 8
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.runner_totals_by_runtime.id
+    row      = 5
+    column   = 0
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.total_ec2_runners_by_tenant.id
+    row      = 5
+    column   = 4
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.total_k8s_runners_by_tenant.id
+    row      = 5
+    column   = 8
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.runner_minutes_by_runtime.id
+    row      = 6
+    column   = 0
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.ec2_runner_hours_by_tenant.id
+    row      = 6
+    column   = 4
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.k8s_runner_hours_by_tenant.id
+    row      = 6
+    column   = 8
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.active_ec2_runners_by_tenant_and_instance_type.id
+    row      = 7
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.ec2_runner_hours_by_tenant_and_instance_type.id
+    row      = 7
     column   = 6
     width    = 6
     height   = 1

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -45,8 +45,12 @@ run "forge_impact_dashboard_contract" {
       && strcontains(signalfx_list_chart.top_tenants_ec2_memory.program_text, "system.memory.usage")
       && strcontains(signalfx_list_chart.top_tenants_ec2_memory.program_text, ".top(count=10)")
       && signalfx_list_chart.top_tenants_ec2_memory.color_by == "Scale"
+      && length(signalfx_list_chart.top_tenants_ec2_memory.color_scale) == 3
+      && one([for scale in signalfx_list_chart.top_tenants_ec2_memory.color_scale : scale.lt if scale.color == "green"]) == 90
       && strcontains(signalfx_list_chart.top_tenants_ec2_cpu.program_text, "CPUUtilization")
       && signalfx_list_chart.top_tenants_ec2_cpu.color_by == "Scale"
+      && length(signalfx_list_chart.top_tenants_ec2_cpu.color_scale) == 3
+      && one([for scale in signalfx_list_chart.top_tenants_ec2_cpu.color_scale : scale.lt if scale.color == "green"]) == 90
       && strcontains(signalfx_list_chart.top_tenants_k8s_pending_pods.program_text, "k8s.pod.phase")
       && strcontains(signalfx_list_chart.top_tenants_k8s_failed_pods.program_text, "k8s.pod.phase")
       && strcontains(signalfx_list_chart.top_tenants_sqs_backlog.program_text, "ApproximateNumberOfMessagesVisible")

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -37,6 +37,41 @@ run "forge_impact_dashboard_contract" {
     )
     error_message = "Forge impact charts must keep EC2 and K8S runner adoption SignalFlow behavior."
   }
+
+  assert {
+    condition = (
+      strcontains(signalfx_list_chart.top_tenants_lambda_errors.program_text, "data('Errors'")
+      && strcontains(signalfx_list_chart.top_tenants_lambda_throttles.program_text, "data('Throttles'")
+      && strcontains(signalfx_list_chart.top_tenants_ec2_memory.program_text, "system.memory.usage")
+      && strcontains(signalfx_list_chart.top_tenants_ec2_memory.program_text, ".top(count=10)")
+      && strcontains(signalfx_list_chart.top_tenants_ec2_cpu.program_text, "CPUUtilization")
+      && strcontains(signalfx_list_chart.top_tenants_k8s_pending_pods.program_text, "k8s.pod.phase")
+      && strcontains(signalfx_list_chart.top_tenants_k8s_failed_pods.program_text, "k8s.pod.phase")
+      && strcontains(signalfx_list_chart.top_tenants_sqs_backlog.program_text, "ApproximateNumberOfMessagesVisible")
+      && strcontains(signalfx_list_chart.top_tenants_sqs_dlq_backlog.program_text, "*dead-letter*")
+      && strcontains(signalfx_list_chart.top_tenants_dynamodb_throttles.program_text, "ThrottledRequests")
+      && strcontains(signalfx_list_chart.top_tenants_dynamodb_system_errors.program_text, "SystemErrors")
+      && strcontains(signalfx_list_chart.top_tenants_ebs_queue_length.program_text, "VolumeQueueLength")
+    )
+    error_message = "Forge impact must rank affected tenants across Lambda, EC2, K8S, SQS, DynamoDB, and EBS issue signals."
+  }
+
+  assert {
+    condition = alltrue([
+      for program_text in [
+        signalfx_list_chart.top_tenants_lambda_errors.program_text,
+        signalfx_list_chart.top_tenants_lambda_throttles.program_text,
+        signalfx_list_chart.top_tenants_ec2_memory.program_text,
+        signalfx_list_chart.top_tenants_ec2_cpu.program_text,
+        signalfx_list_chart.top_tenants_sqs_backlog.program_text,
+        signalfx_list_chart.top_tenants_sqs_dlq_backlog.program_text,
+        signalfx_list_chart.top_tenants_dynamodb_throttles.program_text,
+        signalfx_list_chart.top_tenants_dynamodb_system_errors.program_text,
+        signalfx_list_chart.top_tenants_ebs_queue_length.program_text,
+      ] : strcontains(program_text, "filter('aws_tag_TenantName', 'tenant-a') or filter('aws_tag_TenantName', 'tenant-b')")
+    ])
+    error_message = "AWS issue leaderboards must be restricted to configured Forge tenants."
+  }
 }
 
 run "forge_impact_dashboard_wiring_contract" {
@@ -46,7 +81,7 @@ run "forge_impact_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.forge_impact.name == "ForgeCICD Impact"
       && signalfx_dashboard.forge_impact.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.forge_impact.chart) == 11
+      && length(signalfx_dashboard.forge_impact.chart) == 22
     )
     error_message = "Forge impact dashboard must keep its name, group input, and chart count."
   }
@@ -55,7 +90,13 @@ run "forge_impact_dashboard_wiring_contract" {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.active_ec2_runners_by_tenant.id),
       contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.ec2_runner_hours_by_tenant_and_instance_type.id),
+      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_lambda_errors.id),
+      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_ec2_memory.id),
+      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_k8s_failed_pods.id),
+      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_sqs_dlq_backlog.id),
+      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_dynamodb_throttles.id),
+      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_ebs_queue_length.id),
     ])
-    error_message = "Forge impact dashboard must keep its first and final chart wiring."
+    error_message = "Forge impact dashboard must wire cross-service issue leaderboards and retain adoption charts."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -44,7 +44,9 @@ run "forge_impact_dashboard_contract" {
       && strcontains(signalfx_list_chart.top_tenants_lambda_throttles.program_text, "data('Throttles'")
       && strcontains(signalfx_list_chart.top_tenants_ec2_memory.program_text, "system.memory.usage")
       && strcontains(signalfx_list_chart.top_tenants_ec2_memory.program_text, ".top(count=10)")
+      && signalfx_list_chart.top_tenants_ec2_memory.color_by == "Scale"
       && strcontains(signalfx_list_chart.top_tenants_ec2_cpu.program_text, "CPUUtilization")
+      && signalfx_list_chart.top_tenants_ec2_cpu.color_by == "Scale"
       && strcontains(signalfx_list_chart.top_tenants_k8s_pending_pods.program_text, "k8s.pod.phase")
       && strcontains(signalfx_list_chart.top_tenants_k8s_failed_pods.program_text, "k8s.pod.phase")
       && strcontains(signalfx_list_chart.top_tenants_sqs_backlog.program_text, "ApproximateNumberOfMessagesVisible")

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_inventory.tftest.hcl
@@ -19,6 +19,17 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_invento
       "resource \"signalfx_list_chart\" \"k8s_runners_by_tenant\"",
       "resource \"signalfx_list_chart\" \"total_k8s_runners_by_tenant\"",
       "resource \"signalfx_list_chart\" \"k8s_runner_hours_by_tenant\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_lambda_errors\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_lambda_throttles\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_ec2_memory\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_ec2_cpu\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_k8s_pending_pods\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_k8s_failed_pods\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_sqs_backlog\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_sqs_dlq_backlog\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_dynamodb_throttles\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_dynamodb_system_errors\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_ebs_queue_length\"",
       "resource \"terraform_data\" \"dashboard_parent\"",
       "resource \"signalfx_dashboard\" \"forge_impact\"",
     ]
@@ -30,7 +41,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_invento
   }
 
   assert {
-    condition     = output.expected_literal_count == 13
-    error_message = "Source inventory must keep 13 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 24
+    error_message = "Source inventory must keep 24 module-specific Terraform blocks pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/README.md
@@ -1,0 +1,5 @@
+# Splunk Observability Kubernetes Control Plane Dashboard
+
+This module creates cluster-scoped operational charts for the Kubernetes platform that hosts Forge ARC runners.
+
+It keeps platform components such as Karpenter, networking controllers, Prometheus, and the Splunk OpenTelemetry Collector separate from tenant runner workloads. The dashboard covers configured platform namespace pod health, plus the common `monitoring`, `prometheus`, and `splunk-otel-collector` namespaces, node pressure, collector pod health, exporter queue utilization, and telemetry loss.

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
@@ -95,7 +95,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{k8s.node.name}} - {{condition}}"
+    display_name = "Node pressure"
     label        = "A"
   }
 }
@@ -123,7 +123,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{exporter}} {{data_type}} on {{k8s.pod.name}}"
+    display_name = "OTel exporter queue utilization"
     label        = "A"
     value_suffix = "%"
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
@@ -1,0 +1,212 @@
+locals {
+  k8s_cluster_variables = [
+    for var_def in var.dynamic_variables : var_def
+    if var_def.property == "k8s.cluster.name"
+  ]
+  k8s_cluster_names = distinct(flatten([
+    for var_def in local.k8s_cluster_variables : var_def.values_suggested
+  ]))
+  k8s_cluster_filter = length(local.k8s_cluster_names) > 0 ? join(" or ", [
+    for cluster_name in local.k8s_cluster_names : "filter('k8s.cluster.name', '${cluster_name}')"
+  ]) : "filter('k8s.cluster.name', '__forge_cluster_scope_not_configured__')"
+
+  k8s_platform_namespaces = distinct(concat(
+    var.platform_namespaces,
+    ["monitoring", "prometheus", "splunk-otel-collector"],
+  ))
+  k8s_platform_namespace_filter = length(local.k8s_platform_namespaces) > 0 ? join(" or ", [
+    for namespace in sort(local.k8s_platform_namespaces) : "filter('k8s.namespace.name', '${namespace}')"
+  ]) : "filter('k8s.namespace.name', '__forge_platform_scope_not_configured__')"
+  k8s_platform_filter       = "(${local.k8s_cluster_filter}) and (${local.k8s_platform_namespace_filter})"
+  k8s_otel_collector_filter = "(${local.k8s_cluster_filter}) and filter('k8s.namespace.name', 'splunk-otel-collector') and filter('k8s.pod.name', 'splunk-otel-collector*')"
+}
+
+resource "signalfx_time_chart" "platform_pod_health" {
+  name        = "Platform pod health"
+  description = "Shows running, pending, failed, and unknown pods in configured Kubernetes control-plane namespaces."
+
+  program_text = <<-EOF
+A = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Running')
+B = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Pending')
+C = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Failed or unknown')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "plot_label"
+  time_range                = 900
+
+  axis_left {
+    label = "Platform pods"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "k8s.cluster.name"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "k8s.namespace.name"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "sf_metric"
+  }
+}
+
+resource "signalfx_time_chart" "otel_collector_pods" {
+  name        = "Splunk OTel collector pod health"
+  description = "Shows running, pending, failed, and unknown Splunk OpenTelemetry Collector pods."
+
+  program_text = <<-EOF
+A = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Running')
+B = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Pending')
+C = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Failed or unknown')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "plot_label"
+  time_range                = 900
+
+  axis_left {
+    label = "Collector pods"
+  }
+}
+
+resource "signalfx_time_chart" "node_pressure" {
+  name        = "Node pressure conditions"
+  description = "Shows active PID, memory, disk, or network pressure conditions by Kubernetes node."
+
+  program_text = <<-EOF
+A = data('k8s.node.condition', filter=(${local.k8s_cluster_filter}) and (filter('condition', 'PIDPressure') or filter('condition', 'MemoryPressure') or filter('condition', 'DiskPressure') or filter('condition', 'NetworkUnavailable')), rollup='latest').max(by=['k8s.cluster.name', 'k8s.node.name', 'condition']).publish(label='A')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "condition"
+  time_range                = 86400
+
+  axis_left {
+    label = "Active condition"
+  }
+
+  viz_options {
+    display_name = "{{k8s.node.name}} - {{condition}}"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "otel_exporter_queue_utilization" {
+  name        = "OTel exporter queue utilization"
+  description = "Shows exporter queue size as a percentage of capacity. Sustained growth can precede telemetry loss."
+
+  program_text = <<-EOF
+queue_size = data('otelcol_exporter_queue_size', filter=(${local.k8s_otel_collector_filter}), rollup='latest').mean(by=['k8s.cluster.name', 'k8s.pod.name', 'exporter', 'data_type'])
+queue_capacity = data('otelcol_exporter_queue_capacity', filter=(${local.k8s_otel_collector_filter}), rollup='latest').mean(by=['k8s.cluster.name', 'k8s.pod.name', 'exporter', 'data_type'])
+queue_utilization = ((queue_size / queue_capacity) * 100).top(count=20).publish(label='A')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 2
+  disable_sampling          = true
+  on_chart_legend_dimension = "exporter"
+  time_range                = 86400
+
+  axis_left {
+    label     = "Percent"
+    max_value = 100
+    min_value = 0
+  }
+
+  viz_options {
+    display_name = "{{exporter}} {{data_type}} on {{k8s.pod.name}}"
+    label        = "A"
+    value_suffix = "%"
+  }
+}
+
+resource "signalfx_time_chart" "otel_telemetry_loss" {
+  name        = "OTel refused and failed metric points"
+  description = "Shows metric points refused or failed by receivers and errored by scrapers."
+
+  program_text = <<-EOF
+refused = data('otelcol_receiver_refused_metric_points', filter=(${local.k8s_otel_collector_filter}), rollup='rate').sum(by=['k8s.cluster.name', 'receiver']).publish(label='Refused')
+failed = data('otelcol_receiver_failed_metric_points', filter=(${local.k8s_otel_collector_filter}), rollup='rate').sum(by=['k8s.cluster.name', 'receiver']).publish(label='Failed')
+scraper_errors = data('otelcol_scraper_errored_metric_points', filter=(${local.k8s_otel_collector_filter}), rollup='rate').sum(by=['k8s.cluster.name', 'scraper']).publish(label='Scraper errors')
+EOF
+
+  plot_type                 = "ColumnChart"
+  axes_precision            = 2
+  disable_sampling          = true
+  on_chart_legend_dimension = "plot_label"
+  time_range                = 604800
+
+  axis_left {
+    label = "Metric points / sec"
+  }
+}
+
+resource "signalfx_dashboard" "k8s_control_plane" {
+  name            = "K8S Control Plane"
+  description     = "Forge Kubernetes platform pods, node pressure, and telemetry pipeline health."
+  dashboard_group = var.dashboard_group
+
+  dynamic "variable" {
+    for_each = local.k8s_cluster_variables
+    iterator = var_def
+
+    content {
+      property               = var_def.value.property
+      alias                  = var_def.value.alias
+      description            = var_def.value.description
+      values                 = var_def.value.values
+      value_required         = var_def.value.value_required
+      values_suggested       = var_def.value.values_suggested
+      restricted_suggestions = var_def.value.restricted_suggestions
+    }
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.platform_pod_health.id
+    row      = 0
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.otel_collector_pods.id
+    row      = 1
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.node_pressure.id
+    row      = 1
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.otel_exporter_queue_utilization.id
+    row      = 2
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.otel_telemetry_loss.id
+    row      = 2
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_interface_contract.tftest.hcl
@@ -1,0 +1,62 @@
+run "integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_interface_contract" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_interface_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_input_variables = [
+      "dashboard_group",
+      "dynamic_variables",
+      "platform_namespaces",
+    ]
+    expected_output_values = []
+    expected_interface_literals = [
+      "variable \"dashboard_group\"",
+      "description = \"Dashboard group name for organizing dashboards.\"",
+      "type        = string",
+      "variable \"dynamic_variables\"",
+      "description = \"Dashboard variable definitions; only the Kubernetes cluster variable is used.\"",
+      "type = list(object({",
+      "property               = string",
+      "alias                  = string",
+      "description            = string",
+      "values                 = list(string)",
+      "value_required         = bool",
+      "values_suggested       = list(string)",
+      "restricted_suggestions = bool",
+      "}))",
+      "default = []",
+      "variable \"platform_namespaces\"",
+      "description = \"Namespaces that contain platform pods required for runner scheduling, networking, and telemetry.\"",
+      "type        = list(string)",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_input_variables) == 0
+    error_message = "Interface contract is missing input variables: ${join(", ", output.missing_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.unexpected_input_variables) == 0
+    error_message = "Interface contract has unexpected input variables: ${join(", ", output.unexpected_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.missing_output_values) == 0
+    error_message = "Interface contract is missing outputs: ${join(", ", output.missing_output_values)}"
+  }
+
+  assert {
+    condition     = length(output.unexpected_output_values) == 0
+    error_message = "Interface contract has unexpected outputs: ${join(", ", output.unexpected_output_values)}"
+  }
+
+  assert {
+    condition     = length(output.missing_interface_literals) == 0
+    error_message = "Interface contract is missing expected variable/output source lines: ${join(", ", output.missing_interface_literals)}"
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_source_inventory.tftest.hcl
@@ -1,0 +1,29 @@
+run "integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_source_inventory" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "resource \"signalfx_time_chart\" \"platform_pod_health\"",
+      "resource \"signalfx_time_chart\" \"otel_collector_pods\"",
+      "resource \"signalfx_time_chart\" \"node_pressure\"",
+      "resource \"signalfx_time_chart\" \"otel_exporter_queue_utilization\"",
+      "resource \"signalfx_time_chart\" \"otel_telemetry_loss\"",
+      "resource \"signalfx_dashboard\" \"k8s_control_plane\"",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "Source inventory is missing expected Terraform blocks: ${join(", ", output.missing_expected_literals)}"
+  }
+
+  assert {
+    condition     = output.expected_literal_count == 6
+    error_message = "Source inventory must keep six module-specific Terraform blocks pinned."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
@@ -1,0 +1,55 @@
+mock_provider "signalfx" {}
+
+variables {
+  dashboard_group     = "forge-dashboard-group"
+  platform_namespaces = ["karpenter", "kube-system", "monitoring"]
+  dynamic_variables = [
+    {
+      property               = "k8s.cluster.name"
+      alias                  = "K8S Cluster"
+      description            = "Limit by cluster"
+      values                 = ["forge-euw1-dev"]
+      value_required         = true
+      values_suggested       = ["forge-euw1-dev", "forge-use1-prod"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "k8s.namespace.name"
+      alias                  = "Namespace"
+      description            = "Must not be copied to the control-plane dashboard"
+      values                 = []
+      value_required         = false
+      values_suggested       = ["tenant-a"]
+      restricted_suggestions = true
+    },
+  ]
+}
+
+run "k8s_control_plane_dashboard_contract" {
+  command = plan
+
+  assert {
+    condition = (
+      signalfx_dashboard.k8s_control_plane.name == "K8S Control Plane"
+      && signalfx_dashboard.k8s_control_plane.dashboard_group == "forge-dashboard-group"
+      && length(signalfx_dashboard.k8s_control_plane.variable) == 1
+      && signalfx_dashboard.k8s_control_plane.variable[0].property == "k8s.cluster.name"
+      && length(signalfx_dashboard.k8s_control_plane.chart) == 5
+    )
+    error_message = "K8S control-plane dashboard must use only the cluster selector and wire all platform charts."
+  }
+
+  assert {
+    condition = (
+      strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'karpenter')")
+      && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'kube-system')")
+      && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'monitoring')")
+      && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'prometheus')")
+      && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'splunk-otel-collector')")
+      && strcontains(signalfx_time_chart.node_pressure.program_text, "k8s.node.condition")
+      && strcontains(signalfx_time_chart.otel_exporter_queue_utilization.program_text, "otelcol_exporter_queue_capacity")
+      && strcontains(signalfx_time_chart.otel_telemetry_loss.program_text, "otelcol_receiver_refused_metric_points")
+    )
+    error_message = "K8S control-plane charts must cover configured platform namespaces, node pressure, and OTel pipeline health."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
@@ -47,7 +47,9 @@ run "k8s_control_plane_dashboard_contract" {
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'prometheus')")
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'splunk-otel-collector')")
       && strcontains(signalfx_time_chart.node_pressure.program_text, "k8s.node.condition")
+      && one(signalfx_time_chart.node_pressure.viz_options).display_name == "Node pressure"
       && strcontains(signalfx_time_chart.otel_exporter_queue_utilization.program_text, "otelcol_exporter_queue_capacity")
+      && one(signalfx_time_chart.otel_exporter_queue_utilization.viz_options).display_name == "OTel exporter queue utilization"
       && strcontains(signalfx_time_chart.otel_telemetry_loss.program_text, "otelcol_receiver_refused_metric_points")
     )
     error_message = "K8S control-plane charts must cover configured platform namespaces, node pressure, and OTel pipeline health."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/variables.tf
@@ -1,0 +1,23 @@
+variable "dynamic_variables" {
+  description = "Dashboard variable definitions; only the Kubernetes cluster variable is used."
+  type = list(object({
+    property               = string
+    alias                  = string
+    description            = string
+    values                 = list(string)
+    value_required         = bool
+    values_suggested       = list(string)
+    restricted_suggestions = bool
+  }))
+  default = []
+}
+
+variable "platform_namespaces" {
+  description = "Namespaces that contain platform pods required for runner scheduling, networking, and telemetry."
+  type        = list(string)
+}
+
+variable "dashboard_group" {
+  description = "Dashboard group name for organizing dashboards."
+  type        = string
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "< 10.0.0"
+    }
+  }
+
+  required_version = "~> 1.11"
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/README.md
@@ -13,12 +13,16 @@ Forge relies heavily on Lambdas for webhooks, scaling, tagging, log archival, tr
 - Version-level percentages and average duration lists using the enriched
   `aws_function_name` and `aws_function_version` properties present on Forge
   Lambda metric streams.
+- Top-10 tenant rankings for errors and throttles, followed by top-10 Lambda
+  detail charts that react to the dashboard tenant filter.
 - Dashboard placement in the shared Forge O11y group.
 
 ## Operational Notes
 
 - Start here when an EventBridge, SQS, webhook, or trust-validation workflow behaves inconsistently.
 - Version-level charts help catch partial deployments or aliases pointing at unexpected code.
+- In a top-tenant chart, use the tenant property to apply a dashboard filter;
+  the per-Lambda error and throttle charts then isolate that tenant.
 - Pair Lambda errors with CloudWatch/Splunk logs for request-level detail.
 
 <!-- BEGIN_TF_DOCS -->

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/README.md
@@ -10,7 +10,9 @@ Forge relies heavily on Lambdas for webhooks, scaling, tagging, log archival, tr
 
 - Invocation, error, throttle, and duration charts.
 - Provisioned concurrency and spillover views.
-- Version-level percentages and average duration lists.
+- Version-level percentages and average duration lists using the enriched
+  `aws_function_name` and `aws_function_version` properties present on Forge
+  Lambda metric streams.
 - Dashboard placement in the shared Forge O11y group.
 
 ## Operational Notes

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
@@ -227,7 +227,7 @@ EOF
     label        = "B"
   }
   viz_options {
-    display_name = "{{aws_function_name}} - {{aws_function_version}}"
+    display_name = "Invocation share by version"
     label        = "C"
     value_suffix = "%"
   }
@@ -294,9 +294,9 @@ EOF
 
   viz_options {
     axis         = "left"
-    display_name = "{{aws_function_name}} - {{aws_function_version}}"
+    display_name = "Errors"
     label        = "A"
-    value_suffix = "-errors"
+    value_suffix = " errors"
   }
 }
 
@@ -374,7 +374,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{aws_function_name}} - {{aws_function_version}}"
+    display_name = "Average duration"
     label        = "A"
     value_unit   = "Millisecond"
   }
@@ -459,7 +459,7 @@ EOF
 
   viz_options {
     axis         = "left"
-    display_name = "{{aws_function_name}} - {{aws_function_version}}"
+    display_name = "Throttles"
     label        = "A"
   }
 
@@ -526,9 +526,9 @@ EOF
 
   viz_options {
     axis         = "left"
-    display_name = "{{aws_function_name}} - {{aws_function_version}}"
+    display_name = "Invocations"
     label        = "A"
-    value_suffix = "-invocations"
+    value_suffix = " invocations"
   }
 
 }
@@ -713,7 +713,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "Errors"
     label        = "A"
     value_suffix = " errors"
   }
@@ -739,7 +739,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{aws_tag_TenantName}}"
+    display_name = "Throttles"
     label        = "A"
     value_suffix = " throttles"
   }
@@ -773,7 +773,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{aws_function_name}} - {{aws_function_version}}"
+    display_name = "Errors"
     label        = "A"
     value_suffix = " errors"
   }
@@ -807,7 +807,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{aws_function_name}} - {{aws_function_version}}"
+    display_name = "Throttles"
     label        = "A"
     value_suffix = " throttles"
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
@@ -175,20 +175,20 @@ resource "signalfx_list_chart" "percent_invocations_by_version" {
   sort_by                 = "-value"
 
   program_text = <<-EOF
-A = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).publish(label='A', enable=False)
-B = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='B', enable=False)
+A = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).publish(label='A', enable=False)
+B = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version']).publish(label='B', enable=False)
 C = (B/A).scale(100).publish(label='C')
 EOF
 
   time_range = 3600
 
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "sf_metric"
   }
   legend_options_fields {
     enabled  = true
-    property = "ExecutedVersion"
+    property = "aws_function_version"
   }
   legend_options_fields {
     enabled  = true
@@ -199,8 +199,8 @@ EOF
     property = "AWSUniqueId"
   }
   legend_options_fields {
-    enabled  = false
-    property = "FunctionName"
+    enabled  = true
+    property = "aws_function_name"
   }
   legend_options_fields {
     enabled  = false
@@ -211,18 +211,13 @@ EOF
     property = "namespace"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "Resource"
   }
   legend_options_fields {
     enabled  = false
     property = "stat"
   }
-  legend_options_fields {
-    enabled  = false
-    property = "aws_function_version"
-  }
-
   viz_options {
     display_name = "A"
     label        = "A"
@@ -232,7 +227,7 @@ EOF
     label        = "B"
   }
   viz_options {
-    display_name = "Version"
+    display_name = "{{aws_function_name}} - {{aws_function_version}}"
     label        = "C"
     value_suffix = "%"
   }
@@ -242,7 +237,7 @@ resource "signalfx_time_chart" "errors_by_version" {
   name         = "Errors by version"
   description  = "The number of invocations that failed due to errors in the function (response code 4XX)."
   program_text = <<-EOF
-A = data('Errors', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('ExecutedVersion', '*') and filter('Resource', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
+A = data('Errors', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -252,7 +247,7 @@ EOF
   stacked     = false
 
   axes_precision            = 0
-  on_chart_legend_dimension = "ExecutedVersion"
+  on_chart_legend_dimension = "aws_function_version"
 
   time_range = 3600
 
@@ -262,7 +257,7 @@ EOF
   }
   legend_options_fields {
     enabled  = true
-    property = "FunctionName"
+    property = "aws_function_name"
   }
   legend_options_fields {
     enabled  = true
@@ -281,7 +276,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "Resource"
   }
   legend_options_fields {
@@ -289,17 +284,17 @@ EOF
     property = "stat"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "aws_function_version"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "ExecutedVersion"
   }
 
   viz_options {
     axis         = "left"
-    display_name = "Errors by version"
+    display_name = "{{aws_function_name}} - {{aws_function_version}}"
     label        = "A"
     value_suffix = "-errors"
   }
@@ -332,7 +327,7 @@ resource "signalfx_list_chart" "avg_duration_by_version" {
   disable_sampling = true
 
   program_text = <<-EOF
-A = data('Duration', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='average').mean(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
+A = data('Duration', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('aws_function_version', '*'), rollup='average').mean(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version']).publish(label='A')
 EOF
 
   time_range = 3600
@@ -343,7 +338,7 @@ EOF
   }
   legend_options_fields {
     enabled  = true
-    property = "FunctionName"
+    property = "aws_function_name"
   }
   legend_options_fields {
     enabled  = true
@@ -362,7 +357,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "Resource"
   }
   legend_options_fields {
@@ -370,16 +365,16 @@ EOF
     property = "stat"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "aws_function_version"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "ExecutedVersion"
   }
 
   viz_options {
-    display_name = "Version"
+    display_name = "{{aws_function_name}} - {{aws_function_version}}"
     label        = "A"
     value_unit   = "Millisecond"
   }
@@ -407,7 +402,7 @@ resource "signalfx_time_chart" "throttles_by_version" {
   name         = "Throttles by version"
   description  = "The number of Lambda function invocation attempts that were throttled due to invocation rates exceeding the customer’s concurrent limits (error code 429)."
   program_text = <<-EOF
-A = data('Throttles', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
+A = data('Throttles', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -417,7 +412,7 @@ EOF
   stacked     = true
 
   axes_precision            = 0
-  on_chart_legend_dimension = "ExecutedVersion"
+  on_chart_legend_dimension = "aws_function_version"
 
   time_range = 3600
 
@@ -427,7 +422,7 @@ EOF
   }
   legend_options_fields {
     enabled  = true
-    property = "FunctionName"
+    property = "aws_function_name"
   }
   legend_options_fields {
     enabled  = true
@@ -446,7 +441,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "Resource"
   }
   legend_options_fields {
@@ -458,13 +453,13 @@ EOF
     property = "aws_function_version"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "ExecutedVersion"
   }
 
   viz_options {
     axis         = "left"
-    display_name = "Throttles by version"
+    display_name = "{{aws_function_name}} - {{aws_function_version}}"
     label        = "A"
   }
 
@@ -474,7 +469,7 @@ resource "signalfx_time_chart" "invocations_by_version" {
   name         = "Invocations by version"
   description  = "The number of times a function is invoked in response to an event or invocation API call."
   program_text = <<-EOF
-A = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
+A = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"
@@ -485,7 +480,7 @@ EOF
 
 
   axes_precision            = 0
-  on_chart_legend_dimension = "ExecutedVersion"
+  on_chart_legend_dimension = "aws_function_version"
   time_range                = 3600
 
   histogram_options {
@@ -498,7 +493,7 @@ EOF
   }
   legend_options_fields {
     enabled  = true
-    property = "FunctionName"
+    property = "aws_function_name"
   }
   legend_options_fields {
     enabled  = false
@@ -513,7 +508,7 @@ EOF
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "Resource"
   }
   legend_options_fields {
@@ -521,17 +516,17 @@ EOF
     property = "stat"
   }
   legend_options_fields {
-    enabled  = false
+    enabled  = true
     property = "aws_function_version"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "ExecutedVersion"
   }
 
   viz_options {
     axis         = "left"
-    display_name = "Invocations by version"
+    display_name = "{{aws_function_name}} - {{aws_function_version}}"
     label        = "A"
     value_suffix = "-invocations"
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
@@ -693,6 +693,126 @@ EOF
   }
 }
 
+resource "signalfx_list_chart" "top_tenants_by_errors" {
+  name                    = "Top 10 tenants by Lambda errors"
+  description             = "Last hour. Use the tenant value to filter this dashboard, then inspect the per-Lambda charts below."
+  unit_prefix             = "Metric"
+  color_by                = "Dimension"
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+
+  program_text = <<-EOF
+A = data('Errors', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_tag_TenantName', '*') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over='1h').above(0).top(count=10).publish(label='A')
+EOF
+
+  time_range = 3600
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = " errors"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_by_throttles" {
+  name                    = "Top 10 tenants by Lambda throttles"
+  description             = "Last hour. Use the tenant value to filter this dashboard, then inspect the per-Lambda charts below."
+  unit_prefix             = "Metric"
+  color_by                = "Dimension"
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+
+  program_text = <<-EOF
+A = data('Throttles', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_tag_TenantName', '*') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over='1h').above(0).top(count=10).publish(label='A')
+EOF
+
+  time_range = 3600
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "{{aws_tag_TenantName}}"
+    label        = "A"
+    value_suffix = " throttles"
+  }
+}
+
+resource "signalfx_list_chart" "top_lambdas_by_errors" {
+  name                    = "Top 10 Lambdas by errors"
+  description             = "Last hour. Select one tenant in the dashboard filter to isolate that tenant's failing functions."
+  unit_prefix             = "Metric"
+  color_by                = "Dimension"
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+
+  program_text = <<-EOF
+A = data('Errors', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_tag_TenantName', '*') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version']).sum(over='1h').above(0).top(count=10).publish(label='A')
+EOF
+
+  time_range = 3600
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_function_name"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_function_version"
+  }
+
+  viz_options {
+    display_name = "{{aws_function_name}} - {{aws_function_version}}"
+    label        = "A"
+    value_suffix = " errors"
+  }
+}
+
+resource "signalfx_list_chart" "top_lambdas_by_throttles" {
+  name                    = "Top 10 Lambdas by throttles"
+  description             = "Last hour. Select one tenant in the dashboard filter to isolate that tenant's throttled functions."
+  unit_prefix             = "Metric"
+  color_by                = "Dimension"
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+
+  program_text = <<-EOF
+A = data('Throttles', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_tag_TenantName', '*') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version']).sum(over='1h').above(0).top(count=10).publish(label='A')
+EOF
+
+  time_range = 3600
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_function_name"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_function_version"
+  }
+
+  viz_options {
+    display_name = "{{aws_function_name}} - {{aws_function_version}}"
+    label        = "A"
+    value_suffix = " throttles"
+  }
+}
+
 resource "signalfx_dashboard" "lambda" {
   name            = "Lambdas"
   description     = "Forge CICD Lambda invocation rate, errors, duration, and concurrency."
@@ -726,9 +846,41 @@ resource "signalfx_dashboard" "lambda" {
   time_range = "-1h"
 
   chart {
-    chart_id = signalfx_time_chart.invocations.id
+    chart_id = signalfx_list_chart.top_tenants_by_errors.id
     column   = 0
     row      = 1
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_by_throttles.id
+    column   = 6
+    row      = 1
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_lambdas_by_errors.id
+    column   = 0
+    row      = 2
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_lambdas_by_throttles.id
+    column   = 6
+    row      = 2
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.invocations.id
+    column   = 0
+    row      = 3
     width    = 3
     height   = 1
   }
@@ -776,7 +928,7 @@ resource "signalfx_dashboard" "lambda" {
   chart {
     chart_id = signalfx_time_chart.invocations_by_version.id
     column   = 3
-    row      = 1
+    row      = 3
     width    = 3
     height   = 1
   }
@@ -784,7 +936,7 @@ resource "signalfx_dashboard" "lambda" {
   chart {
     chart_id = signalfx_time_chart.provisioned_concurrency_invocations_by_version.id
     column   = 6
-    row      = 1
+    row      = 3
     width    = 3
     height   = 1
   }
@@ -792,7 +944,7 @@ resource "signalfx_dashboard" "lambda" {
   chart {
     chart_id = signalfx_time_chart.provisioned_concurrent_executions_by_version.id
     column   = 9
-    row      = 1
+    row      = 3
     width    = 3
     height   = 1
   }
@@ -800,7 +952,7 @@ resource "signalfx_dashboard" "lambda" {
   chart {
     chart_id = signalfx_list_chart.avg_duration_by_version.id
     column   = 0
-    row      = 2
+    row      = 4
     width    = 4
     height   = 1
   }
@@ -808,7 +960,7 @@ resource "signalfx_dashboard" "lambda" {
   chart {
     chart_id = signalfx_time_chart.errors_by_version.id
     column   = 4
-    row      = 2
+    row      = 4
     width    = 4
     height   = 1
   }
@@ -816,7 +968,7 @@ resource "signalfx_dashboard" "lambda" {
   chart {
     chart_id = signalfx_time_chart.throttles_by_version.id
     column   = 8
-    row      = 2
+    row      = 4
     width    = 4
     height   = 1
   }
@@ -824,7 +976,7 @@ resource "signalfx_dashboard" "lambda" {
   chart {
     chart_id = signalfx_list_chart.percent_invocations_by_version.id
     column   = 0
-    row      = 3
+    row      = 5
     width    = 4
     height   = 1
   }
@@ -832,7 +984,7 @@ resource "signalfx_dashboard" "lambda" {
   chart {
     chart_id = signalfx_time_chart.provisioned_concurrency_spillover_invocations_by_version.id
     column   = 4
-    row      = 3
+    row      = 5
     width    = 4
     height   = 1
   }
@@ -840,7 +992,7 @@ resource "signalfx_dashboard" "lambda" {
   chart {
     chart_id = signalfx_time_chart.provisioned_concurrency_utilization.id
     column   = 8
-    row      = 3
+    row      = 5
     width    = 4
     height   = 1
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory.tftest.hcl
@@ -23,6 +23,10 @@ run "integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory" {
       "resource \"signalfx_single_value_chart\" \"total_errors\"",
       "resource \"signalfx_time_chart\" \"provisioned_concurrency_utilization\"",
       "resource \"signalfx_single_value_chart\" \"total_invocations\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_by_errors\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_by_throttles\"",
+      "resource \"signalfx_list_chart\" \"top_lambdas_by_errors\"",
+      "resource \"signalfx_list_chart\" \"top_lambdas_by_throttles\"",
       "resource \"signalfx_dashboard\" \"lambda\"",
     ]
   }
@@ -33,7 +37,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 16
-    error_message = "Source inventory must keep 16 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 20
+    error_message = "Source inventory must keep 20 module-specific Terraform blocks pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
@@ -51,6 +51,16 @@ run "lambda_dashboard_contract" {
     ])
     error_message = "Standard Lambda version charts must use the live enriched function name and version properties instead of the sparse ExecutedVersion dimension."
   }
+
+  assert {
+    condition = (
+      strcontains(signalfx_list_chart.top_tenants_by_errors.program_text, ".sum(by=['aws_tag_TenantName']).sum(over='1h').above(0).top(count=10)")
+      && strcontains(signalfx_list_chart.top_tenants_by_throttles.program_text, ".sum(by=['aws_tag_TenantName']).sum(over='1h').above(0).top(count=10)")
+      && strcontains(signalfx_list_chart.top_lambdas_by_errors.program_text, ".sum(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version']).sum(over='1h').above(0).top(count=10)")
+      && strcontains(signalfx_list_chart.top_lambdas_by_throttles.program_text, ".sum(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version']).sum(over='1h').above(0).top(count=10)")
+    )
+    error_message = "Lambda triage charts must rank noisy tenants globally and expose tenant-filtered per-function detail."
+  }
 }
 
 run "lambda_dashboard_wiring_contract" {
@@ -62,7 +72,7 @@ run "lambda_dashboard_wiring_contract" {
       && signalfx_dashboard.lambda.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.lambda.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.lambda.variable[0].value_required
-      && length(signalfx_dashboard.lambda.chart) == 15
+      && length(signalfx_dashboard.lambda.chart) == 19
     )
     error_message = "Lambda dashboard must keep its name, group input, and chart count."
   }
@@ -71,7 +81,11 @@ run "lambda_dashboard_wiring_contract" {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_time_chart.invocations.id),
       contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_time_chart.provisioned_concurrency_utilization.id),
+      contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_list_chart.top_tenants_by_errors.id),
+      contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_list_chart.top_tenants_by_throttles.id),
+      contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_list_chart.top_lambdas_by_errors.id),
+      contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_list_chart.top_lambdas_by_throttles.id),
     ])
-    error_message = "Lambda dashboard must keep its first and final chart wiring."
+    error_message = "Lambda dashboard must wire summary, tenant ranking, per-function detail, and provisioned-concurrency charts."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
@@ -61,6 +61,21 @@ run "lambda_dashboard_contract" {
     )
     error_message = "Lambda triage charts must rank noisy tenants globally and expose tenant-filtered per-function detail."
   }
+
+  assert {
+    condition = (
+      one([for option in signalfx_list_chart.percent_invocations_by_version.viz_options : option if option.label == "C"]).display_name == "Invocation share by version"
+      && one(signalfx_time_chart.errors_by_version.viz_options).display_name == "Errors"
+      && one(signalfx_list_chart.avg_duration_by_version.viz_options).display_name == "Average duration"
+      && one(signalfx_time_chart.throttles_by_version.viz_options).display_name == "Throttles"
+      && one(signalfx_time_chart.invocations_by_version.viz_options).display_name == "Invocations"
+      && one(signalfx_list_chart.top_tenants_by_errors.viz_options).display_name == "Errors"
+      && one(signalfx_list_chart.top_tenants_by_throttles.viz_options).display_name == "Throttles"
+      && one(signalfx_list_chart.top_lambdas_by_errors.viz_options).display_name == "Errors"
+      && one(signalfx_list_chart.top_lambdas_by_throttles.viz_options).display_name == "Throttles"
+    )
+    error_message = "Lambda plot names must be static metric labels; tenant, function, and version identity belongs in dimension columns."
+  }
 }
 
 run "lambda_dashboard_wiring_contract" {

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
@@ -29,10 +29,27 @@ run "lambda_dashboard_contract" {
       && strcontains(signalfx_single_value_chart.total_throttles.program_text, ".sum(over='30m')")
       && strcontains(signalfx_single_value_chart.total_invocations.program_text, ".sum(over='30m')")
       && strcontains(signalfx_time_chart.errors_by_version.program_text, "Errors")
-      && strcontains(signalfx_time_chart.errors_by_version.program_text, ".sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion'])")
-      && strcontains(signalfx_list_chart.avg_duration_by_version.program_text, ".mean(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion'])")
+      && strcontains(signalfx_time_chart.errors_by_version.program_text, ".sum(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version'])")
+      && strcontains(signalfx_list_chart.avg_duration_by_version.program_text, ".mean(by=['aws_tag_TenantName', 'aws_function_name', 'aws_function_version'])")
     )
     error_message = "Lambda charts must keep one-hour visibility and ingestion-delay-safe invocation, error, and throttle behavior."
+  }
+
+  assert {
+    condition = alltrue([
+      for program_text in [
+        signalfx_list_chart.percent_invocations_by_version.program_text,
+        signalfx_time_chart.errors_by_version.program_text,
+        signalfx_list_chart.avg_duration_by_version.program_text,
+        signalfx_time_chart.throttles_by_version.program_text,
+        signalfx_time_chart.invocations_by_version.program_text,
+        ] : (
+        strcontains(program_text, "filter('aws_function_version', '*')")
+        && strcontains(program_text, "aws_function_name")
+        && !strcontains(program_text, "filter('ExecutedVersion', '*')")
+      )
+    ])
+    error_message = "Standard Lambda version charts must use the live enriched function name and version properties instead of the sparse ExecutedVersion dimension."
   }
 }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -1287,12 +1287,12 @@ EOF
 
 resource "signalfx_list_chart" "chart_disk_summary_utilization" {
   name        = "Disk summary utilization (%)"
-  description = "Percent of disk space utilized on all volumes on active hosts with agent installed. Instance id | Host"
+  description = "Percent of disk space utilized on all volumes on active hosts with agent installed. Tenant | Instance id | Host"
 
   program_text = <<-EOF
-A = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'used')).publish(label='A', enable=False)
-B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'free')).publish(label='B', enable=False)
-C = ((A/(A+B))*100).mean(by=['host.name', 'AWSUniqueId']).publish(label='C')
+A = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'used')).sum(by=['aws_tag_TenantName', 'host.name', 'host.id', 'AWSUniqueId']).publish(label='A', enable=False)
+B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'free')).sum(by=['aws_tag_TenantName', 'host.name', 'host.id', 'AWSUniqueId']).publish(label='B', enable=False)
+C = ((A/(A+B))*100).publish(label='C')
 EOF
 
   sort_by = "-value"
@@ -1320,6 +1320,10 @@ EOF
   legend_options_fields {
     enabled  = true
     property = "AWSUniqueId"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
   }
   legend_options_fields {
     enabled  = true
@@ -1392,7 +1396,7 @@ EOF
     value_suffix = "%"
   }
   viz_options {
-    display_name = "Disk summary urilzation"
+    display_name = "{{aws_tag_TenantName}} | {{host.id}} | {{host.name}}"
     label        = "C"
     value_suffix = "%"
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -1396,7 +1396,7 @@ EOF
     value_suffix = "%"
   }
   viz_options {
-    display_name = "{{aws_tag_TenantName}} | {{host.id}} | {{host.name}}"
+    display_name = "Disk utilization"
     label        = "C"
     value_suffix = "%"
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -30,7 +30,7 @@ run "runner_ec2_dashboard_contract" {
       && signalfx_list_chart.chart_disk_summary_utilization.description == "Percent of disk space utilized on all volumes on active hosts with agent installed. Tenant | Instance id | Host"
       && strcontains(signalfx_list_chart.chart_disk_summary_utilization.program_text, ".sum(by=['aws_tag_TenantName', 'host.name', 'host.id', 'AWSUniqueId'])")
       && contains([for field in signalfx_list_chart.chart_disk_summary_utilization.legend_options_fields : field.property if field.enabled], "aws_tag_TenantName")
-      && one([for option in signalfx_list_chart.chart_disk_summary_utilization.viz_options : option.display_name if option.label == "C"]) == "{{aws_tag_TenantName}} | {{host.id}} | {{host.name}}"
+      && one([for option in signalfx_list_chart.chart_disk_summary_utilization.viz_options : option.display_name if option.label == "C"]) == "Disk utilization"
       && signalfx_time_chart.chart_status_check_failures.time_range == 3600
       && signalfx_list_chart.chart_total_network_errors.name == "Network errors/sec"
       && strcontains(signalfx_list_chart.chart_total_network_errors.program_text, "rollup='rate'")

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -27,13 +27,17 @@ run "runner_ec2_dashboard_contract" {
       && signalfx_time_chart.chart_cpu_utilization.time_range == 3600
       && signalfx_list_chart.chart_top_instances_by_cpu_utilization.sort_by == "-value"
       && signalfx_list_chart.chart_top_instances_by_cpu_utilization.time_range == 3600
+      && signalfx_list_chart.chart_disk_summary_utilization.description == "Percent of disk space utilized on all volumes on active hosts with agent installed. Tenant | Instance id | Host"
+      && strcontains(signalfx_list_chart.chart_disk_summary_utilization.program_text, ".sum(by=['aws_tag_TenantName', 'host.name', 'host.id', 'AWSUniqueId'])")
+      && contains([for field in signalfx_list_chart.chart_disk_summary_utilization.legend_options_fields : field.property if field.enabled], "aws_tag_TenantName")
+      && one([for option in signalfx_list_chart.chart_disk_summary_utilization.viz_options : option.display_name if option.label == "C"]) == "{{aws_tag_TenantName}} | {{host.id}} | {{host.name}}"
       && signalfx_time_chart.chart_status_check_failures.time_range == 3600
       && signalfx_list_chart.chart_total_network_errors.name == "Network errors/sec"
       && strcontains(signalfx_list_chart.chart_total_network_errors.program_text, "rollup='rate'")
       && !strcontains(signalfx_list_chart.chart_total_network_errors.program_text, ".count(")
       && strcontains(signalfx_list_chart.chart_top_memory_page_swaps_sec.program_text, "data('vmpage_io.swap.in', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks'), rollup='rate')")
     )
-    error_message = "EC2 runner charts must keep one-hour visibility, active host, CPU utilization, top-instance, and rate-based network and swap behavior."
+    error_message = "EC2 runner charts must keep one-hour visibility, tenant-aware disk identity, active host, CPU utilization, top-instance, and rate-based network and swap behavior."
   }
 }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
@@ -4,22 +4,22 @@ This module creates Kubernetes pod and deployment charts for the ARC runner lane
 
 ## Why This Module Exists
 
-Kubernetes runner failures often show up as pending pods, restarts, resource pressure, or collector gaps. This dashboard provides the pod-level view that complements EKS and Karpenter logs.
+Kubernetes runner failures often show up as pending pods, restarts, or resource pressure. This dashboard provides the tenant pod-level view that complements the separate K8S Control Plane dashboard and EKS/Karpenter logs.
 
 ## What It Manages
 
 - Active, desired, available, and phase-based pod charts.
 - CPU, memory, network, and restart views.
 - Top pod lists for resource usage.
-- Node pressure and tenant pod shutdown/termination diagnostics.
-- OTel collector pod, exporter queue, and telemetry-loss visibility.
+- Tenant pod shutdown and termination diagnostics.
 - Dashboard placement in the shared Forge O11y group.
 
 ## Operational Notes
 
 - Use this when ARC scale sets see demand but jobs do not start.
 - Pending pods usually require checking Karpenter, taints/tolerations, resource requests, and storage.
-- Collector health affects dashboard reliability, so treat no-data signals seriously.
+- Every chart is explicitly restricted to configured Forge tenant namespaces and clusters.
+- Use the K8S Control Plane dashboard for Karpenter, networking, node, Prometheus, and collector health.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -55,10 +55,6 @@ No modules.
 | [signalfx_time_chart.k8s_memory_usage_bytes](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.k8s_memory_usage_pct](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.k8s_network_bytes_per_sec](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
-| [signalfx_time_chart.k8s_node_pressure](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
-| [signalfx_time_chart.k8s_otel_collector_pods](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
-| [signalfx_time_chart.k8s_otel_exporter_queue_utilization](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
-| [signalfx_time_chart.k8s_otel_telemetry_loss](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.k8s_pod_phase_trend](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.k8s_pod_status_reasons](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
@@ -10,15 +10,14 @@ locals {
   k8s_tenant_namespace_filter = length(var.tenant_names) > 0 ? join(" or ", [
     for namespace in sort(var.tenant_names) : "filter('k8s.namespace.name', '${namespace}')"
   ]) : "filter('k8s.namespace.name', '__forge_tenant_scope_not_configured__')"
-  k8s_tenant_filter         = "(${local.k8s_cluster_filter}) and (${local.k8s_tenant_namespace_filter})"
-  k8s_otel_collector_filter = "(${local.k8s_cluster_filter}) and filter('k8s.namespace.name', 'splunk-otel-collector') and filter('k8s.pod.name', 'splunk-otel-collector*')"
+  k8s_tenant_filter = "(${local.k8s_cluster_filter}) and (${local.k8s_tenant_namespace_filter})"
 }
 
 resource "signalfx_single_value_chart" "k8s_available_pods_by_deployments" {
   name        = "# Available pods by deployments"
   description = "Number of pods ready by deployments"
 
-  program_text = "A = data('k8s.deployment.available', rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.deployment.name']).sum().publish(label='A')"
+  program_text = "A = data('k8s.deployment.available', filter=(${local.k8s_tenant_filter}), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.deployment.name']).sum().publish(label='A')"
 
   color_by         = "Dimension"
   refresh_interval = 5
@@ -34,7 +33,7 @@ resource "signalfx_list_chart" "k8s_top_10_cpu_usage_per_pod" {
   description = "Pod name | Node name"
 
   program_text = <<-EOF
-A = data('container_cpu_utilization', rollup='rate').mean(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).scale(0.01).top(count=10).publish(label='A')
+A = data('container_cpu_utilization', filter=(${local.k8s_tenant_filter}), rollup='rate').mean(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).scale(0.01).top(count=10).publish(label='A')
 EOF
 
   sort_by = "-value"
@@ -84,7 +83,7 @@ resource "signalfx_time_chart" "k8s_network_bytes_per_sec" {
   name        = "Network bytes / sec"
   description = ""
 
-  program_text = "A = data('k8s.pod.network.io', filter=filter('k8s.cluster.name', '*') and filter('k8s.namespace.name', '*') and filter('sf_tags', '*', match_missing=True) and filter('k8s.deployment.name', '*', match_missing=True), rollup='rate', extrapolation='zero').sum(by=['k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).publish(label='A')"
+  program_text = "A = data('k8s.pod.network.io', filter=(${local.k8s_tenant_filter}) and filter('sf_tags', '*', match_missing=True) and filter('k8s.deployment.name', '*', match_missing=True), rollup='rate', extrapolation='zero').sum(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).publish(label='A')"
 
   plot_type = "ColumnChart"
 
@@ -127,7 +126,7 @@ resource "signalfx_single_value_chart" "k8s_desired_pods_by_deployments" {
   name        = "# Desired pods by deployments"
   description = "Number of pods that should be created by deployments"
 
-  program_text = "A = data('k8s.deployment.desired', rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.deployment.name']).sum().publish(label='A')"
+  program_text = "A = data('k8s.deployment.desired', filter=(${local.k8s_tenant_filter}), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.deployment.name']).sum().publish(label='A')"
 
   color_by         = "Dimension"
   refresh_interval = 5
@@ -142,7 +141,7 @@ resource "signalfx_list_chart" "k8s_network_errors_per_sec" {
   name        = "Network errors / sec"
   description = ""
 
-  program_text = "A = data('k8s.pod.network.errors', filter=filter('k8s.cluster.name', '*') and filter('k8s.namespace.name', '*') and filter('k8s.deployment.name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.cluster.name', 'k8s.node.name', 'k8s.pod.uid']).publish(label='A')"
+  program_text = "A = data('k8s.pod.network.errors', filter=(${local.k8s_tenant_filter}) and filter('k8s.deployment.name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True), rollup='rate').sum(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.cluster.name', 'k8s.node.name', 'k8s.pod.uid']).publish(label='A')"
 
   sort_by = "-value"
 
@@ -192,8 +191,8 @@ resource "signalfx_time_chart" "k8s_memory_usage_pct" {
   description = "With EKS/Fargate metric data can possibly go >100%"
 
   program_text = <<-EOF
-A = data('container.memory.usage', filter=filter('k8s.cluster.name', '*') and filter('k8s.namespace.name', '*') and filter('k8s.deployment.name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).publish(label='A', enable=False)
-B = data('k8s.container.memory_limit', filter=filter('k8s.cluster.name', '*') and filter('k8s.namespace.name', '*') and filter('k8s.deployment.name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).above(0, inclusive=True).publish(label='B', enable=False)
+A = data('container.memory.usage', filter=(${local.k8s_tenant_filter}) and filter('k8s.deployment.name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).publish(label='A', enable=False)
+B = data('k8s.container.memory_limit', filter=(${local.k8s_tenant_filter}) and filter('k8s.deployment.name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).sum(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).above(0, inclusive=True).publish(label='B', enable=False)
 C = (A/B*100).publish(label='C')
 EOF
 
@@ -263,7 +262,7 @@ resource "signalfx_single_value_chart" "k8s_active_pods" {
   name        = "# Active pods"
   description = "This may include \"pause\" containers used internally by k8s"
 
-  program_text = "A = data('k8s.pod.phase').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count().publish(label='A')"
+  program_text = "A = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count().publish(label='A')"
 
   color_by         = "Dimension"
   refresh_interval = 5
@@ -278,7 +277,7 @@ resource "signalfx_list_chart" "k8s_top_10_pods_by_avg_memory_usage" {
   name        = "Top 10 pods by average memory usage (bytes)"
   description = "Pod name | Node name"
 
-  program_text = "A = data('container.memory.usage', filter=filter('k8s.cluster.name', '*') and filter('k8s.namespace.name', '*') and filter('k8s.deployment.name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).mean(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).top(count=10).publish(label='A')"
+  program_text = "A = data('container.memory.usage', filter=(${local.k8s_tenant_filter}) and filter('k8s.deployment.name', '*', match_missing=True) and filter('sf_tags', '*', match_missing=True)).mean(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.node.name', 'k8s.cluster.name', 'k8s.pod.uid']).top(count=10).publish(label='A')"
 
   sort_by = "-value"
 
@@ -330,11 +329,11 @@ resource "signalfx_list_chart" "k8s_pods_by_phase" {
   description = ""
 
   program_text = <<-EOF
-B = data('k8s.pod.phase', rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='B')
-A = data('k8s.pod.phase', rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='A')
-C = data('k8s.pod.phase', rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='C')
-D = data('k8s.pod.phase', rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='D')
-E = data('k8s.pod.phase', rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='E')
+B = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='B')
+A = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='A')
+C = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='C')
+D = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='D')
+E = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).publish(label='E')
 EOF
 
   sort_by = "+sf_originatingMetric"
@@ -393,7 +392,7 @@ resource "signalfx_time_chart" "k8s_memory_usage_bytes" {
   name        = "Memory usage (bytes)"
   description = ""
 
-  program_text = "A = data('container.memory.usage', filter=filter('k8s.node.name', '*')).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.uid', 'k8s.pod.name', 'k8s.node.name']).publish(label='A')"
+  program_text = "A = data('container.memory.usage', filter=(${local.k8s_tenant_filter}) and filter('k8s.node.name', '*')).sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.uid', 'k8s.pod.name', 'k8s.node.name']).publish(label='A')"
 
   plot_type = "LineChart"
 
@@ -465,11 +464,11 @@ resource "signalfx_time_chart" "k8s_pod_phase_trend" {
   description = "Tracks pending, running, succeeded, failed, and unknown pod counts over time."
 
   program_text = <<-EOF
-A = data('k8s.pod.phase', rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Pending')
-B = data('k8s.pod.phase', rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Running')
-C = data('k8s.pod.phase', rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Succeeded')
-D = data('k8s.pod.phase', rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Failed')
-E = data('k8s.pod.phase', rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Unknown')
+A = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Pending')
+B = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Running')
+C = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Succeeded')
+D = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Failed')
+E = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Unknown')
 EOF
 
   plot_type                 = "LineChart"
@@ -498,9 +497,9 @@ EOF
 
 resource "signalfx_time_chart" "k8s_container_restarts" {
   name        = "Container restarts"
-  description = "Highlights restarting runner, hook, DIND, and platform containers by pod."
+  description = "Highlights restarting runner, hook, and DIND containers in Forge tenant namespaces."
 
-  program_text = "A = data('k8s.container.restarts', rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name', 'k8s.container.name']).top(count=20).publish(label='A')"
+  program_text = "A = data('k8s.container.restarts', filter=(${local.k8s_tenant_filter}), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name', 'k8s.container.name']).top(count=20).publish(label='A')"
 
   plot_type        = "LineChart"
   axes_precision   = 0
@@ -527,101 +526,6 @@ resource "signalfx_time_chart" "k8s_container_restarts" {
   viz_options {
     display_name = "Container restarts"
     label        = "A"
-  }
-}
-
-resource "signalfx_time_chart" "k8s_otel_collector_pods" {
-  name        = "Splunk OTel collector pod health"
-  description = "Shows running, pending, failed, and unknown Splunk OpenTelemetry Collector pods."
-
-  program_text = <<-EOF
-A = data('k8s.pod.phase', filter=filter('k8s.namespace.name', 'splunk-otel-collector') and filter('k8s.pod.name', 'splunk-otel-collector*'), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Running')
-B = data('k8s.pod.phase', filter=filter('k8s.namespace.name', 'splunk-otel-collector') and filter('k8s.pod.name', 'splunk-otel-collector*'), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Pending')
-C = data('k8s.pod.phase', filter=filter('k8s.namespace.name', 'splunk-otel-collector') and filter('k8s.pod.name', 'splunk-otel-collector*'), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Failed or unknown')
-EOF
-
-  plot_type                 = "LineChart"
-  axes_precision            = 0
-  disable_sampling          = true
-  on_chart_legend_dimension = "plot_label"
-  time_range                = 900
-
-  axis_left {
-    label = "Collector pods"
-  }
-}
-
-resource "signalfx_time_chart" "k8s_node_pressure" {
-  name        = "Node pressure conditions"
-  description = "Shows active PID, memory, disk, or network pressure conditions by Kubernetes node."
-
-  program_text = <<-EOF
-A = data('k8s.node.condition', filter=(${local.k8s_cluster_filter}) and (filter('condition', 'PIDPressure') or filter('condition', 'MemoryPressure') or filter('condition', 'DiskPressure') or filter('condition', 'NetworkUnavailable')), rollup='latest').max(by=['k8s.cluster.name', 'k8s.node.name', 'condition']).publish(label='A')
-EOF
-
-  plot_type                 = "LineChart"
-  axes_precision            = 0
-  disable_sampling          = true
-  on_chart_legend_dimension = "condition"
-  time_range                = 86400
-
-  axis_left {
-    label = "Active condition"
-  }
-
-  viz_options {
-    display_name = "{{k8s.node.name}} - {{condition}}"
-    label        = "A"
-  }
-}
-
-resource "signalfx_time_chart" "k8s_otel_exporter_queue_utilization" {
-  name        = "OTel exporter queue utilization"
-  description = "Shows exporter queue size as a percentage of capacity. Sustained growth can precede telemetry loss."
-
-  program_text = <<-EOF
-queue_size = data('otelcol_exporter_queue_size', filter=(${local.k8s_otel_collector_filter}), rollup='latest').mean(by=['k8s.cluster.name', 'k8s.pod.name', 'exporter', 'data_type'])
-queue_capacity = data('otelcol_exporter_queue_capacity', filter=(${local.k8s_otel_collector_filter}), rollup='latest').mean(by=['k8s.cluster.name', 'k8s.pod.name', 'exporter', 'data_type'])
-queue_utilization = ((queue_size / queue_capacity) * 100).top(count=20).publish(label='A')
-EOF
-
-  plot_type                 = "LineChart"
-  axes_precision            = 2
-  disable_sampling          = true
-  on_chart_legend_dimension = "exporter"
-  time_range                = 86400
-
-  axis_left {
-    label     = "Percent"
-    max_value = 100
-    min_value = 0
-  }
-
-  viz_options {
-    display_name = "{{exporter}} {{data_type}} on {{k8s.pod.name}}"
-    label        = "A"
-    value_suffix = "%"
-  }
-}
-
-resource "signalfx_time_chart" "k8s_otel_telemetry_loss" {
-  name        = "OTel refused and failed metric points"
-  description = "Shows metric points refused or failed by receivers and errored by scrapers."
-
-  program_text = <<-EOF
-refused = data('otelcol_receiver_refused_metric_points', filter=(${local.k8s_otel_collector_filter}), rollup='rate').sum(by=['k8s.cluster.name', 'receiver']).publish(label='Refused')
-failed = data('otelcol_receiver_failed_metric_points', filter=(${local.k8s_otel_collector_filter}), rollup='rate').sum(by=['k8s.cluster.name', 'receiver']).publish(label='Failed')
-scraper_errors = data('otelcol_scraper_errored_metric_points', filter=(${local.k8s_otel_collector_filter}), rollup='rate').sum(by=['k8s.cluster.name', 'scraper']).publish(label='Scraper errors')
-EOF
-
-  plot_type                 = "ColumnChart"
-  axes_precision            = 2
-  disable_sampling          = true
-  on_chart_legend_dimension = "plot_label"
-  time_range                = 604800
-
-  axis_left {
-    label = "Metric points / sec"
   }
 }
 
@@ -785,42 +689,10 @@ resource "signalfx_dashboard" "runner_k8s" {
   }
 
   chart {
-    chart_id = signalfx_time_chart.k8s_otel_collector_pods.id
-    row      = 3
-    column   = 9
-    width    = 3
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_time_chart.k8s_node_pressure.id
-    row      = 4
-    column   = 0
-    width    = 6
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_time_chart.k8s_otel_exporter_queue_utilization.id
-    row      = 4
-    column   = 6
-    width    = 6
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_time_chart.k8s_otel_telemetry_loss.id
-    row      = 5
-    column   = 0
-    width    = 6
-    height   = 1
-  }
-
-  chart {
     chart_id = signalfx_time_chart.k8s_pod_status_reasons.id
-    row      = 5
-    column   = 6
-    width    = 6
+    row      = 4
+    column   = 0
+    width    = 12
     height   = 1
   }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
@@ -548,7 +548,7 @@ EOF
   }
 
   viz_options {
-    display_name = "{{k8s.namespace.name}} - {{k8s.pod.status_reason}}"
+    display_name = "Pod status reason"
     label        = "A"
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory.tftest.hcl
@@ -20,10 +20,6 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory
       "resource \"signalfx_time_chart\" \"k8s_memory_usage_bytes\"",
       "resource \"signalfx_time_chart\" \"k8s_pod_phase_trend\"",
       "resource \"signalfx_time_chart\" \"k8s_container_restarts\"",
-      "resource \"signalfx_time_chart\" \"k8s_otel_collector_pods\"",
-      "resource \"signalfx_time_chart\" \"k8s_node_pressure\"",
-      "resource \"signalfx_time_chart\" \"k8s_otel_exporter_queue_utilization\"",
-      "resource \"signalfx_time_chart\" \"k8s_otel_telemetry_loss\"",
       "resource \"signalfx_time_chart\" \"k8s_pod_status_reasons\"",
       "resource \"signalfx_dashboard\" \"runner_k8s\"",
     ]
@@ -35,7 +31,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory
   }
 
   assert {
-    condition     = output.expected_literal_count == 18
-    error_message = "Source inventory must keep 18 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 14
+    error_message = "Source inventory must keep 14 module-specific Terraform blocks pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
@@ -25,13 +25,30 @@ run "runner_k8s_dashboard_contract" {
       && strcontains(signalfx_single_value_chart.k8s_active_pods.program_text, "k8s.pod.phase")
       && signalfx_list_chart.k8s_top_10_cpu_usage_per_pod.sort_by == "-value"
       && signalfx_time_chart.k8s_memory_usage_pct.name == "Memory usage (%)"
-      && strcontains(signalfx_time_chart.k8s_otel_collector_pods.program_text, "splunk-otel-collector")
-      && strcontains(signalfx_time_chart.k8s_node_pressure.program_text, "k8s.node.condition")
-      && strcontains(signalfx_time_chart.k8s_otel_exporter_queue_utilization.program_text, "otelcol_exporter_queue_capacity")
-      && strcontains(signalfx_time_chart.k8s_otel_telemetry_loss.program_text, "otelcol_receiver_refused_metric_points")
       && strcontains(signalfx_time_chart.k8s_pod_status_reasons.program_text, "filter('k8s.namespace.name', 'tenant-a') or filter('k8s.namespace.name', 'tenant-b')")
     )
-    error_message = "K8S runner charts must keep active pod, top CPU, memory percentage, and OTel collector health behavior."
+    error_message = "K8S runner charts must keep active pod, top CPU, memory percentage, and tenant pod status behavior."
+  }
+
+  assert {
+    condition = alltrue([
+      for program_text in [
+        signalfx_single_value_chart.k8s_available_pods_by_deployments.program_text,
+        signalfx_list_chart.k8s_top_10_cpu_usage_per_pod.program_text,
+        signalfx_time_chart.k8s_network_bytes_per_sec.program_text,
+        signalfx_single_value_chart.k8s_desired_pods_by_deployments.program_text,
+        signalfx_list_chart.k8s_network_errors_per_sec.program_text,
+        signalfx_time_chart.k8s_memory_usage_pct.program_text,
+        signalfx_single_value_chart.k8s_active_pods.program_text,
+        signalfx_list_chart.k8s_top_10_pods_by_avg_memory_usage.program_text,
+        signalfx_list_chart.k8s_pods_by_phase.program_text,
+        signalfx_time_chart.k8s_memory_usage_bytes.program_text,
+        signalfx_time_chart.k8s_pod_phase_trend.program_text,
+        signalfx_time_chart.k8s_container_restarts.program_text,
+        signalfx_time_chart.k8s_pod_status_reasons.program_text,
+      ] : strcontains(program_text, "filter('k8s.namespace.name', 'tenant-a') or filter('k8s.namespace.name', 'tenant-b')")
+    ])
+    error_message = "Every K8S runner chart must explicitly restrict telemetry to configured Forge tenant namespaces."
   }
 }
 
@@ -44,7 +61,7 @@ run "runner_k8s_dashboard_wiring_contract" {
       && signalfx_dashboard.runner_k8s.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.runner_k8s.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.runner_k8s.variable[0].value_required
-      && length(signalfx_dashboard.runner_k8s.chart) == 17
+      && length(signalfx_dashboard.runner_k8s.chart) == 13
     )
     error_message = "K8S runner dashboard must keep its name, group input, and chart count."
   }
@@ -52,8 +69,7 @@ run "runner_k8s_dashboard_wiring_contract" {
   assert {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.runner_k8s.chart : chart.chart_id], signalfx_single_value_chart.k8s_active_pods.id),
-      contains([for chart in signalfx_dashboard.runner_k8s.chart : chart.chart_id], signalfx_time_chart.k8s_otel_collector_pods.id),
-      contains([for chart in signalfx_dashboard.runner_k8s.chart : chart.chart_id], signalfx_time_chart.k8s_otel_exporter_queue_utilization.id),
+      contains([for chart in signalfx_dashboard.runner_k8s.chart : chart.chart_id], signalfx_time_chart.k8s_container_restarts.id),
       contains([for chart in signalfx_dashboard.runner_k8s.chart : chart.chart_id], signalfx_time_chart.k8s_pod_status_reasons.id),
     ])
     error_message = "K8S runner dashboard must keep its first and final chart wiring."

--- a/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_source_inventory.tftest.hcl
@@ -10,6 +10,7 @@ run "integrations_splunk_o11y_conf_shared_contract" {
     expected_literals = [
       "module \"dashboard_runner_ec2\"",
       "module \"dashboard_runner_k8s\"",
+      "module \"dashboard_k8s_control_plane\"",
       "module \"dashboard_lambda\"",
       "module \"dashboard_sqs\"",
       "module \"dashboard_dynamodb\"",

--- a/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_source_inventory.tftest.hcl
@@ -37,3 +37,23 @@ run "integrations_splunk_o11y_conf_shared_contract" {
     error_message = "Module contract must pin at least one module-specific literal."
   }
 }
+
+run "splunk_o11y_dashboards_reject_dynamic_plot_names" {
+  command = plan
+
+  module {
+    source = "../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path        = "dashboards"
+    recursive          = true
+    expected_literals  = []
+    forbidden_literals = ["display_name = \"{{"]
+  }
+
+  assert {
+    condition     = length(output.present_forbidden_literals) == 0
+    error_message = "Dashboard viz_options.display_name values must be static; identity belongs in dimension fields."
+  }
+}

--- a/tests/tofu/module_contract/main.tf
+++ b/tests/tofu/module_contract/main.tf
@@ -19,8 +19,14 @@ variable "forbidden_literals" {
   default     = []
 }
 
+variable "recursive" {
+  type        = bool
+  description = "Whether to inspect Terraform files recursively below module_path."
+  default     = false
+}
+
 locals {
-  tf_files = sort(fileset(var.module_path, "*.tf"))
+  tf_files = sort(fileset(var.module_path, var.recursive ? "**/*.tf" : "*.tf"))
   tf_text = join("\n", [
     for file_name in local.tf_files : file("${var.module_path}/${file_name}")
   ])


### PR DESCRIPTION
## Description

Separate Forge tenant runner workload visibility from Kubernetes platform visibility.

- Scope every K8S Runner chart to configured Forge clusters and tenant namespaces.
- Move node pressure and Splunk OTel collector health charts out of the tenant dashboard.
- Add a cluster-scoped `K8S Control Plane` dashboard for platform pod health, node pressure, exporter queue utilization, and telemetry loss.
- Include configured platform namespaces plus common `monitoring`, `prometheus`, and `splunk-otel-collector` namespaces.
- Add interface, source-inventory, behavior, and root wiring coverage for the new dashboard split.
- Restore Lambda invocation, duration, error, throttle, and percentage-by-version charts using the live `aws_function_name` and `aws_function_version` properties.
- Render Lambda series as `function - version` through chart `viz_options`.
- Add top-10 tenant rankings for Lambda errors and throttles over the last hour.
- Add top-10 per-Lambda error and throttle tables that react to the dashboard tenant filter, providing a global-to-tenant triage flow.
- Turn `ForgeCICD Impact` into the global tenant issue entry point with top-10 leaderboards for Lambda errors/throttles, EC2 CPU/memory, K8S unhealthy pods, SQS/DLQ backlog, DynamoDB throttles/system errors, and EBS queue length.
- Keep the existing runner adoption and capacity section below the issue leaderboards.
- Restore the EC2 disk utilization calculation and identify each result as `Tenant | Instance id | Host`.
- Enable scale-based coloring on EC2 CPU and memory impact charts so their warning and critical thresholds pass provider validation.
- Use static control-plane plot names while keeping node, cluster, condition, exporter, and pod identity in their dedicated dimensions.
- Replace Lambda tenant/function/version plot-name placeholders with static metric labels while retaining identity in dedicated legend columns.
- Remove the remaining unsupported plot-name placeholders from Forge Impact, EC2 runners, K8S runners, and EBS, with a recursive regression guard across every dashboard.
- Complete the Forge Impact EC2 CPU and memory color scales with `<90`, `90–99`, and `≥99` ranges required by the SignalFx chart API.

This prevents Prometheus, Karpenter, collectors, and other platform components from obscuring tenant runner diagnostics, while avoiding empty Lambda and EC2 disk charts caused by sparse dimensions and incompatible filesystem state streams.

## Type of Change

- [x] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu test` in `modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s` (4 passed)
- `tofu test` in `modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane` (3 passed)
- `tofu test` in `modules/integrations/splunk_o11y_conf_shared/dashboards/lambda` (4 passed)
- `tofu test` in `modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact` (4 passed)
- `tofu test` in `modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2` (4 passed)
- `tofu test` in `modules/integrations/splunk_o11y_conf_shared` (3 passed)
- Live SignalFlow validation: Lambda rankings, EC2 memory and disk calculations, K8S unhealthy pods, SQS backlog, and EBS queue length return tenant-scoped series
- Full pre-commit hooks passed during commit
