### PR TITLE
fix(observability): harden Forge dashboard telemetry

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
@@ -351,7 +351,7 @@ resource "signalfx_time_chart" "throttled_requests_ts" {
   name         = "Throttled requests"
   description  = "Requests to DynamoDB that exceed the provisioned throughput limits on a resource (such as a table or an index)."
   program_text = <<-EOF
-A = data('ThrottledRequests', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'TableName']).publish(label='A')
+A = data('ThrottledRequests', filter=filter('namespace', 'AWS/DynamoDB') and filter('stat', 'sum') and filter('TableName', '*') and filter('Operation', '*'), rollup='sum').sum(by=['aws_tag_TenantName', 'TableName', 'Operation']).publish(label='A')
 EOF
 
   plot_type   = "AreaChart"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
@@ -504,8 +504,8 @@ resource "signalfx_dashboard" "dynamodb" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = sort(var.tenant_names)
-    value_required         = length(var.tenant_names) > 0
+    values                 = []
+    value_required         = false
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/dynamodb_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/dynamodb_dashboard_behavior.tftest.hcl
@@ -43,8 +43,10 @@ run "dynamodb_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.dynamodb.name == "Forge Tenant - DynamoDB"
       && signalfx_dashboard.dynamodb.dashboard_group == "forge-dashboard-group"
-      && signalfx_dashboard.dynamodb.variable[0].values == toset(["tenant-a", "tenant-b"])
-      && signalfx_dashboard.dynamodb.variable[0].value_required
+      && length(signalfx_dashboard.dynamodb.variable[0].values) == 0
+      && !signalfx_dashboard.dynamodb.variable[0].value_required
+      && signalfx_dashboard.dynamodb.variable[0].values_suggested == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.dynamodb.variable[0].restricted_suggestions
       && length(signalfx_dashboard.dynamodb.chart) == 13
     )
     error_message = "DynamoDB dashboard must keep its name, group input, and chart count."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/dynamodb_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/dynamodb_dashboard_behavior.tftest.hcl
@@ -28,7 +28,8 @@ run "dynamodb_dashboard_contract" {
       && strcontains(signalfx_time_chart.read_capacity_percentage.program_text, "ConsumedReadCapacityUnits")
       && signalfx_single_value_chart.throttled_requests_single.name == "Throttled requests"
       && strcontains(signalfx_time_chart.throttled_requests_ts.program_text, "ThrottledRequests")
-      && strcontains(signalfx_time_chart.throttled_requests_ts.program_text, ".sum(by=['aws_tag_TenantName', 'TableName'])")
+      && strcontains(signalfx_time_chart.throttled_requests_ts.program_text, "filter('Operation', '*')")
+      && strcontains(signalfx_time_chart.throttled_requests_ts.program_text, ".sum(by=['aws_tag_TenantName', 'TableName', 'Operation'])")
       && strcontains(signalfx_time_chart.system_errors_ts.program_text, ".sum(by=['aws_tag_TenantName', 'TableName', 'Operation'])")
     )
     error_message = "DynamoDB charts must keep one-hour capacity, error, and throttling visibility."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
@@ -581,8 +581,8 @@ resource "signalfx_dashboard" "ebs" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = sort(var.tenant_names)
-    value_required         = length(var.tenant_names) > 0
+    values                 = []
+    value_required         = false
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/ebs_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/ebs_dashboard_behavior.tftest.hcl
@@ -44,8 +44,10 @@ run "ebs_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.ebs.name == "Forge Tenant - EBS"
       && signalfx_dashboard.ebs.dashboard_group == "forge-dashboard-group"
-      && signalfx_dashboard.ebs.variable[0].values == toset(["tenant-a", "tenant-b"])
-      && signalfx_dashboard.ebs.variable[0].value_required
+      && length(signalfx_dashboard.ebs.variable[0].values) == 0
+      && !signalfx_dashboard.ebs.variable[0].value_required
+      && signalfx_dashboard.ebs.variable[0].values_suggested == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.ebs.variable[0].restricted_suggestions
       && length(signalfx_dashboard.ebs.chart) == 16
     )
     error_message = "EBS dashboard must keep its name, group input, and chart count."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
@@ -81,7 +81,7 @@ resource "signalfx_time_chart" "node_pressure" {
   description = "Shows active PID, memory, disk, or network pressure conditions by Kubernetes node."
 
   program_text = <<-EOF
-A = data('k8s.node.condition', filter=(${local.k8s_cluster_filter}) and (filter('condition', 'PIDPressure') or filter('condition', 'MemoryPressure') or filter('condition', 'DiskPressure') or filter('condition', 'NetworkUnavailable')), rollup='latest').max(by=['k8s.cluster.name', 'k8s.node.name', 'condition']).publish(label='A')
+A = data('k8s.node.condition', filter=(${local.k8s_cluster_filter}) and (filter('condition', 'PIDPressure') or filter('condition', 'MemoryPressure') or filter('condition', 'DiskPressure') or filter('condition', 'NetworkUnavailable')), rollup='max').max(by=['k8s.cluster.name', 'k8s.node.name', 'condition']).above(0).publish(label='A')
 EOF
 
   plot_type                 = "LineChart"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
@@ -47,6 +47,8 @@ run "k8s_control_plane_dashboard_contract" {
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'prometheus')")
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'splunk-otel-collector')")
       && strcontains(signalfx_time_chart.node_pressure.program_text, "k8s.node.condition")
+      && strcontains(signalfx_time_chart.node_pressure.program_text, "rollup='max'")
+      && strcontains(signalfx_time_chart.node_pressure.program_text, ".max(by=['k8s.cluster.name', 'k8s.node.name', 'condition']).above(0)")
       && one(signalfx_time_chart.node_pressure.viz_options).display_name == "Node pressure"
       && strcontains(signalfx_time_chart.otel_exporter_queue_utilization.program_text, "otelcol_exporter_queue_capacity")
       && one(signalfx_time_chart.otel_exporter_queue_utilization.viz_options).display_name == "OTel exporter queue utilization"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
@@ -594,8 +594,8 @@ resource "signalfx_dashboard" "lambda" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = sort(var.tenant_names)
-    value_required         = length(var.tenant_names) > 0
+    values                 = []
+    value_required         = false
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
@@ -1,171 +1,3 @@
-resource "signalfx_time_chart" "provisioned_concurrent_executions_by_version" {
-  name         = "Provisioned concurrent executions by version"
-  description  = "The number of events that are being processed on provisioned concurrency. For each invocation of an alias or version with provisioned concurrency, Lambda emits the current count."
-  program_text = <<-EOF
-A = data('ProvisionedConcurrentExecutions', filter=filter('stat', 'upper') and filter('Resource', '*') and filter('ExecutedVersion', '*')).sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
-EOF
-
-  plot_type   = "AreaChart"
-  unit_prefix = "Metric"
-  color_by    = "Dimension"
-  timezone    = "UTC"
-  stacked     = true
-
-  axes_precision            = 0
-  on_chart_legend_dimension = "ExecutedVersion"
-
-  time_range = 3600
-
-  viz_options {
-    axis         = "left"
-    display_name = "Provisioned concurrent executions"
-    label        = "A"
-  }
-
-}
-
-resource "signalfx_time_chart" "provisioned_concurrency_invocations_by_version" {
-  name         = "Provisioned concurrency invocations by version"
-  description  = "The number of invocations that are run on provisioned concurrency. Lambda increments the count once for each invocation that runs on provisioned concurrency."
-  program_text = <<-EOF
-A = data('ProvisionedConcurrencyInvocations', filter=filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='rate').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
-EOF
-
-  plot_type   = "AreaChart"
-  unit_prefix = "Metric"
-  color_by    = "Dimension"
-  timezone    = "UTC"
-  stacked     = true
-
-  axes_precision            = 0
-  on_chart_legend_dimension = "ExecutedVersion"
-  time_range                = 3600
-
-  legend_options_fields {
-    enabled  = false
-    property = "AWSUniqueId"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "ExecutedVersion"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "FunctionName"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "aws_tag_TenantName"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "aws_tag_TenantName"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "sf_originatingMetric"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "namespace"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "sf_metric"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "Resource"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "stat"
-  }
-
-  viz_options {
-    axis         = "left"
-    display_name = "Provisioned concurrent invocations"
-    label        = "A"
-  }
-}
-
-resource "signalfx_time_chart" "provisioned_concurrency_spillover_invocations_by_version" {
-  name         = "Provisioned concurrency spillover invocations by version"
-  description  = "The number of invocations that are run on nonprovisioned concurrency, when all provisioned concurrency is in use. For a version or alias that is configured to use provisioned concurrency, Lambda increments the count once for each invocation that runs on non-provisioned concurrency."
-  program_text = <<-EOF
-A = data('ProvisionedConcurrencySpilloverInvocations', filter=filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='rate').sum(by=['aws_tag_TenantName', 'Resource', 'ExecutedVersion']).publish(label='A')
-EOF
-
-  plot_type   = "AreaChart"
-  unit_prefix = "Metric"
-  color_by    = "Dimension"
-  timezone    = "UTC"
-  stacked     = true
-
-  axes_precision            = 0
-  on_chart_legend_dimension = "ExecutedVersion"
-  time_range                = 3600
-
-  legend_options_fields {
-    enabled  = false
-    property = "AWSUniqueId"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "ExecutedVersion"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "FunctionName"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "aws_tag_TenantName"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "sf_originatingMetric"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "namespace"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "sf_metric"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "Resource"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "stat"
-  }
-
-  viz_options {
-    axis         = "left"
-    display_name = "Provisioned concurrent invocations"
-    label        = "A"
-  }
-}
-
-resource "signalfx_single_value_chart" "total_spillover_invocations" {
-  name        = "Total spillover invocations"
-  description = "Over 30m | Spillover invocations are run on nonprovisioned concurrency, when all provisioned concurrency is in use."
-  unit_prefix = "Metric"
-  color_by    = "Dimension"
-
-  program_text = <<-EOF
-A = data('ProvisionedConcurrencySpilloverInvocations', filter=filter('stat', 'sum') and filter('Resource', '*') and filter('ExecutedVersion', '*'), rollup='rate').sum(over='30m').sum().publish(label='A')
-EOF
-
-  viz_options {
-    display_name = "Provisioned concurrent invocations"
-    label        = "A"
-  }
-}
-
 resource "signalfx_list_chart" "percent_invocations_by_version" {
   name                    = "% invocations by version"
   description             = "The % of total invocations handled by version"
@@ -560,7 +392,7 @@ EOF
     property = "AWSUniqueId"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "FunctionName"
   }
   legend_options_fields {
@@ -588,7 +420,7 @@ EOF
     property = "aws_function_version"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "ExecutedVersion"
   }
 
@@ -613,66 +445,6 @@ EOF
     color        = "brown"
     display_name = "Errors"
     label        = "A"
-  }
-}
-
-resource "signalfx_time_chart" "provisioned_concurrency_utilization" {
-  name         = "Provisioned concurrency utilization"
-  description  = "The number of events that are being processed on provisioned concurrency, divided by the total amount of provisioned concurrency allocated. For example, .5 indicates that 50 percent of allocated provisioned concurrency is in use. For each invocation of an alias or version with provisioned concurrency, Lambda emits the current count."
-  program_text = <<-EOF
-A = data('ProvisionedConcurrencyUtilization', filter=filter('stat', 'upper') and filter('Resource', '*') and filter('ExecutedVersion', '*')).scale(100).publish(label='A')
-EOF
-
-  plot_type   = "LineChart"
-  unit_prefix = "Metric"
-  color_by    = "Dimension"
-  timezone    = "UTC"
-  stacked     = false
-
-  axes_include_zero         = true
-  axes_precision            = 0
-  on_chart_legend_dimension = "ExecutedVersion"
-
-  time_range = 3600
-
-  legend_options_fields {
-    enabled  = false
-    property = "AWSUniqueId"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "FunctionName"
-  }
-  legend_options_fields {
-    enabled  = true
-    property = "ExecutedVersion"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "sf_originatingMetric"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "namespace"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "sf_metric"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "Resource"
-  }
-  legend_options_fields {
-    enabled  = false
-    property = "stat"
-  }
-
-  viz_options {
-    axis         = "left"
-    display_name = "Provisioned concurrency utilization"
-    label        = "A"
-    value_suffix = "%"
   }
 }
 
@@ -815,7 +587,7 @@ EOF
 
 resource "signalfx_dashboard" "lambda" {
   name            = "Forge Tenant - Lambdas"
-  description     = "Forge CICD Lambda invocation rate, errors, duration, and concurrency."
+  description     = "Forge CICD Lambda invocation rate, errors, throttles, duration, tenant impact, and function-version detail."
   dashboard_group = var.dashboard_group
 
   variable {
@@ -881,7 +653,7 @@ resource "signalfx_dashboard" "lambda" {
     chart_id = signalfx_time_chart.invocations.id
     column   = 0
     row      = 3
-    width    = 3
+    width    = 6
     height   = 1
   }
 
@@ -902,50 +674,26 @@ resource "signalfx_dashboard" "lambda" {
   }
 
   chart {
-    chart_id = signalfx_single_value_chart.total_spillover_invocations.id
+    chart_id = signalfx_single_value_chart.total_errors.id
     column   = 6
     row      = 0
-    width    = 2
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_single_value_chart.total_errors.id
-    column   = 8
-    row      = 0
-    width    = 2
+    width    = 3
     height   = 1
   }
 
   chart {
     chart_id = signalfx_single_value_chart.total_throttles.id
-    column   = 10
+    column   = 9
     row      = 0
-    width    = 2
+    width    = 3
     height   = 1
   }
 
   chart {
     chart_id = signalfx_time_chart.invocations_by_version.id
-    column   = 3
-    row      = 3
-    width    = 3
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_time_chart.provisioned_concurrency_invocations_by_version.id
     column   = 6
     row      = 3
-    width    = 3
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_time_chart.provisioned_concurrent_executions_by_version.id
-    column   = 9
-    row      = 3
-    width    = 3
+    width    = 6
     height   = 1
   }
 
@@ -977,23 +725,7 @@ resource "signalfx_dashboard" "lambda" {
     chart_id = signalfx_list_chart.percent_invocations_by_version.id
     column   = 0
     row      = 5
-    width    = 4
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_time_chart.provisioned_concurrency_spillover_invocations_by_version.id
-    column   = 4
-    row      = 5
-    width    = 4
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_time_chart.provisioned_concurrency_utilization.id
-    column   = 8
-    row      = 5
-    width    = 4
+    width    = 12
     height   = 1
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory.tftest.hcl
@@ -8,10 +8,6 @@ run "integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory" {
   variables {
     module_path = "."
     expected_literals = [
-      "resource \"signalfx_time_chart\" \"provisioned_concurrent_executions_by_version\"",
-      "resource \"signalfx_time_chart\" \"provisioned_concurrency_invocations_by_version\"",
-      "resource \"signalfx_time_chart\" \"provisioned_concurrency_spillover_invocations_by_version\"",
-      "resource \"signalfx_single_value_chart\" \"total_spillover_invocations\"",
       "resource \"signalfx_list_chart\" \"percent_invocations_by_version\"",
       "resource \"signalfx_time_chart\" \"errors_by_version\"",
       "resource \"signalfx_single_value_chart\" \"total_throttles\"",
@@ -21,7 +17,6 @@ run "integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory" {
       "resource \"signalfx_time_chart\" \"invocations_by_version\"",
       "resource \"signalfx_time_chart\" \"invocations\"",
       "resource \"signalfx_single_value_chart\" \"total_errors\"",
-      "resource \"signalfx_time_chart\" \"provisioned_concurrency_utilization\"",
       "resource \"signalfx_single_value_chart\" \"total_invocations\"",
       "resource \"signalfx_list_chart\" \"top_tenants_by_errors\"",
       "resource \"signalfx_list_chart\" \"top_tenants_by_throttles\"",
@@ -37,7 +32,32 @@ run "integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 20
-    error_message = "Source inventory must keep 20 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 15
+    error_message = "Source inventory must keep 15 live-backed module-specific Terraform blocks pinned."
+  }
+}
+
+run "lambda_rejects_unavailable_provisioned_concurrency_metrics" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path       = "."
+    recursive         = true
+    expected_literals = []
+    forbidden_literals = [
+      "ProvisionedConcurrentExecutions",
+      "ProvisionedConcurrencyInvocations",
+      "ProvisionedConcurrencySpilloverInvocations",
+      "ProvisionedConcurrencyUtilization",
+    ]
+  }
+
+  assert {
+    condition     = length(output.present_forbidden_literals) == 0
+    error_message = "Unavailable provisioned-concurrency metrics must not create permanently empty Lambda charts."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
@@ -89,8 +89,10 @@ run "lambda_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.lambda.name == "Forge Tenant - Lambdas"
       && signalfx_dashboard.lambda.dashboard_group == "forge-dashboard-group"
-      && signalfx_dashboard.lambda.variable[0].values == toset(["tenant-a", "tenant-b"])
-      && signalfx_dashboard.lambda.variable[0].value_required
+      && length(signalfx_dashboard.lambda.variable[0].values) == 0
+      && !signalfx_dashboard.lambda.variable[0].value_required
+      && signalfx_dashboard.lambda.variable[0].values_suggested == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.lambda.variable[0].restricted_suggestions
       && length(signalfx_dashboard.lambda.chart) == 14
     )
     error_message = "Lambda dashboard must keep its name, group input, and chart count."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/lambda_dashboard_behavior.tftest.hcl
@@ -24,6 +24,10 @@ run "lambda_dashboard_contract" {
       signalfx_time_chart.invocations.name == "Invocations"
       && signalfx_time_chart.invocations.time_range == 3600
       && strcontains(signalfx_time_chart.invocations.program_text, "Invocations")
+      && alltrue([
+        for field in signalfx_time_chart.invocations.legend_options_fields :
+        !field.enabled
+      ])
       && signalfx_single_value_chart.total_errors.name == "Total errors"
       && strcontains(signalfx_single_value_chart.total_errors.program_text, ".sum(over='30m')")
       && strcontains(signalfx_single_value_chart.total_throttles.program_text, ".sum(over='30m')")
@@ -87,7 +91,7 @@ run "lambda_dashboard_wiring_contract" {
       && signalfx_dashboard.lambda.dashboard_group == "forge-dashboard-group"
       && signalfx_dashboard.lambda.variable[0].values == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.lambda.variable[0].value_required
-      && length(signalfx_dashboard.lambda.chart) == 19
+      && length(signalfx_dashboard.lambda.chart) == 14
     )
     error_message = "Lambda dashboard must keep its name, group input, and chart count."
   }
@@ -95,12 +99,13 @@ run "lambda_dashboard_wiring_contract" {
   assert {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_time_chart.invocations.id),
-      contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_time_chart.provisioned_concurrency_utilization.id),
+      contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_time_chart.invocations_by_version.id),
+      contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_list_chart.percent_invocations_by_version.id),
       contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_list_chart.top_tenants_by_errors.id),
       contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_list_chart.top_tenants_by_throttles.id),
       contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_list_chart.top_lambdas_by_errors.id),
       contains([for chart in signalfx_dashboard.lambda.chart : chart.chart_id], signalfx_list_chart.top_lambdas_by_throttles.id),
     ])
-    error_message = "Lambda dashboard must wire summary, tenant ranking, per-function detail, and provisioned-concurrency charts."
+    error_message = "Lambda dashboard must wire summary, tenant ranking, per-function detail, and invocation-share charts."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -1679,8 +1679,8 @@ resource "signalfx_dashboard" "runner_ec2" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = sort(var.tenant_names)
-    value_required         = length(var.tenant_names) > 0
+    values                 = []
+    value_required         = false
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -47,12 +47,12 @@ resource "signalfx_time_chart" "chart_total_memory_overview_bytes" {
   description = "From hosts with agent installed"
 
   program_text = <<-EOF
-C = data('system.memory.usage', filter=filter('state', 'free') and filter('cloud.platform', 'aws_ec2', 'aws_eks')).sum().publish(label='C')
-F = data('system.memory.usage', filter=filter('state', 'used') and filter('cloud.platform', 'aws_ec2', 'aws_eks')).sum().publish(label='F')
-A = data('system.memory.usage', filter=filter('state', 'buffered') and filter('cloud.platform', 'aws_ec2', 'aws_eks')).sum().publish(label='A')
-B = data('system.memory.usage', filter=filter('state', 'cached') and filter('cloud.platform', 'aws_ec2', 'aws_eks')).sum().publish(label='B')
-D = data('system.memory.usage', filter=filter('state', 'slab_reclaimable') and filter('cloud.platform', 'aws_ec2', 'aws_eks')).sum().publish(label='D')
-E = data('system.memory.usage', filter=filter('state', 'slab_unreclaimable') and filter('cloud.platform', 'aws_ec2', 'aws_eks')).sum().publish(label='E')
+C = data('system.memory.usage', filter=filter('state', 'free') and filter('cloud.platform', 'aws_ec2')).sum().publish(label='C')
+F = data('system.memory.usage', filter=filter('state', 'used') and filter('cloud.platform', 'aws_ec2')).sum().publish(label='F')
+A = data('system.memory.usage', filter=filter('state', 'buffered') and filter('cloud.platform', 'aws_ec2')).sum().publish(label='A')
+B = data('system.memory.usage', filter=filter('state', 'cached') and filter('cloud.platform', 'aws_ec2')).sum().publish(label='B')
+D = data('system.memory.usage', filter=filter('state', 'slab_reclaimable') and filter('cloud.platform', 'aws_ec2')).sum().publish(label='D')
+E = data('system.memory.usage', filter=filter('state', 'slab_unreclaimable') and filter('cloud.platform', 'aws_ec2')).sum().publish(label='E')
 EOF
 
   plot_type = "AreaChart"
@@ -298,8 +298,8 @@ resource "signalfx_time_chart" "chart_disk_utilization" {
   description = "Percentile distribution across active hosts with agent installed"
 
   program_text = <<-EOF
-B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'used')).publish(label='B', enable=False)
-C = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'free')).publish(label='C', enable=False)
+B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used')).publish(label='B', enable=False)
+C = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'free')).publish(label='C', enable=False)
 D = ((B/(B+C))*100).mean(by=['AWSUniqueId']).publish(label='D', enable=False)
 E = (D).min().publish(label='E')
 F = (D).percentile(pct=10).publish(label='F')
@@ -326,111 +326,111 @@ EOF
   }
 
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "sf_originatingMetric"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "aws_instance_id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "k8s.cluster.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.image.id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "os.type"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "type"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "AWSUniqueId"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.type"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.availability_zone"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "mountpoint"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "mode"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.platform"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.provider"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "k8s.node.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.account.id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "device"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "deployment.environment"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "state"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure.resourcegroup.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure.vm.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure.vm.size"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure_resource_id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure.vm.scaleset.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "gcp_id"
   }
 
@@ -594,7 +594,7 @@ resource "signalfx_list_chart" "chart_top_images_by_mean_cpu_utilization" {
 
   program_text = <<-EOF
 A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=5).mean(by=['aws_image_id', 'aws_tag_TenantName']).top(count=5).publish(label='A',enable=False)
-B = data('cpu.utilization', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks'), extrapolation='last_value', maxExtrapolations=5).dimensions(renames={'aws_image_id':'host.image.id'}).mean(by=['aws_image_id', 'aws_tag_TenantName']).top(count=5).publish(label='B',enable=False)
+B = data('cpu.utilization', filter=filter('cloud.platform', 'aws_ec2'), extrapolation='last_value', maxExtrapolations=5).dimensions(renames={'aws_image_id':'host.image.id'}).mean(by=['aws_image_id', 'aws_tag_TenantName']).top(count=5).publish(label='B',enable=False)
 C = union(A,B).top(count=5).publish("C")
 EOF
 
@@ -726,8 +726,8 @@ resource "signalfx_time_chart" "chart_memory_utilization" {
   description = "Percentile distribution across active hosts with agent installed"
 
   program_text = <<-EOF
-H = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'used')).sum(by=['host.name']).publish(label='H', enable=False)
-I = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'used', 'free', 'cached', 'buffered')).sum(by=['host.name']).publish(label='I', enable=False)
+H = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used')).sum(by=['host.name']).publish(label='H', enable=False)
+I = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used', 'free', 'cached', 'buffered')).sum(by=['host.name']).publish(label='I', enable=False)
 J = ((H/I)*100).publish(label='J', enable=False)
 C = (J).min().publish(label='C')
 D = (J).percentile(pct=10).publish(label='D')
@@ -759,107 +759,107 @@ EOF
   }
 
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "sf_originatingMetric"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "sf_metric"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.image.id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "os.type"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "AWSUniqueId"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.type"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.availability_zone"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.provider"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.account.id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "state"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.platform"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "k8s.cluster.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "deployment.environment"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "k8s.node.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure.resourcegroup.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure.vm.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure.vm.size"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure_resource_id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "azure.vm.scaleset.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "gcp_id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "telemetry.sdk.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "telemetry.sdk.language"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "telemetry.sdk.version"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "service.name"
   }
 
@@ -911,6 +911,61 @@ EOF
     color        = "yellowgreen"
     display_name = "P10"
     label        = "D"
+    value_suffix = "%"
+  }
+}
+
+resource "signalfx_list_chart" "chart_top_instances_by_memory_utilization" {
+  name        = "Top instances by memory utilization (%)"
+  description = "Highest current memory utilization on Forge EC2 runner hosts. Tenant | Instance ID | Host"
+
+  program_text = <<-EOF
+used = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('aws_tag_TenantName', '*') and filter('state', 'used'), rollup='latest').sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.id', 'host.name'])
+total = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('aws_tag_TenantName', '*') and filter('state', 'used', 'free', 'cached', 'buffered'), rollup='latest').sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.id', 'host.name'])
+A = ((used / total) * 100).top(count=10).publish(label='A')
+EOF
+
+  color_by                = "Scale"
+  hide_missing_values     = true
+  max_precision           = 2
+  secondary_visualization = "Sparkline"
+  sort_by                 = "-value"
+  time_range              = 3600
+
+  color_scale {
+    color = "green"
+    lt    = 90
+  }
+  color_scale {
+    color = "orange"
+    gte   = 90
+    lt    = 99
+  }
+  color_scale {
+    color = "red"
+    gte   = 99
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_tag_TenantName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "aws_instance_id"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "host.id"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "host.name"
+  }
+
+  viz_options {
+    display_name = "Memory utilization"
+    label        = "A"
     value_suffix = "%"
   }
 }
@@ -1022,8 +1077,8 @@ resource "signalfx_list_chart" "chart_total_network_errors" {
   name = "Network errors/sec"
 
   program_text = <<-EOF
-A = data('system.network.errors', filter=filter('direction', 'receive') and filter('cloud.platform', 'aws_ec2', 'aws_eks'), rollup='rate').sum(by=['aws_tag_TenantName']).publish(label='A')
-B = data('system.network.errors', filter=filter('direction', 'transmit') and filter('cloud.platform', 'aws_ec2', 'aws_eks'), rollup='rate').sum(by=['aws_tag_TenantName']).publish(label='B')
+A = data('system.network.errors', filter=filter('direction', 'receive') and filter('cloud.platform', 'aws_ec2'), rollup='rate').sum(by=['aws_tag_TenantName']).publish(label='A')
+B = data('system.network.errors', filter=filter('direction', 'transmit') and filter('cloud.platform', 'aws_ec2'), rollup='rate').sum(by=['aws_tag_TenantName']).publish(label='B')
 EOF
 
   sort_by = "-value"
@@ -1063,8 +1118,8 @@ resource "signalfx_list_chart" "chart_top_memory_page_swaps_sec" {
   description = "From hosts with agent installed"
 
   program_text = <<-EOF
-A = data('vmpage_io.swap.in', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks'), rollup='rate').mean(by=['host.name', 'aws_tag_TenantName']).top(count=5).publish(label='A')
-B = data('vmpage_io.swap.out', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks'), rollup='rate').mean(by=['host.name', 'aws_tag_TenantName']).top(count=5).publish(label='B')
+A = data('vmpage_io.swap.in', filter=filter('cloud.platform', 'aws_ec2'), rollup='rate').mean(by=['host.name', 'aws_tag_TenantName']).top(count=5).publish(label='A')
+B = data('vmpage_io.swap.out', filter=filter('cloud.platform', 'aws_ec2'), rollup='rate').mean(by=['host.name', 'aws_tag_TenantName']).top(count=5).publish(label='B')
 EOF
 
   sort_by = "-value"
@@ -1239,7 +1294,7 @@ resource "signalfx_list_chart" "chart_active_hosts_by_availability_zone" {
 
   program_text = <<-EOF
 A = data('CPUUtilization', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'mean'), extrapolation='last_value', maxExtrapolations=5).max(over='1h').count(by=['aws_availability_zone', 'aws_tag_TenantName']).publish(label='A',enable=False)
-B = data('cpu.utilization', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks'), extrapolation='last_value', maxExtrapolations=5).dimensions(renames={'aws_availability_zone':'cloud.availability_zone'}).max(over='1h').count(by=['aws_availability_zone', 'aws_tag_TenantName']).publish(label='B',enable=False)
+B = data('cpu.utilization', filter=filter('cloud.platform', 'aws_ec2'), extrapolation='last_value', maxExtrapolations=5).dimensions(renames={'aws_availability_zone':'cloud.availability_zone'}).max(over='1h').count(by=['aws_availability_zone', 'aws_tag_TenantName']).publish(label='B',enable=False)
 C = union(A,B).publish("C")
 EOF
 
@@ -1290,8 +1345,8 @@ resource "signalfx_list_chart" "chart_disk_summary_utilization" {
   description = "Percent of disk space utilized on all volumes on active hosts with agent installed. Tenant | Instance id | Host"
 
   program_text = <<-EOF
-A = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'used')).sum(by=['aws_tag_TenantName', 'host.name', 'host.id', 'AWSUniqueId']).publish(label='A', enable=False)
-B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks') and filter('state', 'free')).sum(by=['aws_tag_TenantName', 'host.name', 'host.id', 'AWSUniqueId']).publish(label='B', enable=False)
+A = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used')).sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.name', 'host.id', 'AWSUniqueId', 'mountpoint', 'device']).publish(label='A', enable=False)
+B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'free')).sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.name', 'host.id', 'AWSUniqueId', 'mountpoint', 'device']).publish(label='B', enable=False)
 C = ((A/(A+B))*100).publish(label='C')
 EOF
 
@@ -1326,23 +1381,23 @@ EOF
     property = "aws_tag_TenantName"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.image.id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "os.type"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "type"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "host.type"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.availability_zone"
   }
   legend_options_fields {
@@ -1350,15 +1405,15 @@ EOF
     property = "mountpoint"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "mode"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "state"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.platform"
   }
   legend_options_fields {
@@ -1366,11 +1421,11 @@ EOF
     property = "host.id"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.provider"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "cloud.account.id"
   }
   legend_options_fields {
@@ -1378,15 +1433,15 @@ EOF
     property = "device"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "k8s.cluster.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "k8s.node.name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "deployment.environment"
   }
 
@@ -1584,9 +1639,9 @@ resource "signalfx_time_chart" "chart_status_check_failures" {
   description = "Shows EC2 instance and system status check failures for runner hosts."
 
   program_text = <<-EOF
-A = data('StatusCheckFailed', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'maximum'), rollup='max').sum(by=['aws_tag_TenantName', 'aws_instance_id']).publish(label='Any failure')
-B = data('StatusCheckFailed_Instance', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'maximum'), rollup='max').sum(by=['aws_tag_TenantName', 'aws_instance_id']).publish(label='Instance failure')
-C = data('StatusCheckFailed_System', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'maximum'), rollup='max').sum(by=['aws_tag_TenantName', 'aws_instance_id']).publish(label='System failure')
+A = data('StatusCheckFailed', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'upper'), rollup='max').sum(by=['aws_tag_TenantName', 'aws_instance_id']).publish(label='Any failure')
+B = data('StatusCheckFailed_Instance', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'upper'), rollup='max').sum(by=['aws_tag_TenantName', 'aws_instance_id']).publish(label='Instance failure')
+C = data('StatusCheckFailed_System', filter=filter('namespace', 'AWS/EC2') and filter('stat', 'upper'), rollup='max').sum(by=['aws_tag_TenantName', 'aws_instance_id']).publish(label='System failure')
 EOF
 
   plot_type                 = "LineChart"
@@ -1624,8 +1679,8 @@ resource "signalfx_dashboard" "runner_ec2" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = []
-    value_required         = false
+    values                 = sort(var.tenant_names)
+    value_required         = length(var.tenant_names) > 0
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }
@@ -1713,22 +1768,29 @@ resource "signalfx_dashboard" "runner_ec2" {
   chart {
     chart_id = signalfx_time_chart.chart_total_memory_overview_bytes.id
     row      = 4
-    column   = 4
-    width    = 4
+    column   = 6
+    width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_list_chart.chart_top_memory_page_swaps_sec.id
     row      = 4
-    column   = 8
-    width    = 4
+    column   = 9
+    width    = 3
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.chart_memory_utilization.id
     row      = 4
     column   = 0
-    width    = 4
+    width    = 3
+    height   = 1
+  }
+  chart {
+    chart_id = signalfx_list_chart.chart_top_instances_by_memory_utilization.id
+    row      = 4
+    column   = 3
+    width    = 3
     height   = 1
   }
   chart {

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory.tftest.hcl
@@ -18,6 +18,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory
       "resource \"signalfx_list_chart\" \"chart_top_images_by_mean_cpu_utilization\"",
       "resource \"signalfx_time_chart\" \"chart_network_in_bytes\"",
       "resource \"signalfx_time_chart\" \"chart_memory_utilization\"",
+      "resource \"signalfx_list_chart\" \"chart_top_instances_by_memory_utilization\"",
       "resource \"signalfx_time_chart\" \"chart_disk_io_bytes\"",
       "resource \"signalfx_time_chart\" \"chart_network_in_bytes_vs_24h_change\"",
       "resource \"signalfx_list_chart\" \"chart_total_network_errors\"",
@@ -42,7 +43,47 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory
   }
 
   assert {
-    condition     = output.expected_literal_count == 25
-    error_message = "Source inventory must keep 25 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 26
+    error_message = "Source inventory must keep 26 module-specific Terraform blocks pinned."
+  }
+}
+
+run "runner_ec2_rejects_kubernetes_platform_scope" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path        = "."
+    recursive          = true
+    expected_literals  = []
+    forbidden_literals = ["filter('cloud.platform', 'aws_ec2', 'aws_eks')"]
+  }
+
+  assert {
+    condition     = length(output.present_forbidden_literals) == 0
+    error_message = "The tenant EC2 dashboard must not mix EKS node and platform telemetry into EC2 runner charts."
+  }
+}
+
+run "runner_ec2_rejects_invalid_cloudwatch_stat_aliases" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path        = "."
+    recursive          = true
+    expected_literals  = []
+    forbidden_literals = ["filter('stat', 'maximum')"]
+  }
+
+  assert {
+    condition     = length(output.present_forbidden_literals) == 0
+    error_message = "CloudWatch maximum statistics are exposed in Splunk as stat=upper, not stat=maximum."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -39,14 +39,26 @@ run "runner_ec2_dashboard_contract" {
       && signalfx_list_chart.chart_top_instances_by_cpu_utilization.sort_by == "-value"
       && signalfx_list_chart.chart_top_instances_by_cpu_utilization.time_range == 3600
       && signalfx_list_chart.chart_disk_summary_utilization.description == "Percent of disk space utilized on all volumes on active hosts with agent installed. Tenant | Instance id | Host"
-      && strcontains(signalfx_list_chart.chart_disk_summary_utilization.program_text, ".sum(by=['aws_tag_TenantName', 'host.name', 'host.id', 'AWSUniqueId'])")
+      && strcontains(signalfx_list_chart.chart_disk_summary_utilization.program_text, ".sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.name', 'host.id', 'AWSUniqueId', 'mountpoint', 'device'])")
       && contains([for field in signalfx_list_chart.chart_disk_summary_utilization.legend_options_fields : field.property if field.enabled], "aws_tag_TenantName")
+      && contains([for field in signalfx_list_chart.chart_disk_summary_utilization.legend_options_fields : field.property if field.enabled], "aws_instance_id")
+      && contains([for field in signalfx_list_chart.chart_disk_summary_utilization.legend_options_fields : field.property if field.enabled], "mountpoint")
+      && contains([for field in signalfx_list_chart.chart_disk_summary_utilization.legend_options_fields : field.property if field.enabled], "device")
       && one([for option in signalfx_list_chart.chart_disk_summary_utilization.viz_options : option.display_name if option.label == "C"]) == "Disk utilization"
+      && signalfx_list_chart.chart_top_instances_by_memory_utilization.name == "Top instances by memory utilization (%)"
+      && strcontains(signalfx_list_chart.chart_top_instances_by_memory_utilization.program_text, "filter('cloud.platform', 'aws_ec2')")
+      && strcontains(signalfx_list_chart.chart_top_instances_by_memory_utilization.program_text, ".sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.id', 'host.name'])")
+      && signalfx_list_chart.chart_top_instances_by_memory_utilization.color_by == "Scale"
+      && signalfx_list_chart.chart_top_instances_by_memory_utilization.sort_by == "-value"
       && signalfx_time_chart.chart_status_check_failures.time_range == 3600
+      && strcontains(signalfx_time_chart.chart_status_check_failures.program_text, "filter('stat', 'upper')")
+      && !strcontains(signalfx_time_chart.chart_status_check_failures.program_text, "filter('stat', 'maximum')")
       && signalfx_list_chart.chart_total_network_errors.name == "Network errors/sec"
       && strcontains(signalfx_list_chart.chart_total_network_errors.program_text, "rollup='rate'")
       && !strcontains(signalfx_list_chart.chart_total_network_errors.program_text, ".count(")
-      && strcontains(signalfx_list_chart.chart_top_memory_page_swaps_sec.program_text, "data('vmpage_io.swap.in', filter=filter('cloud.platform', 'aws_ec2', 'aws_eks'), rollup='rate')")
+      && strcontains(signalfx_list_chart.chart_top_memory_page_swaps_sec.program_text, "data('vmpage_io.swap.in', filter=filter('cloud.platform', 'aws_ec2'), rollup='rate')")
+      && !strcontains(signalfx_time_chart.chart_disk_utilization.program_text, "aws_eks")
+      && !strcontains(signalfx_time_chart.chart_memory_utilization.program_text, "aws_eks")
     )
     error_message = "EC2 runner charts must keep one-hour visibility, tenant-aware disk identity, active host, CPU utilization, top-instance, and rate-based network and swap behavior."
   }
@@ -59,11 +71,11 @@ run "runner_ec2_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.runner_ec2.name == "Forge Tenant - EC2 Runners"
       && signalfx_dashboard.runner_ec2.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.runner_ec2.variable[0].values) == 0
-      && !signalfx_dashboard.runner_ec2.variable[0].value_required
+      && signalfx_dashboard.runner_ec2.variable[0].values == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.runner_ec2.variable[0].value_required
       && signalfx_dashboard.runner_ec2.variable[0].values_suggested == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.runner_ec2.variable[0].restricted_suggestions
-      && length(signalfx_dashboard.runner_ec2.chart) == 24
+      && length(signalfx_dashboard.runner_ec2.chart) == 25
     )
     error_message = "EC2 runner dashboard must keep its name, group input, and chart count."
   }
@@ -72,6 +84,7 @@ run "runner_ec2_dashboard_wiring_contract" {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.runner_ec2.chart : chart.chart_id], signalfx_single_value_chart.chart_active_hosts.id),
       contains([for chart in signalfx_dashboard.runner_ec2.chart : chart.chart_id], signalfx_list_chart.chart_active_hosts_missing_agent.id),
+      contains([for chart in signalfx_dashboard.runner_ec2.chart : chart.chart_id], signalfx_list_chart.chart_top_instances_by_memory_utilization.id),
       contains([for chart in signalfx_dashboard.runner_ec2.chart : chart.chart_id], signalfx_time_chart.chart_status_check_failures.id),
     ])
     error_message = "EC2 runner dashboard must keep its first and final chart wiring."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -71,8 +71,8 @@ run "runner_ec2_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.runner_ec2.name == "Forge Tenant - EC2 Runners"
       && signalfx_dashboard.runner_ec2.dashboard_group == "forge-dashboard-group"
-      && signalfx_dashboard.runner_ec2.variable[0].values == toset(["tenant-a", "tenant-b"])
-      && signalfx_dashboard.runner_ec2.variable[0].value_required
+      && length(signalfx_dashboard.runner_ec2.variable[0].values) == 0
+      && !signalfx_dashboard.runner_ec2.variable[0].value_required
       && signalfx_dashboard.runner_ec2.variable[0].values_suggested == toset(["tenant-a", "tenant-b"])
       && signalfx_dashboard.runner_ec2.variable[0].restricted_suggestions
       && length(signalfx_dashboard.runner_ec2.chart) == 25

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
@@ -407,19 +407,19 @@ resource "signalfx_time_chart" "k8s_memory_usage_bytes" {
   }
 
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "kubernetes_pod_name"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "kubernetes_namespace"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "kubernetes_cluster"
   }
   legend_options_fields {
-    enabled  = true
+    enabled  = false
     property = "kubernetes_pod_uid"
   }
   legend_options_fields {

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
@@ -562,8 +562,8 @@ resource "signalfx_dashboard" "runner_k8s" {
     property               = "k8s.namespace.name"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = sort(var.tenant_names)
-    value_required         = length(var.tenant_names) > 0
+    values                 = []
+    value_required         = false
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
@@ -67,8 +67,10 @@ run "runner_k8s_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.runner_k8s.name == "Forge Tenant - K8S Runners"
       && signalfx_dashboard.runner_k8s.dashboard_group == "forge-dashboard-group"
-      && signalfx_dashboard.runner_k8s.variable[0].values == toset(["tenant-a", "tenant-b"])
-      && signalfx_dashboard.runner_k8s.variable[0].value_required
+      && length(signalfx_dashboard.runner_k8s.variable[0].values) == 0
+      && !signalfx_dashboard.runner_k8s.variable[0].value_required
+      && signalfx_dashboard.runner_k8s.variable[0].values_suggested == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.runner_k8s.variable[0].restricted_suggestions
       && length(signalfx_dashboard.runner_k8s.chart) == 13
     )
     error_message = "K8S runner dashboard must keep its name, group input, and chart count."

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
@@ -26,6 +26,14 @@ run "runner_k8s_dashboard_contract" {
       && signalfx_list_chart.k8s_top_10_cpu_usage_per_pod.sort_by == "-value"
       && signalfx_time_chart.k8s_memory_usage_pct.name == "Memory usage (%)"
       && strcontains(signalfx_time_chart.k8s_pod_status_reasons.program_text, "filter('k8s.namespace.name', 'tenant-a') or filter('k8s.namespace.name', 'tenant-b')")
+      && alltrue([
+        for property in ["k8s.cluster.name", "k8s.namespace.name", "k8s.pod.name", "k8s.pod.uid", "k8s.node.name"] :
+        contains([for field in signalfx_time_chart.k8s_memory_usage_bytes.legend_options_fields : field.property if field.enabled], property)
+      ])
+      && alltrue([
+        for property in ["kubernetes_cluster", "kubernetes_namespace", "kubernetes_pod_name", "kubernetes_pod_uid"] :
+        !contains([for field in signalfx_time_chart.k8s_memory_usage_bytes.legend_options_fields : field.property if field.enabled], property)
+      ])
     )
     error_message = "K8S runner charts must keep active pod, top CPU, memory percentage, and tenant pod status behavior."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/main.tf
@@ -499,8 +499,8 @@ resource "signalfx_dashboard" "sqs" {
     property               = "aws_tag_TenantName"
     alias                  = "ForgeCICD Tenant Name"
     description            = ""
-    values                 = sort(var.tenant_names)
-    value_required         = length(var.tenant_names) > 0
+    values                 = []
+    value_required         = false
     values_suggested       = sort(var.tenant_names)
     restricted_suggestions = true
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/sqs_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/sqs_dashboard_behavior.tftest.hcl
@@ -46,8 +46,10 @@ run "sqs_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.sqs.name == "Forge Tenant - SQS"
       && signalfx_dashboard.sqs.dashboard_group == "forge-dashboard-group"
-      && signalfx_dashboard.sqs.variable[0].values == toset(["tenant-a", "tenant-b"])
-      && signalfx_dashboard.sqs.variable[0].value_required
+      && length(signalfx_dashboard.sqs.variable[0].values) == 0
+      && !signalfx_dashboard.sqs.variable[0].value_required
+      && signalfx_dashboard.sqs.variable[0].values_suggested == toset(["tenant-a", "tenant-b"])
+      && signalfx_dashboard.sqs.variable[0].restricted_suggestions
       && length(signalfx_dashboard.sqs.chart) == 13
     )
     error_message = "SQS dashboard must keep its name, group input, and chart count."


### PR DESCRIPTION
## Description

- remove five Lambda provisioned-concurrency charts whose metrics are unavailable in live Splunk telemetry
- keep EC2 runner charts scoped to EC2 resources, add per-instance memory ranking, and preserve disk resource identity
- expose configured tenants as restricted suggestions without preloading or requiring every tenant
- correct EC2 status checks to use the live Splunk CloudWatch statistic alias `stat=upper`
- preserve DynamoDB operation identity and correct Kubernetes node-pressure and legend behavior
- add behavior and source-level regression guards for the changed dashboard contracts

Live validation executed all 137 retained SignalFlow programs over 24 hours. All programs were syntactically valid; 126 returned live series and 11 valid incident/failure views were quiet.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- 47 focused dashboard and shared-module OpenTofu test runs passed
- `tofu fmt -check -recursive modules/integrations/splunk_o11y_conf_shared/dashboards`
- `git diff --check`
- 137/137 retained SignalFlow programs executed without syntax or runtime errors
- repository-wide OpenTofu validation hooks were skipped after repeatedly stalling; the affected dashboard suites passed independently
