### PR TITLE
feat(observability): complete Forge dashboard operator model

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
@@ -105,7 +105,11 @@ module "dashboard_forge_impact" {
 
   tenant_names      = try(var.dashboard_variables.forge_impact.tenant_names, var.dashboard_variables.runner_k8s.tenant_names)
   dynamic_variables = try(var.dashboard_variables.forge_impact.dynamic_variables, [])
-  dashboard_group   = signalfx_dashboard_group.forgecicd.id
+  cluster_names = distinct(flatten([
+    for variable in var.dashboard_variables.runner_k8s.dynamic_variables :
+    variable.property == "k8s.cluster.name" ? variable.values : []
+  ]))
+  dashboard_group = signalfx_dashboard_group.forgecicd.id
 }
 
 # Cost and usage

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/main.tf
@@ -275,8 +275,8 @@ EOF
 }
 
 resource "signalfx_dashboard" "billing" {
-  name            = "Billing"
-  description     = "Forge CICD cost and net cost by service and tenant."
+  name            = "Forge Billing and Cost - AWS"
+  description     = "AWS billing cost and net cost for Forge, separated from OpenCost allocation estimates."
   dashboard_group = var.dashboard_group
 
   time_range = "-31d"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/billing_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/billing_dashboard_behavior.tftest.hcl
@@ -36,7 +36,7 @@ run "billing_dashboard_wiring_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.billing.name == "Billing"
+      signalfx_dashboard.billing.name == "Forge Billing and Cost - AWS"
       && signalfx_dashboard.billing.dashboard_group == "forge-dashboard-group"
       && length(signalfx_dashboard.billing.chart) == 8
     )

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
@@ -495,7 +495,7 @@ EOF
 
 
 resource "signalfx_dashboard" "dynamodb" {
-  name        = "DynamoDBs"
+  name        = "Forge Tenant - DynamoDB"
   description = "Forge CICD DynamoDB table performance, capacity, and throttling."
 
   dashboard_group = var.dashboard_group

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/dynamodb_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/dynamodb_dashboard_behavior.tftest.hcl
@@ -40,7 +40,7 @@ run "dynamodb_dashboard_wiring_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.dynamodb.name == "DynamoDBs"
+      signalfx_dashboard.dynamodb.name == "Forge Tenant - DynamoDB"
       && signalfx_dashboard.dynamodb.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.dynamodb.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.dynamodb.variable[0].value_required

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
@@ -573,7 +573,7 @@ EOF
 }
 
 resource "signalfx_dashboard" "ebs" {
-  name            = "EBS"
+  name            = "Forge Tenant - EBS"
   description     = "EC2/EBS volume throughput, IOPS, and latency for Forge runners."
   dashboard_group = var.dashboard_group
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/ebs_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/ebs_dashboard_behavior.tftest.hcl
@@ -42,7 +42,7 @@ run "ebs_dashboard_wiring_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.ebs.name == "EBS"
+      signalfx_dashboard.ebs.name == "Forge Tenant - EBS"
       && signalfx_dashboard.ebs.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.ebs.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.ebs.variable[0].value_required

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/README.md
@@ -1,22 +1,22 @@
 # Splunk Observability Forge Impact Dashboard
 
-This module creates the high-level Forge tenant issue and usage dashboard.
+This module creates separate Forge tenant-impact and runner-usage dashboards.
 
 ## Why This Module Exists
 
 Operators need one place to identify which tenants are most affected before
 opening a subsystem dashboard. The dashboard starts with top-10 tenant
-leaderboards for actionable Lambda, EC2, Kubernetes, SQS, DynamoDB, and EBS
-signals, then retains the adoption and workload-shape section.
+leaderboards for live-backed Lambda, EC2, Kubernetes, SQS, and EBS signals.
+Runner adoption and workload-shape charts live in a separate usage dashboard
+so they do not dilute the incident landing page.
 
 ## What It Manages
 
 - Top tenants by Lambda errors and throttles.
-- Top tenants by EC2 runner memory and CPU utilization.
-- Top tenant namespaces by pending, failed, or unknown Kubernetes pods.
+- Top tenants by EC2 runner CPU, memory, disk, and status-check failures.
+- Top tenant namespaces by pending, failed, unknown, or restarting Kubernetes workloads.
 - Top tenants by SQS and dead-letter backlog.
-- Top tenants by DynamoDB throttles and system errors.
-- Top tenants by EBS queue length.
+- Top tenants by EBS queue length and exceeded IOPS limits.
 - Runner totals and minutes by runtime.
 - Active EC2 runners by tenant and instance type.
 - EC2 runner hours and total runners by tenant.
@@ -29,8 +29,13 @@ signals, then retains the adoption and workload-shape section.
   that needs deeper investigation.
 - Tenant properties remain visible in each leaderboard so the same identity can
   be used in the matching subsystem dashboard.
-- Use the lower section for capacity planning and stakeholder reporting.
+- Open `Forge Runner Usage` for capacity planning and stakeholder reporting.
 - Tenant names must be consistently emitted as dimensions.
+- Kubernetes signals are restricted to configured Forge clusters and tenant namespaces.
+- Required AWS scope values are embedded in SignalFlow so they cannot suppress
+  Kubernetes charts that do not carry AWS tag dimensions.
+- DynamoDB throttling and system-error leaderboards are intentionally absent:
+  the live metrics do not currently expose a confirmed tenant identity.
 - Use subsystem dashboards for resource-level diagnosis after identifying the
   tenant and issue category here.
 
@@ -58,6 +63,7 @@ No modules.
 | Name | Type |
 | ---- | ---- |
 | [signalfx_dashboard.forge_impact](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/dashboard) | resource |
+| [signalfx_dashboard.runner_usage](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/dashboard) | resource |
 | [signalfx_list_chart.active_ec2_runners_by_tenant](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.active_ec2_runners_by_tenant_and_instance_type](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.ec2_runner_hours_by_tenant](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
@@ -66,13 +72,15 @@ No modules.
 | [signalfx_list_chart.k8s_runners_by_tenant](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.runner_minutes_by_runtime](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.runner_totals_by_runtime](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
-| [signalfx_list_chart.top_tenants_dynamodb_system_errors](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
-| [signalfx_list_chart.top_tenants_dynamodb_throttles](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_ebs_iops_exceeded](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.top_tenants_ebs_queue_length](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.top_tenants_ec2_cpu](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_ec2_disk](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.top_tenants_ec2_memory](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_ec2_status_failures](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.top_tenants_k8s_failed_pods](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.top_tenants_k8s_pending_pods](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
+| [signalfx_list_chart.top_tenants_k8s_restarts](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.top_tenants_lambda_errors](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.top_tenants_lambda_throttles](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.top_tenants_sqs_backlog](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
@@ -86,6 +94,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cluster_names"></a> [cluster\_names](#input\_cluster\_names) | Forge Kubernetes clusters included in global tenant impact and runner usage. | `list(string)` | `[]` | no |
 | <a name="input_dashboard_group"></a> [dashboard\_group](#input\_dashboard\_group) | Dashboard group name for organizing dashboards. | `string` | n/a | yes |
 | <a name="input_dynamic_variables"></a> [dynamic\_variables](#input\_dynamic\_variables) | Additional dynamic variable definitions for the dashboard. | <pre>list(object({<br/>    property               = string<br/>    alias                  = string<br/>    description            = string<br/>    values                 = list(string)<br/>    value_required         = bool<br/>    values_suggested       = list(string)<br/>    restricted_suggestions = bool<br/>  }))</pre> | `[]` | no |
 | <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | Tenant namespaces that run Forge ARC runners. | `list(string)` | n/a | yes |

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
@@ -236,18 +236,37 @@ resource "signalfx_list_chart" "top_tenants_sqs_dlq_backlog" {
   }
 }
 
-resource "signalfx_list_chart" "top_tenants_dynamodb_throttles" {
-  name        = "Top 10 tenants: DynamoDB throttled requests"
-  description = "DynamoDB throttled requests over the selected window, summed by Forge tenant."
+resource "signalfx_list_chart" "top_tenants_ec2_disk" {
+  name        = "Top 10 tenants: EC2 disk utilization"
+  description = "Highest current filesystem utilization on a Forge EC2 runner host per tenant."
 
-  program_text = "A = data('ThrottledRequests', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+used = data('system.filesystem.usage', filter=(${local.ec2_tenant_filter}) and filter('cloud.platform', 'aws_ec2') and filter('state', 'used'), rollup='latest').sum(by=['aws_tag_TenantName', 'host.id'])
+free = data('system.filesystem.usage', filter=(${local.ec2_tenant_filter}) and filter('cloud.platform', 'aws_ec2') and filter('state', 'free'), rollup='latest').sum(by=['aws_tag_TenantName', 'host.id'])
+A = ((used / (used + free)) * 100).max(by=['aws_tag_TenantName']).top(count=10).publish(label='A')
+EOF
 
+  color_by                = "Scale"
   hide_missing_values     = true
-  max_precision           = 0
+  max_precision           = 2
   secondary_visualization = "Sparkline"
   sort_by                 = "-value"
   time_range              = 3600
   unit_prefix             = "Metric"
+
+  color_scale {
+    color = "green"
+    lt    = 80
+  }
+  color_scale {
+    color = "orange"
+    gte   = 80
+    lt    = 90
+  }
+  color_scale {
+    color = "red"
+    gte   = 90
+  }
 
   legend_options_fields {
     enabled  = true
@@ -255,18 +274,19 @@ resource "signalfx_list_chart" "top_tenants_dynamodb_throttles" {
   }
 
   viz_options {
-    display_name = "DynamoDB throttled requests"
+    display_name = "EC2 disk utilization"
     label        = "A"
-    value_suffix = " throttled"
+    value_suffix = "%"
   }
 }
 
-resource "signalfx_list_chart" "top_tenants_dynamodb_system_errors" {
-  name        = "Top 10 tenants: DynamoDB system errors"
-  description = "DynamoDB HTTP 500 errors over the selected window, summed by Forge tenant."
+resource "signalfx_list_chart" "top_tenants_ec2_status_failures" {
+  name        = "Top 10 tenants: EC2 status check failures"
+  description = "Highest instance or system status-check failure count on a Forge EC2 runner per tenant over the selected window."
 
-  program_text = "A = data('SystemErrors', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+  program_text = "A = data('StatusCheckFailed', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'sum') and filter('aws_instance_id', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'aws_instance_id']).sum(over=${local.issue_window}).max(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')"
 
+  color_by                = "Scale"
   hide_missing_values     = true
   max_precision           = 0
   secondary_visualization = "Sparkline"
@@ -274,15 +294,59 @@ resource "signalfx_list_chart" "top_tenants_dynamodb_system_errors" {
   time_range              = 3600
   unit_prefix             = "Metric"
 
+  color_scale {
+    color = "green"
+    lt    = 1
+  }
+  color_scale {
+    color = "red"
+    gte   = 1
+  }
+
   legend_options_fields {
     enabled  = true
     property = "aws_tag_TenantName"
   }
 
   viz_options {
-    display_name = "DynamoDB system errors"
+    display_name = "EC2 status check failures"
     label        = "A"
-    value_suffix = " errors"
+    value_suffix = " failed checks"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_k8s_restarts" {
+  name        = "Top 10 tenants: K8S container restarts"
+  description = "Positive container restart deltas in Forge tenant namespaces over the selected window."
+
+  program_text = "A = data('k8s.container.restarts', filter=(${local.k8s_tenant_namespace_filter}) and filter('k8s.container.name', '*'), rollup='latest').max(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.container.name']).delta().sum(by=['k8s.namespace.name']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+
+  color_by                = "Scale"
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  color_scale {
+    color = "green"
+    lt    = 1
+  }
+  color_scale {
+    color = "red"
+    gte   = 1
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "k8s.namespace.name"
+  }
+
+  viz_options {
+    display_name = "K8S container restarts"
+    label        = "A"
+    value_suffix = " restarts"
   }
 }
 
@@ -307,5 +371,40 @@ resource "signalfx_list_chart" "top_tenants_ebs_queue_length" {
   viz_options {
     display_name = "EBS queue length"
     label        = "A"
+  }
+}
+
+resource "signalfx_list_chart" "top_tenants_ebs_iops_exceeded" {
+  name        = "Top 10 tenants: EBS IOPS limit exceeded"
+  description = "Highest EBS provisioned-IOPS exceeded count per Forge tenant over the selected window."
+
+  program_text = "A = data('VolumeIOPSExceededCheck', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EBS') and filter('stat', 'sum') and filter('VolumeId', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'VolumeId']).sum(over=${local.issue_window}).max(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')"
+
+  color_by                = "Scale"
+  hide_missing_values     = true
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  color_scale {
+    color = "green"
+    lt    = 1
+  }
+  color_scale {
+    color = "red"
+    gte   = 1
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+
+  viz_options {
+    display_name = "EBS IOPS limit exceeded"
+    label        = "A"
+    value_suffix = " exceeded checks"
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
@@ -1,10 +1,27 @@
 locals {
-  k8s_tenant_namespace_filter = length(var.tenant_names) > 0 ? join(" or ", [
-    for namespace in sort(var.tenant_names) : "filter('k8s.namespace.name', '${namespace}')"
-  ]) : "filter('k8s.namespace.name', '__forge_tenant_scope_not_configured__')"
-  ec2_tenant_filter = length(var.tenant_names) > 0 ? join(" or ", [
+  configured_tenant_filter = length(var.tenant_names) > 0 ? join(" or ", [
     for tenant_name in sort(var.tenant_names) : "filter('aws_tag_TenantName', '${tenant_name}')"
   ]) : "filter('aws_tag_TenantName', '__forge_tenant_scope_not_configured__')"
+  configured_aws_scope_filter = length([
+    for variable in var.dynamic_variables : variable
+    if variable.value_required && length(variable.values) > 0
+    ]) > 0 ? join(" and ", [
+    for variable in var.dynamic_variables :
+    "filter('${variable.property}', '${join("', '", sort(variable.values))}')"
+    if variable.value_required && length(variable.values) > 0
+  ]) : "filter('aws_tag_TenantName', '*')"
+  ec2_tenant_filter = "(${local.configured_tenant_filter}) and (${local.configured_aws_scope_filter})"
+
+  configured_k8s_tenant_filter = length(var.tenant_names) > 0 ? join(" or ", [
+    for namespace in sort(var.tenant_names) : "filter('k8s.namespace.name', '${namespace}')"
+  ]) : "filter('k8s.namespace.name', '__forge_tenant_scope_not_configured__')"
+  configured_k8s_cluster_filter = length(var.cluster_names) > 0 ? join(" or ", [
+    for cluster_name in sort(var.cluster_names) : "filter('k8s.cluster.name', '${cluster_name}')"
+  ]) : "filter('k8s.cluster.name', '__forge_cluster_scope_not_configured__')"
+  k8s_tenant_namespace_filter = join(" and ", [
+    "(${local.configured_k8s_tenant_filter})",
+    "(${local.configured_k8s_cluster_filter})",
+  ])
 
   k8s_runner_container_filter  = "filter('k8s.container.name', 'runner') and (${local.k8s_tenant_namespace_filter})"
   k8s_runner_pod_dimensions    = "['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name']"
@@ -350,8 +367,8 @@ resource "terraform_data" "dashboard_parent" {
 }
 
 resource "signalfx_dashboard" "forge_impact" {
-  name            = "ForgeCICD Impact"
-  description     = "Cross-service tenant issue leaderboards followed by Forge adoption and runner usage."
+  name            = "Forge Tenant Impact"
+  description     = "Cross-service tenant issue leaderboards for the first step of workload incident investigation."
   dashboard_group = var.dashboard_group
 
   # Splunk O11y rejects moving an existing dashboard to a new parent group.
@@ -359,21 +376,6 @@ resource "signalfx_dashboard" "forge_impact" {
     replace_triggered_by = [
       terraform_data.dashboard_parent,
     ]
-  }
-
-  dynamic "variable" {
-    for_each = var.dynamic_variables
-    iterator = var_def
-
-    content {
-      property               = var_def.value.property
-      alias                  = var_def.value.alias
-      description            = var_def.value.description
-      values                 = var_def.value.values
-      value_required         = var_def.value.value_required
-      values_suggested       = var_def.value.values_suggested
-      restricted_suggestions = var_def.value.restricted_suggestions
-    }
   }
 
   chart {
@@ -410,22 +412,6 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.top_tenants_k8s_pending_pods.id
-    row      = 1
-    column   = 4
-    width    = 4
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_list_chart.top_tenants_k8s_failed_pods.id
-    row      = 1
-    column   = 8
-    width    = 4
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_list_chart.top_tenants_sqs_backlog.id
     row      = 2
     column   = 0
     width    = 4
@@ -433,7 +419,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.top_tenants_sqs_dlq_backlog.id
+    chart_id = signalfx_list_chart.top_tenants_k8s_failed_pods.id
     row      = 2
     column   = 4
     width    = 4
@@ -441,15 +427,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.top_tenants_dynamodb_throttles.id
-    row      = 2
-    column   = 8
-    width    = 4
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_list_chart.top_tenants_dynamodb_system_errors.id
+    chart_id = signalfx_list_chart.top_tenants_sqs_backlog.id
     row      = 3
     column   = 0
     width    = 6
@@ -457,7 +435,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.top_tenants_ebs_queue_length.id
+    chart_id = signalfx_list_chart.top_tenants_sqs_dlq_backlog.id
     row      = 3
     column   = 6
     width    = 6
@@ -465,8 +443,60 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.active_ec2_runners_by_tenant.id
+    chart_id = signalfx_list_chart.top_tenants_ec2_disk.id
+    row      = 1
+    column   = 4
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_ec2_status_failures.id
+    row      = 1
+    column   = 8
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_k8s_restarts.id
+    row      = 2
+    column   = 8
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_ebs_queue_length.id
     row      = 4
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_ebs_iops_exceeded.id
+    row      = 4
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+}
+
+resource "signalfx_dashboard" "runner_usage" {
+  name            = "Forge Runner Usage"
+  description     = "Forge EC2 and Kubernetes runner adoption, active capacity, and runtime estimates by tenant."
+  dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.active_ec2_runners_by_tenant.id
+    row      = 0
     column   = 0
     width    = 4
     height   = 1
@@ -474,7 +504,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.active_ec2_runners_by_tenant_and_instance_type.id
-    row      = 4
+    row      = 0
     column   = 4
     width    = 4
     height   = 1
@@ -482,7 +512,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.k8s_runners_by_tenant.id
-    row      = 4
+    row      = 0
     column   = 8
     width    = 4
     height   = 1
@@ -490,7 +520,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.runner_totals_by_runtime.id
-    row      = 5
+    row      = 1
     column   = 0
     width    = 4
     height   = 1
@@ -498,7 +528,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.total_ec2_runners_by_tenant.id
-    row      = 5
+    row      = 1
     column   = 4
     width    = 4
     height   = 1
@@ -506,7 +536,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.total_k8s_runners_by_tenant.id
-    row      = 5
+    row      = 1
     column   = 8
     width    = 4
     height   = 1
@@ -514,7 +544,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.runner_minutes_by_runtime.id
-    row      = 6
+    row      = 2
     column   = 0
     width    = 4
     height   = 1
@@ -522,7 +552,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.ec2_runner_hours_by_tenant.id
-    row      = 6
+    row      = 2
     column   = 4
     width    = 4
     height   = 1
@@ -530,7 +560,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.k8s_runner_hours_by_tenant.id
-    row      = 6
+    row      = 2
     column   = 8
     width    = 4
     height   = 1
@@ -538,7 +568,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_time_chart.active_ec2_runners_by_tenant_and_instance_type.id
-    row      = 7
+    row      = 3
     column   = 0
     width    = 6
     height   = 1
@@ -546,7 +576,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.ec2_runner_hours_by_tenant_and_instance_type.id
-    row      = 7
+    row      = 3
     column   = 6
     width    = 6
     height   = 1

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
@@ -366,6 +366,10 @@ resource "terraform_data" "dashboard_parent" {
   triggers_replace = var.dashboard_group
 }
 
+resource "terraform_data" "runner_usage_dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "forge_impact" {
   name            = "Forge Tenant Impact"
   description     = "Cross-service tenant issue leaderboards for the first step of workload incident investigation."
@@ -490,7 +494,7 @@ resource "signalfx_dashboard" "runner_usage" {
 
   lifecycle {
     replace_triggered_by = [
-      terraform_data.dashboard_parent,
+      terraform_data.runner_usage_dashboard_parent,
     ]
   }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -2,6 +2,7 @@ mock_provider "signalfx" {}
 
 variables {
   tenant_names    = ["tenant-b", "tenant-a"]
+  cluster_names   = ["forge-cluster-b", "forge-cluster-a"]
   dashboard_group = "forge-dashboard-group"
   dynamic_variables = [
     {
@@ -31,7 +32,9 @@ run "forge_impact_dashboard_contract" {
       signalfx_list_chart.runner_totals_by_runtime.name == "Total runners by runtime over selected window"
       && strcontains(signalfx_list_chart.runner_totals_by_runtime.program_text, "CPUUtilization")
       && strcontains(signalfx_list_chart.runner_totals_by_runtime.program_text, "filter('aws_tag_TenantName', 'tenant-a') or filter('aws_tag_TenantName', 'tenant-b')")
+      && strcontains(signalfx_list_chart.runner_totals_by_runtime.program_text, "filter('aws_region', 'us-east-1')")
       && strcontains(signalfx_list_chart.runner_totals_by_runtime.program_text, "filter('k8s.namespace.name', 'tenant-a') or filter('k8s.namespace.name', 'tenant-b')")
+      && strcontains(signalfx_list_chart.runner_totals_by_runtime.program_text, "filter('k8s.cluster.name', 'forge-cluster-a') or filter('k8s.cluster.name', 'forge-cluster-b')")
       && signalfx_list_chart.active_ec2_runners_by_tenant.name == "Active EC2 runners by tenant"
       && strcontains(signalfx_list_chart.k8s_runners_by_tenant.program_text, "container.memory.usage")
     )
@@ -55,11 +58,13 @@ run "forge_impact_dashboard_contract" {
       && strcontains(signalfx_list_chart.top_tenants_k8s_failed_pods.program_text, "k8s.pod.phase")
       && strcontains(signalfx_list_chart.top_tenants_sqs_backlog.program_text, "ApproximateNumberOfMessagesVisible")
       && strcontains(signalfx_list_chart.top_tenants_sqs_dlq_backlog.program_text, "*dead-letter*")
-      && strcontains(signalfx_list_chart.top_tenants_dynamodb_throttles.program_text, "ThrottledRequests")
-      && strcontains(signalfx_list_chart.top_tenants_dynamodb_system_errors.program_text, "SystemErrors")
+      && strcontains(signalfx_list_chart.top_tenants_ec2_disk.program_text, "system.filesystem.usage")
+      && strcontains(signalfx_list_chart.top_tenants_ec2_status_failures.program_text, "StatusCheckFailed")
+      && strcontains(signalfx_list_chart.top_tenants_k8s_restarts.program_text, "k8s.container.restarts")
       && strcontains(signalfx_list_chart.top_tenants_ebs_queue_length.program_text, "VolumeQueueLength")
+      && strcontains(signalfx_list_chart.top_tenants_ebs_iops_exceeded.program_text, "VolumeIOPSExceededCheck")
     )
-    error_message = "Forge impact must rank affected tenants across Lambda, EC2, K8S, SQS, DynamoDB, and EBS issue signals."
+    error_message = "Forge impact must rank affected tenants across live-backed Lambda, EC2, K8S, SQS, and EBS issue signals."
   }
 
   assert {
@@ -69,11 +74,12 @@ run "forge_impact_dashboard_contract" {
         signalfx_list_chart.top_tenants_lambda_throttles.program_text,
         signalfx_list_chart.top_tenants_ec2_memory.program_text,
         signalfx_list_chart.top_tenants_ec2_cpu.program_text,
+        signalfx_list_chart.top_tenants_ec2_disk.program_text,
+        signalfx_list_chart.top_tenants_ec2_status_failures.program_text,
         signalfx_list_chart.top_tenants_sqs_backlog.program_text,
         signalfx_list_chart.top_tenants_sqs_dlq_backlog.program_text,
-        signalfx_list_chart.top_tenants_dynamodb_throttles.program_text,
-        signalfx_list_chart.top_tenants_dynamodb_system_errors.program_text,
         signalfx_list_chart.top_tenants_ebs_queue_length.program_text,
+        signalfx_list_chart.top_tenants_ebs_iops_exceeded.program_text,
       ] : strcontains(program_text, "filter('aws_tag_TenantName', 'tenant-a') or filter('aws_tag_TenantName', 'tenant-b')")
     ])
     error_message = "AWS issue leaderboards must be restricted to configured Forge tenants."
@@ -85,24 +91,26 @@ run "forge_impact_dashboard_wiring_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.forge_impact.name == "ForgeCICD Impact"
+      signalfx_dashboard.forge_impact.name == "Forge Tenant Impact"
       && signalfx_dashboard.forge_impact.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.forge_impact.chart) == 22
+      && length(signalfx_dashboard.forge_impact.chart) == 13
+      && signalfx_dashboard.runner_usage.name == "Forge Runner Usage"
+      && length(signalfx_dashboard.runner_usage.chart) == 11
     )
-    error_message = "Forge impact dashboard must keep its name, group input, and chart count."
+    error_message = "Tenant impact and runner usage must remain separate dashboards with pinned chart counts."
   }
 
   assert {
     condition = alltrue([
-      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.active_ec2_runners_by_tenant.id),
-      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.ec2_runner_hours_by_tenant_and_instance_type.id),
       contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_lambda_errors.id),
       contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_ec2_memory.id),
       contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_k8s_failed_pods.id),
       contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_sqs_dlq_backlog.id),
-      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_dynamodb_throttles.id),
+      contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_ec2_status_failures.id),
       contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_ebs_queue_length.id),
+      contains([for chart in signalfx_dashboard.runner_usage.chart : chart.chart_id], signalfx_list_chart.active_ec2_runners_by_tenant.id),
+      contains([for chart in signalfx_dashboard.runner_usage.chart : chart.chart_id], signalfx_list_chart.ec2_runner_hours_by_tenant_and_instance_type.id),
     ])
-    error_message = "Forge impact dashboard must wire cross-service issue leaderboards and retain adoption charts."
+    error_message = "Tenant impact must contain only issue leaderboards, while runner usage retains adoption charts."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -23,8 +23,9 @@ run "forge_impact_dashboard_contract" {
   assert {
     condition = (
       terraform_data.dashboard_parent.triggers_replace == "forge-dashboard-group"
+      && terraform_data.runner_usage_dashboard_parent.triggers_replace == "forge-dashboard-group"
     )
-    error_message = "Forge impact dashboard must keep the dashboard-group replacement trigger."
+    error_message = "Forge impact and runner usage dashboards must keep independent dashboard-group replacement triggers."
   }
 
   assert {

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_contract.tftest.hcl
@@ -11,6 +11,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_cont
       "dashboard_group",
       "dynamic_variables",
       "tenant_names",
+      "cluster_names",
     ]
     expected_output_values = []
     expected_interface_literals = [
@@ -32,6 +33,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_cont
       "variable \"tenant_names\"",
       "description = \"Tenant namespaces that run Forge ARC runners.\"",
       "type        = list(string)",
+      "variable \"cluster_names\"",
+      "description = \"Forge Kubernetes clusters included in global tenant impact and runner usage.\"",
     ]
   }
 
@@ -62,9 +65,9 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_cont
 
   assert {
     condition = (
-      output.expected_input_variable_count == 3
+      output.expected_input_variable_count == 4
       && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 18
+      && output.expected_interface_literal_count == 20
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_inventory.tftest.hcl
@@ -27,11 +27,14 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_invento
       "resource \"signalfx_list_chart\" \"top_tenants_k8s_failed_pods\"",
       "resource \"signalfx_list_chart\" \"top_tenants_sqs_backlog\"",
       "resource \"signalfx_list_chart\" \"top_tenants_sqs_dlq_backlog\"",
-      "resource \"signalfx_list_chart\" \"top_tenants_dynamodb_throttles\"",
-      "resource \"signalfx_list_chart\" \"top_tenants_dynamodb_system_errors\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_ec2_disk\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_ec2_status_failures\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_k8s_restarts\"",
       "resource \"signalfx_list_chart\" \"top_tenants_ebs_queue_length\"",
+      "resource \"signalfx_list_chart\" \"top_tenants_ebs_iops_exceeded\"",
       "resource \"terraform_data\" \"dashboard_parent\"",
       "resource \"signalfx_dashboard\" \"forge_impact\"",
+      "resource \"signalfx_dashboard\" \"runner_usage\"",
     ]
   }
 
@@ -41,7 +44,30 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_invento
   }
 
   assert {
-    condition     = output.expected_literal_count == 24
-    error_message = "Source inventory must keep 24 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 27
+    error_message = "Source inventory must keep 27 module-specific Terraform blocks pinned."
+  }
+}
+
+run "forge_impact_rejects_unattributed_dynamodb_tenant_rankings" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path       = "."
+    recursive         = true
+    expected_literals = []
+    forbidden_literals = [
+      "top_tenants_dynamodb_throttles",
+      "top_tenants_dynamodb_system_errors",
+    ]
+  }
+
+  assert {
+    condition     = length(output.present_forbidden_literals) == 0
+    error_message = "DynamoDB failure metrics must not be ranked by tenant until live metrics expose a confirmed tenant identity."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_inventory.tftest.hcl
@@ -33,6 +33,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_invento
       "resource \"signalfx_list_chart\" \"top_tenants_ebs_queue_length\"",
       "resource \"signalfx_list_chart\" \"top_tenants_ebs_iops_exceeded\"",
       "resource \"terraform_data\" \"dashboard_parent\"",
+      "resource \"terraform_data\" \"runner_usage_dashboard_parent\"",
+      "terraform_data.runner_usage_dashboard_parent,",
       "resource \"signalfx_dashboard\" \"forge_impact\"",
       "resource \"signalfx_dashboard\" \"runner_usage\"",
     ]
@@ -44,8 +46,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_invento
   }
 
   assert {
-    condition     = output.expected_literal_count == 27
-    error_message = "Source inventory must keep 27 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 29
+    error_message = "Source inventory must keep 29 module-specific Terraform and lifecycle literals pinned."
   }
 }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/variables.tf
@@ -21,3 +21,9 @@ variable "tenant_names" {
   description = "Tenant namespaces that run Forge ARC runners."
   type        = list(string)
 }
+
+variable "cluster_names" {
+  description = "Forge Kubernetes clusters included in global tenant impact and runner usage."
+  type        = list(string)
+  default     = []
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
@@ -151,7 +151,7 @@ EOF
 }
 
 resource "signalfx_dashboard" "k8s_control_plane" {
-  name            = "K8S Control Plane"
+  name            = "Forge Control Plane - Kubernetes"
   description     = "Forge Kubernetes platform pods, node pressure, and telemetry pipeline health."
   dashboard_group = var.dashboard_group
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
@@ -30,7 +30,7 @@ run "k8s_control_plane_dashboard_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.k8s_control_plane.name == "K8S Control Plane"
+      signalfx_dashboard.k8s_control_plane.name == "Forge Control Plane - Kubernetes"
       && signalfx_dashboard.k8s_control_plane.dashboard_group == "forge-dashboard-group"
       && length(signalfx_dashboard.k8s_control_plane.variable) == 1
       && signalfx_dashboard.k8s_control_plane.variable[0].property == "k8s.cluster.name"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
@@ -814,7 +814,7 @@ EOF
 }
 
 resource "signalfx_dashboard" "lambda" {
-  name            = "Lambdas"
+  name            = "Forge Tenant - Lambdas"
   description     = "Forge CICD Lambda invocation rate, errors, duration, and concurrency."
   dashboard_group = var.dashboard_group
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
@@ -83,7 +83,7 @@ run "lambda_dashboard_wiring_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.lambda.name == "Lambdas"
+      signalfx_dashboard.lambda.name == "Forge Tenant - Lambdas"
       && signalfx_dashboard.lambda.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.lambda.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.lambda.variable[0].value_required

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
@@ -227,8 +227,8 @@ EOF
 }
 
 resource "signalfx_dashboard" "opencost" {
-  name            = "OpenCost Tenant Cost"
-  description     = "OpenCost Kubernetes CPU and memory allocation cost by tenant namespace."
+  name            = "Forge Billing and Cost - OpenCost"
+  description     = "OpenCost Kubernetes CPU and memory allocation estimates by Forge tenant namespace; these are not AWS billing charges."
   dashboard_group = var.dashboard_group
 
   time_range = "-24h"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/tests/opencost_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/tests/opencost_dashboard_behavior.tftest.hcl
@@ -38,7 +38,7 @@ run "opencost_dashboard_wiring_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.opencost.name == "OpenCost Tenant Cost"
+      signalfx_dashboard.opencost.name == "Forge Billing and Cost - OpenCost"
       && signalfx_dashboard.opencost.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.opencost.variable[1].property == "k8s.cluster.name"
       && length(signalfx_dashboard.opencost.chart) == 6

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -1411,7 +1411,7 @@ resource "signalfx_single_value_chart" "chart_hosts_with_agent_installed" {
   name        = "# Hosts with agent installed"
   description = "Splunk OTel connector installed"
 
-  program_text = "A = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks'), rollup='average').sum(by=['AWSUniqueId']).count().publish(label='A')"
+  program_text = "A = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2'), rollup='average').sum(by=['AWSUniqueId']).count().publish(label='A')"
 
   color_by         = "Dimension"
   max_precision    = 4
@@ -1483,6 +1483,51 @@ resource "signalfx_single_value_chart" "chart_active_hosts" {
   viz_options {
     display_name = "# Hosts"
     label        = "A"
+  }
+}
+
+resource "signalfx_list_chart" "chart_active_hosts_missing_agent" {
+  name        = "Active hosts missing Splunk OTel agent"
+  description = "Active EC2 hosts without agent-correlated host.id metadata. Tenant | Instance ID | AMI | Host name"
+
+  program_text = "A = data('^aws.ec2.cpu.utilization', filter=not filter('host.id', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['AWSUniqueId', 'aws_tag_TenantName', 'aws_instance_id', 'aws_image_id', 'aws_tag_Name']).publish(label='A')"
+
+  sort_by = "-value"
+
+  color_by                = "Dimension"
+  max_precision           = 2
+  refresh_interval        = 60
+  secondary_visualization = "None"
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_instance_id"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_image_id"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_Name"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "AWSUniqueId"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "sf_metric"
+  }
+
+  viz_options {
+    display_name = "Missing agent"
+    label        = "A"
+    value_suffix = "%"
   }
 }
 
@@ -1638,127 +1683,134 @@ resource "signalfx_dashboard" "runner_ec2" {
     height   = 1
   }
   chart {
-    chart_id = signalfx_time_chart.chart_cpu_utilization.id
+    chart_id = signalfx_list_chart.chart_active_hosts_missing_agent.id
     row      = 1
+    column   = 0
+    width    = 12
+    height   = 2
+  }
+  chart {
+    chart_id = signalfx_time_chart.chart_cpu_utilization.id
+    row      = 3
     column   = 0
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_list_chart.chart_top_instances_by_cpu_utilization.id
-    row      = 1
+    row      = 3
     column   = 4
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_list_chart.chart_top_images_by_mean_cpu_utilization.id
-    row      = 1
+    row      = 3
     column   = 8
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_total_memory_overview_bytes.id
-    row      = 2
+    row      = 4
     column   = 4
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_list_chart.chart_top_memory_page_swaps_sec.id
-    row      = 2
+    row      = 4
     column   = 8
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_memory_utilization.id
-    row      = 2
+    row      = 4
     column   = 0
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_list_chart.chart_disk_metrics_24h_change.id
-    row      = 3
+    row      = 5
     column   = 9
     width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_disk_io_bytes.id
-    row      = 3
+    row      = 5
     column   = 6
     width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_disk_utilization.id
-    row      = 3
+    row      = 5
     column   = 0
     width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_disk_ops.id
-    row      = 3
+    row      = 5
     column   = 3
     width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_list_chart.chart_top_5_network_in_bytes.id
-    row      = 4
+    row      = 6
     column   = 6
     width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_network_in_bytes_vs_24h_change.id
-    row      = 4
+    row      = 6
     column   = 9
     width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_list_chart.chart_disk_summary_utilization.id
-    row      = 4
+    row      = 6
     column   = 0
     width    = 6
     height   = 2
   }
   chart {
     chart_id = signalfx_list_chart.chart_top_5_network_out_bytes.id
-    row      = 5
+    row      = 7
     column   = 6
     width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_network_out_bytes_vs_24h_change.id
-    row      = 5
+    row      = 7
     column   = 9
     width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_network_out_bytes.id
-    row      = 6
+    row      = 8
     column   = 8
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_network_in_bytes.id
-    row      = 6
+    row      = 8
     column   = 0
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_list_chart.chart_total_network_errors.id
-    row      = 6
+    row      = 8
     column   = 4
     width    = 4
     height   = 1
@@ -1766,7 +1818,7 @@ resource "signalfx_dashboard" "runner_ec2" {
 
   chart {
     chart_id = signalfx_time_chart.chart_status_check_failures.id
-    row      = 7
+    row      = 9
     column   = 0
     width    = 12
     height   = 1

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -1411,7 +1411,7 @@ resource "signalfx_single_value_chart" "chart_hosts_with_agent_installed" {
   name        = "# Hosts with agent installed"
   description = "Splunk OTel connector installed"
 
-  program_text = "A = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2'), rollup='average').sum(by=['AWSUniqueId']).count().publish(label='A')"
+  program_text = "A = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('aws_tag_TenantName', '*'), rollup='average').sum(by=['AWSUniqueId']).count().publish(label='A')"
 
   color_by         = "Dimension"
   max_precision    = 4
@@ -1474,7 +1474,7 @@ resource "signalfx_list_chart" "chart_top_5_network_out_bytes" {
 resource "signalfx_single_value_chart" "chart_active_hosts" {
   name = "# Active hosts"
 
-  program_text = "A = data('^aws.ec2.cpu.utilization', extrapolation='last_value', maxExtrapolations=2).sum(by=['AWSUniqueId']).count().publish(label='A')"
+  program_text = "A = data('^aws.ec2.cpu.utilization', filter=filter('aws_tag_TenantName', '*'), extrapolation='last_value', maxExtrapolations=2).sum(by=['AWSUniqueId']).count().publish(label='A')"
 
   color_by         = "Dimension"
   max_precision    = 4
@@ -1490,7 +1490,7 @@ resource "signalfx_list_chart" "chart_active_hosts_missing_agent" {
   name        = "Active hosts missing Splunk OTel agent"
   description = "Active EC2 hosts without agent-correlated host.id metadata. Tenant | Instance ID | AMI | Host name"
 
-  program_text = "A = data('^aws.ec2.cpu.utilization', filter=not filter('host.id', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['AWSUniqueId', 'aws_tag_TenantName', 'aws_instance_id', 'aws_image_id', 'aws_tag_Name']).publish(label='A')"
+  program_text = "A = data('^aws.ec2.cpu.utilization', filter=filter('aws_tag_TenantName', '*') and not filter('host.id', '*'), extrapolation='last_value', maxExtrapolations=2).mean(by=['AWSUniqueId', 'aws_tag_TenantName', 'aws_instance_id', 'aws_image_id', 'aws_tag_Name']).publish(label='A')"
 
   sort_by = "-value"
 
@@ -1624,8 +1624,8 @@ resource "signalfx_dashboard" "runner_ec2" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = sort(var.tenant_names)
-    value_required         = length(var.tenant_names) > 0
+    values                 = []
+    value_required         = false
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -1571,7 +1571,7 @@ EOF
 }
 
 resource "signalfx_dashboard" "runner_ec2" {
-  name            = "EC2 Runners"
+  name            = "Forge Tenant - EC2 Runners"
   description     = "EC2-based GitHub Actions runners: CPU, memory, disk, and network."
   dashboard_group = var.dashboard_group
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory.tftest.hcl
@@ -29,6 +29,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory
       "resource \"signalfx_single_value_chart\" \"chart_hosts_with_agent_installed\"",
       "resource \"signalfx_list_chart\" \"chart_top_5_network_out_bytes\"",
       "resource \"signalfx_single_value_chart\" \"chart_active_hosts\"",
+      "resource \"signalfx_list_chart\" \"chart_active_hosts_missing_agent\"",
       "resource \"signalfx_list_chart\" \"chart_top_5_network_in_bytes\"",
       "resource \"signalfx_time_chart\" \"chart_status_check_failures\"",
       "resource \"signalfx_dashboard\" \"runner_ec2\"",
@@ -41,7 +42,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory
   }
 
   assert {
-    condition     = output.expected_literal_count == 24
-    error_message = "Source inventory must keep 24 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 25
+    error_message = "Source inventory must keep 25 module-specific Terraform blocks pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -23,10 +23,12 @@ run "runner_ec2_dashboard_contract" {
     condition = (
       signalfx_single_value_chart.chart_active_hosts.name == "# Active hosts"
       && strcontains(signalfx_single_value_chart.chart_active_hosts.program_text, "^aws.ec2.cpu.utilization")
+      && strcontains(signalfx_single_value_chart.chart_active_hosts.program_text, "filter('aws_tag_TenantName', '*')")
       && strcontains(signalfx_single_value_chart.chart_hosts_with_agent_installed.program_text, "filter('cloud.platform', 'aws_ec2')")
+      && strcontains(signalfx_single_value_chart.chart_hosts_with_agent_installed.program_text, "filter('aws_tag_TenantName', '*')")
       && !strcontains(signalfx_single_value_chart.chart_hosts_with_agent_installed.program_text, "aws_eks")
       && signalfx_list_chart.chart_active_hosts_missing_agent.name == "Active hosts missing Splunk OTel agent"
-      && strcontains(signalfx_list_chart.chart_active_hosts_missing_agent.program_text, "filter=not filter('host.id', '*')")
+      && strcontains(signalfx_list_chart.chart_active_hosts_missing_agent.program_text, "filter=filter('aws_tag_TenantName', '*') and not filter('host.id', '*')")
       && strcontains(signalfx_list_chart.chart_active_hosts_missing_agent.program_text, "'aws_tag_TenantName', 'aws_instance_id', 'aws_image_id', 'aws_tag_Name'")
       && alltrue([
         for property in ["aws_tag_TenantName", "aws_instance_id", "aws_image_id", "aws_tag_Name"] :
@@ -57,8 +59,10 @@ run "runner_ec2_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.runner_ec2.name == "Forge Tenant - EC2 Runners"
       && signalfx_dashboard.runner_ec2.dashboard_group == "forge-dashboard-group"
-      && signalfx_dashboard.runner_ec2.variable[0].values == toset(["tenant-a", "tenant-b"])
-      && signalfx_dashboard.runner_ec2.variable[0].value_required
+      && length(signalfx_dashboard.runner_ec2.variable[0].values) == 0
+      && !signalfx_dashboard.runner_ec2.variable[0].value_required
+      && signalfx_dashboard.runner_ec2.variable[0].values_suggested == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.runner_ec2.variable[0].restricted_suggestions
       && length(signalfx_dashboard.runner_ec2.chart) == 24
     )
     error_message = "EC2 runner dashboard must keep its name, group input, and chart count."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -46,7 +46,7 @@ run "runner_ec2_dashboard_wiring_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.runner_ec2.name == "EC2 Runners"
+      signalfx_dashboard.runner_ec2.name == "Forge Tenant - EC2 Runners"
       && signalfx_dashboard.runner_ec2.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.runner_ec2.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.runner_ec2.variable[0].value_required

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -23,6 +23,15 @@ run "runner_ec2_dashboard_contract" {
     condition = (
       signalfx_single_value_chart.chart_active_hosts.name == "# Active hosts"
       && strcontains(signalfx_single_value_chart.chart_active_hosts.program_text, "^aws.ec2.cpu.utilization")
+      && strcontains(signalfx_single_value_chart.chart_hosts_with_agent_installed.program_text, "filter('cloud.platform', 'aws_ec2')")
+      && !strcontains(signalfx_single_value_chart.chart_hosts_with_agent_installed.program_text, "aws_eks")
+      && signalfx_list_chart.chart_active_hosts_missing_agent.name == "Active hosts missing Splunk OTel agent"
+      && strcontains(signalfx_list_chart.chart_active_hosts_missing_agent.program_text, "filter=not filter('host.id', '*')")
+      && strcontains(signalfx_list_chart.chart_active_hosts_missing_agent.program_text, "'aws_tag_TenantName', 'aws_instance_id', 'aws_image_id', 'aws_tag_Name'")
+      && alltrue([
+        for property in ["aws_tag_TenantName", "aws_instance_id", "aws_image_id", "aws_tag_Name"] :
+        contains([for field in signalfx_list_chart.chart_active_hosts_missing_agent.legend_options_fields : field.property if field.enabled], property)
+      ])
       && signalfx_time_chart.chart_cpu_utilization.name == "CPU utilization (%)"
       && signalfx_time_chart.chart_cpu_utilization.time_range == 3600
       && signalfx_list_chart.chart_top_instances_by_cpu_utilization.sort_by == "-value"
@@ -50,7 +59,7 @@ run "runner_ec2_dashboard_wiring_contract" {
       && signalfx_dashboard.runner_ec2.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.runner_ec2.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.runner_ec2.variable[0].value_required
-      && length(signalfx_dashboard.runner_ec2.chart) == 23
+      && length(signalfx_dashboard.runner_ec2.chart) == 24
     )
     error_message = "EC2 runner dashboard must keep its name, group input, and chart count."
   }
@@ -58,6 +67,7 @@ run "runner_ec2_dashboard_wiring_contract" {
   assert {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.runner_ec2.chart : chart.chart_id], signalfx_single_value_chart.chart_active_hosts.id),
+      contains([for chart in signalfx_dashboard.runner_ec2.chart : chart.chart_id], signalfx_list_chart.chart_active_hosts_missing_agent.id),
       contains([for chart in signalfx_dashboard.runner_ec2.chart : chart.chart_id], signalfx_time_chart.chart_status_check_failures.id),
     ])
     error_message = "EC2 runner dashboard must keep its first and final chart wiring."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
@@ -4,7 +4,7 @@ This module creates Kubernetes pod and deployment charts for the ARC runner lane
 
 ## Why This Module Exists
 
-Kubernetes runner failures often show up as pending pods, restarts, or resource pressure. This dashboard provides the tenant pod-level view that complements the separate K8S Control Plane dashboard and EKS/Karpenter logs.
+Kubernetes runner failures often show up as pending pods, restarts, or resource pressure. This dashboard provides the tenant pod-level view that complements the separate `Forge Control Plane - Kubernetes` dashboard and EKS/Karpenter logs.
 
 ## What It Manages
 
@@ -19,7 +19,7 @@ Kubernetes runner failures often show up as pending pods, restarts, or resource 
 - Use this when ARC scale sets see demand but jobs do not start.
 - Pending pods usually require checking Karpenter, taints/tolerations, resource requests, and storage.
 - Every chart is explicitly restricted to configured Forge tenant namespaces and clusters.
-- Use the K8S Control Plane dashboard for Karpenter, networking, node, Prometheus, and collector health.
+- Use `Forge Control Plane - Kubernetes` for Karpenter, networking, node, Prometheus, and collector health.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
@@ -554,7 +554,7 @@ EOF
 }
 
 resource "signalfx_dashboard" "runner_k8s" {
-  name            = "K8S Runners"
+  name            = "Forge Tenant - K8S Runners"
   description     = "Kubernetes-based runners: pod states, CPU, memory, and network health."
   dashboard_group = var.dashboard_group
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
@@ -57,7 +57,7 @@ run "runner_k8s_dashboard_wiring_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.runner_k8s.name == "K8S Runners"
+      signalfx_dashboard.runner_k8s.name == "Forge Tenant - K8S Runners"
       && signalfx_dashboard.runner_k8s.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.runner_k8s.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.runner_k8s.variable[0].value_required

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/main.tf
@@ -490,7 +490,7 @@ resource "signalfx_list_chart" "dead_letter_visible_messages" {
 }
 
 resource "signalfx_dashboard" "sqs" {
-  name        = "SQS"
+  name        = "Forge Tenant - SQS"
   description = "SQS queue counts, message states, sizes, and processing trends."
 
   dashboard_group = var.dashboard_group

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/sqs_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/sqs_dashboard_behavior.tftest.hcl
@@ -44,7 +44,7 @@ run "sqs_dashboard_wiring_contract" {
 
   assert {
     condition = (
-      signalfx_dashboard.sqs.name == "SQS"
+      signalfx_dashboard.sqs.name == "Forge Tenant - SQS"
       && signalfx_dashboard.sqs.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.sqs.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.sqs.variable[0].value_required


### PR DESCRIPTION
## Description

Redesigns the Forge Splunk Observability dashboard hierarchy around operator investigation paths:

- separates AWS billing, OpenCost, tenant impact, tenant detail, runner usage, and Kubernetes control-plane scopes
- renames dashboards consistently for operator navigation
- keeps the tenant-impact landing page focused on ranked incident signals and moves adoption/runtime charts to `Forge Runner Usage`
- scopes AWS signals to configured Forge tenant and required AWS dimensions, and Kubernetes signals to configured tenants and clusters
- adds tenant rankings for EC2 disk utilization, EC2 status failures, Kubernetes restarts, and EBS exceeded-IOPS events
- removes unsupported DynamoDB tenant rankings because the live failure metrics do not expose a confirmed tenant identity
- adds behavioral coverage and a source guard preventing those unattributed DynamoDB rankings from returning

Live SignalFlow checks against production-scoped metrics returned tenant series for Lambda errors, SQS backlog, EBS queue length, EC2 disk utilization, EBS exceeded-IOPS events, and Kubernetes pending pods. EC2 status failures and Kubernetes restart deltas executed successfully with no matching events in the checked one-hour window.

## Type of Change

- [x] Feature
- [x] Bug Fix
- [x] Documentation
- [x] Refactor
- [ ] Other: __________

## Testing

- all dashboard OpenTofu test suites
- shared `splunk_o11y_conf_shared` OpenTofu test suite
- staged-file pre-commit hooks, including OpenTofu validation, TFLint, security, and formatting
- live production-scoped SignalFlow execution for changed tenant-impact queries
