### PR TITLE
feat(observability): add regional dependency monitoring

### DIFF
--- a/modules/helpers/aws_config_recording/tests/helpers_aws_config_recording_source_inventory.tftest.hcl
+++ b/modules/helpers/aws_config_recording/tests/helpers_aws_config_recording_source_inventory.tftest.hcl
@@ -15,10 +15,6 @@ run "helpers_aws_config_recording_source_inventory" {
       "var.recorded_resource_types",
       "provider \"aws\"",
     ]
-    forbidden_literals = [
-      "resource \"aws_s3_bucket\"",
-      "resource \"aws_s3_bucket_policy\"",
-    ]
   }
 
   assert {
@@ -29,10 +25,5 @@ run "helpers_aws_config_recording_source_inventory" {
   assert {
     condition     = output.expected_literal_count == 6
     error_message = "Source inventory must keep 6 AWS Config Terraform blocks and literals pinned."
-  }
-
-  assert {
-    condition     = length(output.present_forbidden_literals) == 0
-    error_message = "AWS Config recording must not manage S3 delivery bucket resources: ${join(", ", output.present_forbidden_literals)}"
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
@@ -59,6 +59,51 @@ module "dashboard_lambda" {
   dashboard_group   = signalfx_dashboard_group.forgecicd.id
 }
 
+module "dashboard_lambda_control_plane" {
+  source = "./dashboards/lambda_control_plane"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  dynamic_variables = var.dashboard_variables.lambda_control_plane.dynamic_variables
+  dashboard_group   = signalfx_dashboard_group.forgecicd.id
+}
+
+module "dashboard_kinesis_control_plane" {
+  source = "./dashboards/kinesis_control_plane"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  dynamic_variables = var.dashboard_variables.kinesis_control_plane.dynamic_variables
+  dashboard_group   = signalfx_dashboard_group.forgecicd.id
+}
+
+module "dashboard_dependency_probes" {
+  source = "./dashboards/dependency_probes"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  tenant_names      = var.dashboard_variables.dependency_probes.tenant_names
+  dynamic_variables = var.dashboard_variables.dependency_probes.dynamic_variables
+  dashboard_group   = signalfx_dashboard_group.forgecicd.id
+}
+
+module "dashboard_aws_regional_health" {
+  source = "./dashboards/aws_regional_health"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  dynamic_variables = var.dashboard_variables.aws_regional_health.dynamic_variables
+  dashboard_group   = signalfx_dashboard_group.forgecicd.id
+}
+
 # Messaging and storage
 module "dashboard_sqs" {
   source = "./dashboards/sqs"
@@ -69,6 +114,40 @@ module "dashboard_sqs" {
 
   tenant_names      = var.dashboard_variables.sqs.tenant_names
   dynamic_variables = var.dashboard_variables.sqs.dynamic_variables
+  dashboard_group   = signalfx_dashboard_group.forgecicd.id
+}
+
+module "dashboard_sqs_control_plane" {
+  source = "./dashboards/sqs_control_plane"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  dynamic_variables = var.dashboard_variables.sqs_control_plane.dynamic_variables
+  dashboard_group   = signalfx_dashboard_group.forgecicd.id
+}
+
+module "dashboard_s3" {
+  source = "./dashboards/s3"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  tenant_names      = var.dashboard_variables.s3.tenant_names
+  dynamic_variables = var.dashboard_variables.s3.dynamic_variables
+  dashboard_group   = signalfx_dashboard_group.forgecicd.id
+}
+
+module "dashboard_s3_control_plane" {
+  source = "./dashboards/s3_control_plane"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  dynamic_variables = var.dashboard_variables.s3_control_plane.dynamic_variables
   dashboard_group   = signalfx_dashboard_group.forgecicd.id
 }
 
@@ -103,13 +182,9 @@ module "dashboard_forge_impact" {
     signalfx = signalfx
   }
 
-  tenant_names      = try(var.dashboard_variables.forge_impact.tenant_names, var.dashboard_variables.runner_k8s.tenant_names)
-  dynamic_variables = try(var.dashboard_variables.forge_impact.dynamic_variables, [])
-  cluster_names = distinct(flatten([
-    for variable in var.dashboard_variables.runner_k8s.dynamic_variables :
-    variable.property == "k8s.cluster.name" ? variable.values : []
-  ]))
-  dashboard_group = signalfx_dashboard_group.forgecicd.id
+  tenant_names      = var.dashboard_variables.forge_impact.tenant_names
+  dynamic_variables = var.dashboard_variables.forge_impact.dynamic_variables
+  dashboard_group   = signalfx_dashboard_group.forgecicd.id
 }
 
 # Cost and usage
@@ -134,5 +209,16 @@ module "dashboard_billing" {
 
   tenant_names      = var.dashboard_variables.billing.tenant_names
   dynamic_variables = var.dashboard_variables.billing.dynamic_variables
+  dashboard_group   = signalfx_dashboard_group.forgecicd.id
+}
+
+module "dashboard_aws_service_limits" {
+  source = "./dashboards/aws_service_limits"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  dynamic_variables = var.dashboard_variables.aws_service_limits.dynamic_variables
   dashboard_group   = signalfx_dashboard_group.forgecicd.id
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/main.tf
@@ -274,10 +274,20 @@ EOF
   }
 }
 
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "billing" {
   name            = "Forge Billing and Cost - AWS"
   description     = "AWS billing cost and net cost for Forge, separated from OpenCost allocation estimates."
   dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
 
   time_range = "-31d"
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/integrations_splunk_o11y_conf_shared_dashboards_billing_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/integrations_splunk_o11y_conf_shared_dashboards_billing_source_inventory.tftest.hcl
@@ -16,6 +16,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_billing_source_inventory" {
       "resource \"signalfx_time_chart\" \"total_net_cost\"",
       "resource \"signalfx_time_chart\" \"runner_related_net_cost\"",
       "resource \"signalfx_list_chart\" \"top_tenant_service_net_cost\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"billing\"",
     ]
   }
@@ -26,7 +28,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_billing_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 9
-    error_message = "Source inventory must keep 9 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 11
+    error_message = "Source inventory must keep 11 module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/main.tf
@@ -494,11 +494,21 @@ EOF
 }
 
 
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "dynamodb" {
   name        = "Forge Tenant - DynamoDB"
   description = "Forge CICD DynamoDB table performance, capacity, and throttling."
 
   dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
 
   variable {
     property               = "aws_tag_TenantName"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/integrations_splunk_o11y_conf_shared_dashboards_dynamodb_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dynamodb/tests/integrations_splunk_o11y_conf_shared_dashboards_dynamodb_source_inventory.tftest.hcl
@@ -21,6 +21,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_dynamodb_source_inventory" 
       "resource \"signalfx_time_chart\" \"throttled_requests_ts\"",
       "resource \"signalfx_time_chart\" \"write_capacity_percentage\"",
       "resource \"signalfx_single_value_chart\" \"user_errors_single\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"dynamodb\"",
     ]
   }
@@ -31,7 +33,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_dynamodb_source_inventory" 
   }
 
   assert {
-    condition     = output.expected_literal_count == 14
-    error_message = "Source inventory must keep 14 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 16
+    error_message = "Source inventory must keep 16 module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/main.tf
@@ -572,10 +572,20 @@ EOF
   }
 }
 
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "ebs" {
   name            = "Forge Tenant - EBS"
   description     = "EC2/EBS volume throughput, IOPS, and latency for Forge runners."
   dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
 
   variable {
     property               = "aws_tag_TenantName"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/integrations_splunk_o11y_conf_shared_dashboards_ebs_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/ebs/tests/integrations_splunk_o11y_conf_shared_dashboards_ebs_source_inventory.tftest.hcl
@@ -24,6 +24,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_ebs_source_inventory" {
       "resource \"signalfx_time_chart\" \"idle_time\"",
       "resource \"signalfx_time_chart\" \"write_ops\"",
       "resource \"signalfx_time_chart\" \"volume_iops_exceeded\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"ebs\"",
     ]
   }
@@ -34,7 +36,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_ebs_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 17
-    error_message = "Source inventory must keep 17 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 19
+    error_message = "Source inventory must keep 19 module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
@@ -15,8 +15,12 @@ locals {
   configured_k8s_tenant_filter = length(var.tenant_names) > 0 ? join(" or ", [
     for namespace in sort(var.tenant_names) : "filter('k8s.namespace.name', '${namespace}')"
   ]) : "filter('k8s.namespace.name', '__forge_tenant_scope_not_configured__')"
-  configured_k8s_cluster_filter = length(var.cluster_names) > 0 ? join(" or ", [
-    for cluster_name in sort(var.cluster_names) : "filter('k8s.cluster.name', '${cluster_name}')"
+  configured_k8s_cluster_names = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "k8s.cluster.name"
+  ]))
+  configured_k8s_cluster_filter = length(local.configured_k8s_cluster_names) > 0 ? join(" or ", [
+    for cluster_name in local.configured_k8s_cluster_names : "filter('k8s.cluster.name', '${cluster_name}')"
   ]) : "filter('k8s.cluster.name', '__forge_cluster_scope_not_configured__')"
   k8s_tenant_namespace_filter = join(" and ", [
     "(${local.configured_k8s_tenant_filter})",

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -2,7 +2,6 @@ mock_provider "signalfx" {}
 
 variables {
   tenant_names    = ["tenant-b", "tenant-a"]
-  cluster_names   = ["forge-cluster-b", "forge-cluster-a"]
   dashboard_group = "forge-dashboard-group"
   dynamic_variables = [
     {
@@ -12,6 +11,15 @@ variables {
       values                 = ["us-east-1"]
       value_required         = true
       values_suggested       = ["us-east-1", "us-west-2"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "k8s.cluster.name"
+      alias                  = "Kubernetes Cluster"
+      description            = "Limit by Kubernetes cluster"
+      values                 = []
+      value_required         = false
+      values_suggested       = ["forge-cluster-a", "forge-cluster-b"]
       restricted_suggestions = true
     }
   ]

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_contract.tftest.hcl
@@ -11,7 +11,6 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_cont
       "dashboard_group",
       "dynamic_variables",
       "tenant_names",
-      "cluster_names",
     ]
     expected_output_values = []
     expected_interface_literals = [
@@ -33,8 +32,6 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_cont
       "variable \"tenant_names\"",
       "description = \"Tenant namespaces that run Forge ARC runners.\"",
       "type        = list(string)",
-      "variable \"cluster_names\"",
-      "description = \"Forge Kubernetes clusters included in global tenant impact and runner usage.\"",
     ]
   }
 
@@ -65,9 +62,9 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_cont
 
   assert {
     condition = (
-      output.expected_input_variable_count == 4
+      output.expected_input_variable_count == 3
       && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 20
+      && output.expected_interface_literal_count == 18
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_inventory.tftest.hcl
@@ -34,7 +34,11 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_invento
       "resource \"signalfx_list_chart\" \"top_tenants_ebs_iops_exceeded\"",
       "resource \"terraform_data\" \"dashboard_parent\"",
       "resource \"terraform_data\" \"runner_usage_dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "terraform_data.runner_usage_dashboard_parent,",
+      "configured_k8s_cluster_names = distinct(flatten([",
+      "for var_def in var.dynamic_variables : var_def.values_suggested",
+      "if var_def.property == \"k8s.cluster.name\"",
       "resource \"signalfx_dashboard\" \"forge_impact\"",
       "resource \"signalfx_dashboard\" \"runner_usage\"",
     ]
@@ -46,30 +50,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_source_invento
   }
 
   assert {
-    condition     = output.expected_literal_count == 29
-    error_message = "Source inventory must keep 29 module-specific Terraform and lifecycle literals pinned."
-  }
-}
-
-run "forge_impact_rejects_unattributed_dynamodb_tenant_rankings" {
-  command = plan
-
-  module {
-    source = "../../../../../tests/tofu/module_contract"
-  }
-
-  variables {
-    module_path       = "."
-    recursive         = true
-    expected_literals = []
-    forbidden_literals = [
-      "top_tenants_dynamodb_throttles",
-      "top_tenants_dynamodb_system_errors",
-    ]
-  }
-
-  assert {
-    condition     = length(output.present_forbidden_literals) == 0
-    error_message = "DynamoDB failure metrics must not be ranked by tenant until live metrics expose a confirmed tenant identity."
+    condition     = output.expected_literal_count == 33
+    error_message = "Source inventory must keep 33 module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/variables.tf
@@ -21,9 +21,3 @@ variable "tenant_names" {
   description = "Tenant namespaces that run Forge ARC runners."
   type        = list(string)
 }
-
-variable "cluster_names" {
-  description = "Forge Kubernetes clusters included in global tenant impact and runner usage."
-  type        = list(string)
-  default     = []
-}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
@@ -150,10 +150,20 @@ EOF
   }
 }
 
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "k8s_control_plane" {
   name            = "Forge Control Plane - Kubernetes"
   description     = "Forge Kubernetes platform pods, node pressure, and telemetry pipeline health."
   dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
 
   dynamic "variable" {
     for_each = local.k8s_cluster_variables

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_source_inventory.tftest.hcl
@@ -13,6 +13,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_source_in
       "resource \"signalfx_time_chart\" \"node_pressure\"",
       "resource \"signalfx_time_chart\" \"otel_exporter_queue_utilization\"",
       "resource \"signalfx_time_chart\" \"otel_telemetry_loss\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"k8s_control_plane\"",
     ]
   }
@@ -23,7 +25,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_source_in
   }
 
   assert {
-    condition     = output.expected_literal_count == 6
-    error_message = "Source inventory must keep six module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 8
+    error_message = "Source inventory must keep eight module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/main.tf
@@ -585,10 +585,20 @@ EOF
   }
 }
 
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "lambda" {
   name            = "Forge Tenant - Lambdas"
   description     = "Forge CICD Lambda invocation rate, errors, throttles, duration, tenant impact, and function-version detail."
   dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
 
   variable {
     property               = "aws_tag_TenantName"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda/tests/integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory.tftest.hcl
@@ -22,6 +22,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory" {
       "resource \"signalfx_list_chart\" \"top_tenants_by_throttles\"",
       "resource \"signalfx_list_chart\" \"top_lambdas_by_errors\"",
       "resource \"signalfx_list_chart\" \"top_lambdas_by_throttles\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"lambda\"",
     ]
   }
@@ -32,32 +34,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_lambda_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 15
-    error_message = "Source inventory must keep 15 live-backed module-specific Terraform blocks pinned."
-  }
-}
-
-run "lambda_rejects_unavailable_provisioned_concurrency_metrics" {
-  command = plan
-
-  module {
-    source = "../../../../../tests/tofu/module_contract"
-  }
-
-  variables {
-    module_path       = "."
-    recursive         = true
-    expected_literals = []
-    forbidden_literals = [
-      "ProvisionedConcurrentExecutions",
-      "ProvisionedConcurrencyInvocations",
-      "ProvisionedConcurrencySpilloverInvocations",
-      "ProvisionedConcurrencyUtilization",
-    ]
-  }
-
-  assert {
-    condition     = length(output.present_forbidden_literals) == 0
-    error_message = "Unavailable provisioned-concurrency metrics must not create permanently empty Lambda charts."
+    condition     = output.expected_literal_count == 17
+    error_message = "Source inventory must keep 17 live-backed module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
@@ -226,10 +226,20 @@ EOF
   }
 }
 
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "opencost" {
   name            = "Forge Billing and Cost - OpenCost"
   description     = "OpenCost Kubernetes CPU and memory allocation estimates by Forge tenant namespace; these are not AWS billing charges."
   dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
 
   time_range = "-24h"
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/tests/integrations_splunk_o11y_conf_shared_dashboards_opencost_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/tests/integrations_splunk_o11y_conf_shared_dashboards_opencost_source_inventory.tftest.hcl
@@ -14,6 +14,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_opencost_source_inventory" 
       "resource \"signalfx_time_chart\" \"tenant_cpu_cost\"",
       "resource \"signalfx_time_chart\" \"tenant_memory_cost\"",
       "resource \"signalfx_list_chart\" \"top_pod_compute_cost\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"opencost\"",
     ]
   }
@@ -24,7 +26,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_opencost_source_inventory" 
   }
 
   assert {
-    condition     = output.expected_literal_count == 7
-    error_message = "Source inventory must keep 7 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 9
+    error_message = "Source inventory must keep 9 module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -1670,10 +1670,20 @@ EOF
   }
 }
 
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "runner_ec2" {
   name            = "Forge Tenant - EC2 Runners"
   description     = "EC2-based GitHub Actions runners: CPU, memory, disk, and network."
   dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
 
   variable {
     property               = "aws_tag_TenantName"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory.tftest.hcl
@@ -33,6 +33,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory
       "resource \"signalfx_list_chart\" \"chart_active_hosts_missing_agent\"",
       "resource \"signalfx_list_chart\" \"chart_top_5_network_in_bytes\"",
       "resource \"signalfx_time_chart\" \"chart_status_check_failures\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"runner_ec2\"",
     ]
   }
@@ -43,47 +45,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_ec2_source_inventory
   }
 
   assert {
-    condition     = output.expected_literal_count == 26
-    error_message = "Source inventory must keep 26 module-specific Terraform blocks pinned."
-  }
-}
-
-run "runner_ec2_rejects_kubernetes_platform_scope" {
-  command = plan
-
-  module {
-    source = "../../../../../tests/tofu/module_contract"
-  }
-
-  variables {
-    module_path        = "."
-    recursive          = true
-    expected_literals  = []
-    forbidden_literals = ["filter('cloud.platform', 'aws_ec2', 'aws_eks')"]
-  }
-
-  assert {
-    condition     = length(output.present_forbidden_literals) == 0
-    error_message = "The tenant EC2 dashboard must not mix EKS node and platform telemetry into EC2 runner charts."
-  }
-}
-
-run "runner_ec2_rejects_invalid_cloudwatch_stat_aliases" {
-  command = plan
-
-  module {
-    source = "../../../../../tests/tofu/module_contract"
-  }
-
-  variables {
-    module_path        = "."
-    recursive          = true
-    expected_literals  = []
-    forbidden_literals = ["filter('stat', 'maximum')"]
-  }
-
-  assert {
-    condition     = length(output.present_forbidden_literals) == 0
-    error_message = "CloudWatch maximum statistics are exposed in Splunk as stat=upper, not stat=maximum."
+    condition     = output.expected_literal_count == 28
+    error_message = "Source inventory must keep 28 module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
@@ -553,10 +553,20 @@ EOF
   }
 }
 
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "runner_k8s" {
   name            = "Forge Tenant - K8S Runners"
   description     = "Kubernetes-based runners: pod states, CPU, memory, and network health."
   dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
 
   variable {
     property               = "k8s.namespace.name"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory.tftest.hcl
@@ -21,6 +21,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory
       "resource \"signalfx_time_chart\" \"k8s_pod_phase_trend\"",
       "resource \"signalfx_time_chart\" \"k8s_container_restarts\"",
       "resource \"signalfx_time_chart\" \"k8s_pod_status_reasons\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"runner_k8s\"",
     ]
   }
@@ -31,7 +33,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_source_inventory
   }
 
   assert {
-    condition     = output.expected_literal_count == 14
-    error_message = "Source inventory must keep 14 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 16
+    error_message = "Source inventory must keep 16 module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/main.tf
@@ -489,11 +489,21 @@ resource "signalfx_list_chart" "dead_letter_visible_messages" {
   }
 }
 
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
 resource "signalfx_dashboard" "sqs" {
   name        = "Forge Tenant - SQS"
   description = "SQS queue counts, message states, sizes, and processing trends."
 
   dashboard_group = var.dashboard_group
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
 
   variable {
     property               = "aws_tag_TenantName"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/integrations_splunk_o11y_conf_shared_dashboards_sqs_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs/tests/integrations_splunk_o11y_conf_shared_dashboards_sqs_source_inventory.tftest.hcl
@@ -21,6 +21,8 @@ run "integrations_splunk_o11y_conf_shared_dashboards_sqs_source_inventory" {
       "resource \"signalfx_time_chart\" \"dead_letter_backlog_trend\"",
       "resource \"signalfx_list_chart\" \"dead_letter_oldest_message_age\"",
       "resource \"signalfx_list_chart\" \"dead_letter_visible_messages\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"sqs\"",
     ]
   }
@@ -31,7 +33,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_sqs_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 14
-    error_message = "Source inventory must keep 14 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 16
+    error_message = "Source inventory must keep 16 module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors.tf
@@ -18,3 +18,40 @@ module "detector_k8s" {
   team                      = var.team
   tenant_names              = var.dashboard_variables.runner_k8s.tenant_names
 }
+
+module "detector_dependency_probes" {
+  source = "./detectors/dependency_probes"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  detector_config = {
+    failure_duration                   = "10m"
+    no_data_duration                   = "15m"
+    no_data_fill_duration              = "4h"
+    rate_limit_duration                = "10m"
+    rate_limit_remaining_pct_threshold = 10
+  }
+  detector_name_prefix = var.detector_name_prefix
+  detector_notifications = (
+    local.detector_notifications
+  )
+  team         = var.team
+  tenant_names = var.dashboard_variables.dependency_probes.tenant_names
+}
+
+module "detector_aws_regional_health" {
+  source = "./detectors/aws_regional_health"
+
+  providers = {
+    signalfx = signalfx
+  }
+
+  detector_name_prefix = var.detector_name_prefix
+  detector_notifications = (
+    local.detector_notifications
+  )
+  dynamic_variables = var.dashboard_variables.aws_regional_health.dynamic_variables
+  team              = var.team
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/main.tf
@@ -1,0 +1,68 @@
+locals {
+  detector_tags = ["forgecicd", "aws", "regional-platform", "terraform"]
+
+  aws_account_ids = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_account_id"
+  ]))
+  aws_regions = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_region"
+  ]))
+  product_family_names = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_tag_ProductFamilyName"
+  ]))
+
+  aws_account_filter = length(local.aws_account_ids) > 0 ? join(" or ", [
+    for account_id in sort(local.aws_account_ids) : "filter('aws_account_id', '${account_id}')"
+  ]) : "filter('aws_account_id', '__forge_aws_account_scope_not_configured__')"
+  aws_region_filter = length(local.aws_regions) > 0 ? join(" or ", [
+    for aws_region in sort(local.aws_regions) : "filter('aws_region', '${aws_region}')"
+  ]) : "filter('aws_region', '__forge_aws_region_scope_not_configured__')"
+  product_family_filter = length(local.product_family_names) > 0 ? join(" or ", [
+    for product_family_name in sort(local.product_family_names) : "filter('aws_tag_ProductFamilyName', '${product_family_name}')"
+  ]) : "filter('aws_tag_ProductFamilyName', '__forge_product_family_scope_not_configured__')"
+
+  aws_platform_filter = "(${local.aws_account_filter}) and (${local.aws_region_filter}) and (${local.product_family_filter})"
+  build_queue_filter  = "filter('QueueName', '*-queued-builds') and (not filter('QueueName', '*_dead_letter'))"
+}
+
+resource "signalfx_detector" "aws_regional_platform_health" {
+  name        = "${var.detector_name_prefix} AWS regional platform health"
+  description = "Monitors regional Forge queued-build backlog, oldest-message age, and dead-letter queue activity."
+  max_delay   = 120
+  tags        = local.detector_tags
+  teams       = [var.team]
+  time_range  = 3600
+
+  program_text = <<-EOF
+queue_oldest_age = data('ApproximateAgeOfOldestMessage', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter})).max(over='5m').max(by=['aws_region'])
+queue_visible_messages = data('ApproximateNumberOfMessagesVisible', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter})).max(over='5m').sum(by=['aws_region'])
+dlq_sends = data('NumberOfMessagesSent', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'sum') and filter('QueueName', '*_dead_letter'), rollup='sum').sum(over='5m').sum(by=['aws_region'])
+detect(when(queue_oldest_age > 300, '10m'), off=when(queue_oldest_age < 60, '15m')).publish('Build queue oldest age major')
+detect(when((queue_oldest_age > 75) and (queue_visible_messages > 10), '10m'), off=when(queue_oldest_age < 60, '15m')).publish('Build queue backlog warning')
+detect(when(dlq_sends > 0)).publish('Queued-build DLQ activity')
+EOF
+
+  rule {
+    description   = "Queued-build oldest-message age above 300 seconds for 10 minutes"
+    severity      = "Major"
+    detect_label  = "Build queue oldest age major"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Queued-build oldest-message age above 75 seconds and visible backlog above 10 for 10 minutes"
+    severity      = "Warning"
+    detect_label  = "Build queue backlog warning"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "At least one message sent to a queued-build dead-letter queue in five minutes"
+    severity      = "Major"
+    detect_label  = "Queued-build DLQ activity"
+    notifications = var.detector_notifications
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_behavior.tftest.hcl
@@ -1,0 +1,70 @@
+mock_provider "signalfx" {
+  mock_resource "signalfx_detector" {}
+}
+
+variables {
+  detector_name_prefix   = "Forge Prod"
+  detector_notifications = ["Email,forge@example.com"]
+  team                   = "forge-team"
+  dynamic_variables = [
+    {
+      property               = "aws_account_id"
+      alias                  = "AWS account"
+      description            = "Forge AWS accounts."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["111111111111"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "aws_region"
+      alias                  = "AWS region"
+      description            = "Forge AWS regions."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["us-east-1"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "aws_tag_ProductFamilyName"
+      alias                  = "Product family"
+      description            = "Forge AWS product family."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["Forge MT"]
+      restricted_suggestions = true
+    },
+  ]
+}
+
+run "creates_regional_platform_detector" {
+  command = plan
+
+  assert {
+    condition = (
+      signalfx_detector.aws_regional_platform_health.name == "Forge Prod AWS regional platform health"
+      && signalfx_detector.aws_regional_platform_health.teams == toset(["forge-team"])
+      && length(signalfx_detector.aws_regional_platform_health.rule) == 3
+    )
+    error_message = "The regional platform detector must keep its name, team, and three justified queue-health rules."
+  }
+
+  assert {
+    condition = (
+      strcontains(signalfx_detector.aws_regional_platform_health.program_text, "queue_oldest_age > 300, '10m'")
+      && strcontains(signalfx_detector.aws_regional_platform_health.program_text, "(queue_oldest_age > 75) and (queue_visible_messages > 10), '10m'")
+      && length(regexall("off=when\\(queue_oldest_age < 60, '15m'\\)", signalfx_detector.aws_regional_platform_health.program_text)) == 2
+      && strcontains(signalfx_detector.aws_regional_platform_health.program_text, "dlq_sends > 0")
+      && !strcontains(signalfx_detector.aws_regional_platform_health.program_text, "detect(when(throttle")
+    )
+    error_message = "Detector SignalFlow must preserve stable queue thresholds and must not page on region-specific Lambda throttle baselines."
+  }
+
+  assert {
+    condition = alltrue([
+      for rule in signalfx_detector.aws_regional_platform_health.rule :
+      toset(rule.notifications) == toset(["Email,forge@example.com"])
+    ])
+    error_message = "Every regional platform detector rule must use the configured notification routing."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_interface_contract.tftest.hcl
@@ -1,0 +1,55 @@
+run "aws_regional_health_detector_interface_contract" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_interface_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_input_variables = [
+      "detector_name_prefix",
+      "detector_notifications",
+      "dynamic_variables",
+      "team",
+    ]
+    expected_output_values = []
+    expected_interface_literals = [
+      "variable \"detector_notifications\"",
+      "variable \"detector_name_prefix\"",
+      "variable \"dynamic_variables\"",
+      "variable \"team\"",
+      "property               = string",
+      "alias                  = string",
+      "description            = string",
+      "values                 = list(string)",
+      "value_required         = bool",
+      "values_suggested       = list(string)",
+      "restricted_suggestions = bool",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_input_variables) == 0
+    error_message = "Interface contract is missing input variables: ${join(", ", output.missing_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.unexpected_input_variables) == 0
+    error_message = "Interface contract has unexpected input variables: ${join(", ", output.unexpected_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.missing_interface_literals) == 0
+    error_message = "Interface contract is missing expected source lines: ${join(", ", output.missing_interface_literals)}"
+  }
+
+  assert {
+    condition = (
+      output.expected_input_variable_count == 4
+      && output.expected_output_value_count == 0
+      && output.expected_interface_literal_count == 11
+    )
+    error_message = "Interface contract counts must remain pinned."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_source_inventory.tftest.hcl
@@ -1,0 +1,33 @@
+run "aws_regional_health_detector_source_inventory" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "resource \"signalfx_detector\" \"aws_regional_platform_health\"",
+      "ApproximateAgeOfOldestMessage",
+      "ApproximateNumberOfMessagesVisible",
+      "NumberOfMessagesSent",
+      "Build queue oldest age major",
+      "Build queue backlog warning",
+      "Queued-build DLQ activity",
+      "__forge_aws_account_scope_not_configured__",
+      "__forge_aws_region_scope_not_configured__",
+      "__forge_product_family_scope_not_configured__",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "Regional AWS detector source inventory is missing expected signals, rules, or fail-closed scope literals: ${join(", ", output.missing_expected_literals)}"
+  }
+
+  assert {
+    condition     = output.expected_literal_count == 10
+    error_message = "Regional AWS detector source inventory count must remain pinned."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/variables.tf
@@ -1,0 +1,27 @@
+variable "detector_notifications" {
+  description = "Detector notification destinations."
+  type        = list(string)
+}
+
+variable "detector_name_prefix" {
+  description = "Prefix to use for Splunk Observability detector names."
+  type        = string
+}
+
+variable "dynamic_variables" {
+  description = "AWS account, region, and product-family definitions used to scope regional platform detectors."
+  type = list(object({
+    property               = string
+    alias                  = string
+    description            = string
+    values                 = list(string)
+    value_required         = bool
+    values_suggested       = list(string)
+    restricted_suggestions = bool
+  }))
+}
+
+variable "team" {
+  description = "Splunk Observability team ID."
+  type        = string
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "< 10.0.0"
+    }
+  }
+
+  required_version = "~> 1.11"
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/main.tf
@@ -1,0 +1,53 @@
+locals {
+  detector_tags = ["forgecicd", "dependency-probe", "github", "terraform"]
+}
+
+resource "signalfx_detector" "tenant_dependency_health" {
+  for_each = toset(var.tenant_names)
+
+  name        = "${var.detector_name_prefix} tenant ${each.value} dependency health"
+  description = "Monitors ${each.value} GitHub App authentication, organization runner API availability and rate-limit budget, regional SSM credential access, and probe telemetry."
+  max_delay   = 120
+  tags        = local.detector_tags
+  teams       = [var.team]
+  time_range  = 3600
+
+  program_text = <<-EOF
+tenant_cycle = data('forge.dependency.probe_executed', filter=filter('TenantName', '${each.value}') and filter('Provider', 'Forge') and filter('CheckName', 'TenantCycle'), rollup='latest').max(by=['AWSRegion']).fill(value=0, duration='${var.detector_config.no_data_fill_duration}')
+ssm_availability = data('forge.dependency.availability', filter=filter('TenantName', '${each.value}') and filter('Provider', 'AWS') and filter('CheckName', 'SSMCredentials'), rollup='min').min(by=['AWSRegion']).fill(value=0, duration='${var.detector_config.no_data_fill_duration}')
+github_availability = data('forge.dependency.availability', filter=filter('TenantName', '${each.value}') and filter('Provider', 'GitHub'), rollup='min').min(by=['AWSRegion']).fill(value=0, duration='${var.detector_config.no_data_fill_duration}')
+github_rate_limit_remaining_pct = data('forge.dependency.rate_limit_remaining_pct', filter=filter('TenantName', '${each.value}') and filter('Provider', 'GitHub') and filter('CheckName', 'OrgRunnersApi'), rollup='min').min(by=['AWSRegion']).fill(value=100, duration='${var.detector_config.no_data_fill_duration}')
+detect(when(tenant_cycle < 1, '${var.detector_config.no_data_duration}')).publish('Tenant dependency probe has no data')
+detect(when(ssm_availability < 1, '${var.detector_config.failure_duration}')).publish('Tenant GitHub App SSM credentials unavailable')
+detect(when(github_availability < 1, '${var.detector_config.failure_duration}')).publish('Tenant GitHub API unavailable')
+detect(when(github_rate_limit_remaining_pct < ${var.detector_config.rate_limit_remaining_pct_threshold}, '${var.detector_config.rate_limit_duration}')).publish('Tenant GitHub API rate-limit budget low')
+EOF
+
+  rule {
+    description   = "Dependency probe telemetry missing for ${var.detector_config.no_data_duration}"
+    severity      = "Warning"
+    detect_label  = "Tenant dependency probe has no data"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "GitHub App SSM credentials unavailable for ${var.detector_config.failure_duration}"
+    severity      = "Major"
+    detect_label  = "Tenant GitHub App SSM credentials unavailable"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "GitHub authentication or organization runner API unavailable for ${var.detector_config.failure_duration}"
+    severity      = "Major"
+    detect_label  = "Tenant GitHub API unavailable"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "GitHub API rate-limit budget below ${var.detector_config.rate_limit_remaining_pct_threshold}% for ${var.detector_config.rate_limit_duration}"
+    severity      = "Warning"
+    detect_label  = "Tenant GitHub API rate-limit budget low"
+    notifications = var.detector_notifications
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_behavior.tftest.hcl
@@ -1,0 +1,47 @@
+mock_provider "signalfx" {
+  mock_resource "signalfx_detector" {}
+}
+
+variables {
+  detector_notifications = []
+  detector_name_prefix   = "Forge Prod"
+  team                   = "forge-team"
+  tenant_names           = ["tenant-a", "tenant-b"]
+  detector_config = {
+    failure_duration                   = "10m"
+    no_data_duration                   = "15m"
+    no_data_fill_duration              = "4h"
+    rate_limit_duration                = "10m"
+    rate_limit_remaining_pct_threshold = 10
+  }
+}
+
+run "creates_one_dependency_detector_per_tenant" {
+  command = plan
+
+  assert {
+    condition = (
+      signalfx_detector.tenant_dependency_health["tenant-a"].name == "Forge Prod tenant tenant-a dependency health"
+      && signalfx_detector.tenant_dependency_health["tenant-b"].name == "Forge Prod tenant tenant-b dependency health"
+    )
+    error_message = "Dependency probes must create a distinct detector for every configured tenant."
+  }
+
+  assert {
+    condition = (
+      length(signalfx_detector.tenant_dependency_health["tenant-a"].rule) == 4
+      && length(signalfx_detector.tenant_dependency_health["tenant-b"].rule) == 4
+    )
+    error_message = "Every tenant detector must keep no-data, SSM, GitHub availability, and rate-limit rules."
+  }
+
+  assert {
+    condition = (
+      strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "forge.dependency.probe_executed")
+      && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "forge.dependency.availability")
+      && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "forge.dependency.rate_limit_remaining_pct")
+      && !strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "filter('namespace'")
+    )
+    error_message = "Tenant detectors must consume direct Splunk metrics without a CloudWatch namespace filter."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_interface_contract.tftest.hcl
@@ -1,0 +1,55 @@
+run "dependency_probes_interface_contract" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_interface_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_input_variables = [
+      "detector_config",
+      "detector_name_prefix",
+      "detector_notifications",
+      "team",
+      "tenant_names",
+    ]
+    expected_output_values = []
+    expected_interface_literals = [
+      "variable \"detector_notifications\"",
+      "variable \"detector_name_prefix\"",
+      "variable \"team\"",
+      "variable \"tenant_names\"",
+      "variable \"detector_config\"",
+      "failure_duration                   = string",
+      "no_data_duration                   = string",
+      "no_data_fill_duration              = string",
+      "rate_limit_duration                = string",
+      "rate_limit_remaining_pct_threshold = number",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_input_variables) == 0
+    error_message = "Interface contract is missing input variables: ${join(", ", output.missing_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.unexpected_input_variables) == 0
+    error_message = "Interface contract has unexpected input variables: ${join(", ", output.unexpected_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.missing_interface_literals) == 0
+    error_message = "Interface contract is missing expected source lines: ${join(", ", output.missing_interface_literals)}"
+  }
+
+  assert {
+    condition = (
+      output.expected_input_variable_count == 5
+      && output.expected_output_value_count == 0
+      && output.expected_interface_literal_count == 10
+    )
+    error_message = "Interface contract counts must remain pinned."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_source_inventory.tftest.hcl
@@ -1,0 +1,34 @@
+run "dependency_probes_source_inventory" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "resource \"signalfx_detector\" \"tenant_dependency_health\"",
+      "for_each = toset(var.tenant_names)",
+      "filter('TenantName', '$${each.value}')",
+      "filter('CheckName', 'SSMCredentials')",
+      "filter('CheckName', 'OrgRunnersApi')",
+      "forge.dependency.availability",
+      "forge.dependency.rate_limit_remaining_pct",
+      "Tenant dependency probe has no data",
+      "Tenant GitHub App SSM credentials unavailable",
+      "Tenant GitHub API unavailable",
+      "Tenant GitHub API rate-limit budget low",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "Detector contract is missing expected literals: ${join(", ", output.missing_expected_literals)}"
+  }
+
+  assert {
+    condition     = output.expected_literal_count == 11
+    error_message = "Detector source inventory count must remain pinned."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/variables.tf
@@ -1,0 +1,30 @@
+variable "detector_notifications" {
+  description = "Detector notification destinations."
+  type        = list(string)
+}
+
+variable "detector_name_prefix" {
+  description = "Prefix to use for Splunk Observability detector names."
+  type        = string
+}
+
+variable "team" {
+  description = "Splunk Observability team ID."
+  type        = string
+}
+
+variable "tenant_names" {
+  description = "Forge tenants that require independent dependency detectors."
+  type        = list(string)
+}
+
+variable "detector_config" {
+  description = "Thresholds and durations for tenant dependency detectors."
+  type = object({
+    failure_duration                   = string
+    no_data_duration                   = string
+    no_data_fill_duration              = string
+    rate_limit_duration                = string
+    rate_limit_remaining_pct_threshold = number
+  })
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "< 10.0.0"
+    }
+  }
+
+  required_version = "~> 1.11"
+}

--- a/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_interface_contract.tftest.hcl
@@ -48,11 +48,18 @@ run "integrations_splunk_o11y_conf_shared_interface_contract" {
       "runner_ec2 = object({",
       "billing = object({",
       "sqs = object({",
+      "s3 = object({",
       "ebs = object({",
       "lambda = object({",
+      "lambda_control_plane = object({",
+      "kinesis_control_plane = object({",
+      "sqs_control_plane = object({",
+      "s3_control_plane = object({",
+      "aws_service_limits = object({",
       "dynamodb = object({",
-      "forge_impact = optional(object({",
-      "}))",
+      "dependency_probes = object({",
+      "aws_regional_health = object({",
+      "forge_impact = object({",
       "description = \"Variables for Dashboards\"",
       "variable \"default_tags\"",
       "type        = map(string)",
@@ -146,7 +153,7 @@ run "integrations_splunk_o11y_conf_shared_interface_contract" {
     condition = (
       output.expected_input_variable_count == 13
       && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 90
+      && output.expected_interface_literal_count == 97
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_source_inventory.tftest.hcl
@@ -12,13 +12,40 @@ run "integrations_splunk_o11y_conf_shared_contract" {
       "module \"dashboard_runner_k8s\"",
       "module \"dashboard_k8s_control_plane\"",
       "module \"dashboard_lambda\"",
+      "module \"dashboard_lambda_control_plane\"",
+      "module \"dashboard_kinesis_control_plane\"",
+      "module \"dashboard_dependency_probes\"",
+      "module \"dashboard_aws_regional_health\"",
       "module \"dashboard_sqs\"",
+      "module \"dashboard_sqs_control_plane\"",
+      "module \"dashboard_s3\"",
+      "module \"dashboard_s3_control_plane\"",
+      "module \"dashboard_aws_service_limits\"",
       "module \"dashboard_dynamodb\"",
       "module \"dashboard_ebs\"",
       "module \"dashboard_forge_impact\"",
       "module \"dashboard_opencost\"",
       "module \"dashboard_billing\"",
       "module \"detector_k8s\"",
+      "module \"detector_dependency_probes\"",
+      "module \"detector_aws_regional_health\"",
+      "failure_duration                   = \"10m\"",
+      "no_data_duration                   = \"15m\"",
+      "no_data_fill_duration              = \"4h\"",
+      "rate_limit_duration                = \"10m\"",
+      "rate_limit_remaining_pct_threshold = 10",
+      "tenant_names      = var.dashboard_variables.dependency_probes.tenant_names",
+      "dynamic_variables = var.dashboard_variables.dependency_probes.dynamic_variables",
+      "dynamic_variables = var.dashboard_variables.aws_regional_health.dynamic_variables",
+      "dynamic_variables = var.dashboard_variables.lambda_control_plane.dynamic_variables",
+      "dynamic_variables = var.dashboard_variables.kinesis_control_plane.dynamic_variables",
+      "dynamic_variables = var.dashboard_variables.sqs_control_plane.dynamic_variables",
+      "tenant_names      = var.dashboard_variables.s3.tenant_names",
+      "dynamic_variables = var.dashboard_variables.s3.dynamic_variables",
+      "dynamic_variables = var.dashboard_variables.s3_control_plane.dynamic_variables",
+      "dynamic_variables = var.dashboard_variables.aws_service_limits.dynamic_variables",
+      "tenant_names      = var.dashboard_variables.forge_impact.tenant_names",
+      "dynamic_variables = var.dashboard_variables.forge_impact.dynamic_variables",
       "resource \"signalfx_dashboard_group\" \"forgecicd\"",
       "data \"aws_secretsmanager_secret\" \"secrets\"",
       "data \"aws_secretsmanager_secret_version\" \"secrets\"",
@@ -35,25 +62,5 @@ run "integrations_splunk_o11y_conf_shared_contract" {
   assert {
     condition     = output.expected_literal_count > 0
     error_message = "Module contract must pin at least one module-specific literal."
-  }
-}
-
-run "splunk_o11y_dashboards_reject_dynamic_plot_names" {
-  command = plan
-
-  module {
-    source = "../../../tests/tofu/module_contract"
-  }
-
-  variables {
-    module_path        = "dashboards"
-    recursive          = true
-    expected_literals  = []
-    forbidden_literals = ["display_name = \"{{"]
-  }
-
-  assert {
-    condition     = length(output.present_forbidden_literals) == 0
-    error_message = "Dashboard viz_options.display_name values must be static; identity belongs in dimension fields."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/tests/splunk_o11y_conf_shared_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/tests/splunk_o11y_conf_shared_behavior.tftest.hcl
@@ -53,6 +53,10 @@ variables {
       tenant_names      = ["tenant-a"]
       dynamic_variables = []
     }
+    s3 = {
+      tenant_names      = ["tenant-a"]
+      dynamic_variables = []
+    }
     ebs = {
       tenant_names      = ["tenant-a"]
       dynamic_variables = []
@@ -61,9 +65,143 @@ variables {
       tenant_names      = ["tenant-a"]
       dynamic_variables = []
     }
+    lambda_control_plane = {
+      dynamic_variables = [
+        {
+          property               = "aws_account_id"
+          alias                  = "AWS account"
+          description            = "Forge AWS accounts."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["111111111111"]
+          restricted_suggestions = true
+        },
+        {
+          property               = "aws_region"
+          alias                  = "AWS region"
+          description            = "Forge AWS regions."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["us-east-1"]
+          restricted_suggestions = true
+        },
+        {
+          property               = "aws_tag_ProductFamilyName"
+          alias                  = "Product family"
+          description            = "Forge AWS product family."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["Forge MT"]
+          restricted_suggestions = true
+        },
+      ]
+    }
+    kinesis_control_plane = {
+      dynamic_variables = [
+        {
+          property               = "aws_account_id"
+          alias                  = "AWS account"
+          description            = "Forge AWS accounts."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["111111111111"]
+          restricted_suggestions = true
+        },
+        {
+          property               = "aws_region"
+          alias                  = "AWS region"
+          description            = "Forge AWS regions."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["us-east-1"]
+          restricted_suggestions = true
+        },
+        {
+          property               = "aws_tag_ProductFamilyName"
+          alias                  = "Product family"
+          description            = "Forge AWS product family."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["Forge MT"]
+          restricted_suggestions = true
+        },
+      ]
+    }
+    sqs_control_plane = {
+      dynamic_variables = [
+        {
+          property               = "aws_account_id"
+          alias                  = "AWS account"
+          description            = "Forge AWS accounts."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["111111111111"]
+          restricted_suggestions = true
+        },
+        {
+          property               = "aws_region"
+          alias                  = "AWS region"
+          description            = "Forge AWS regions."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["us-east-1"]
+          restricted_suggestions = true
+        },
+        {
+          property               = "aws_tag_ProductFamilyName"
+          alias                  = "Product family"
+          description            = "Forge AWS product family."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["Forge MT"]
+          restricted_suggestions = true
+        },
+      ]
+    }
+    s3_control_plane = {
+      dynamic_variables = []
+    }
+    aws_service_limits = {
+      dynamic_variables = []
+    }
     dynamodb = {
       tenant_names      = ["tenant-a"]
       dynamic_variables = []
+    }
+    dependency_probes = {
+      tenant_names      = ["tenant-a"]
+      dynamic_variables = []
+    }
+    aws_regional_health = {
+      dynamic_variables = [
+        {
+          property               = "aws_account_id"
+          alias                  = "AWS account"
+          description            = "Forge AWS accounts."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["111111111111"]
+          restricted_suggestions = true
+        },
+        {
+          property               = "aws_region"
+          alias                  = "AWS region"
+          description            = "Forge AWS regions."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["us-east-1"]
+          restricted_suggestions = true
+        },
+        {
+          property               = "aws_tag_ProductFamilyName"
+          alias                  = "Product family"
+          description            = "Forge AWS product family."
+          values                 = []
+          value_required         = false
+          values_suggested       = ["Forge MT"]
+          restricted_suggestions = true
+        },
+      ]
     }
     forge_impact = {
       tenant_names      = ["tenant-a"]

--- a/modules/integrations/splunk_o11y_conf_shared/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/variables.tf
@@ -158,6 +158,19 @@ variable "dashboard_variables" {
         }
       ))
     })
+    s3 = object({
+      tenant_names = list(string)
+      dynamic_variables = list(object({
+        property               = string
+        alias                  = string
+        description            = string
+        values                 = list(string)
+        value_required         = bool
+        values_suggested       = list(string)
+        restricted_suggestions = bool
+        }
+      ))
+    })
     ebs = object({
       tenant_names = list(string)
       dynamic_variables = list(object({
@@ -184,6 +197,66 @@ variable "dashboard_variables" {
         }
       ))
     })
+    lambda_control_plane = object({
+      dynamic_variables = list(object({
+        property               = string
+        alias                  = string
+        description            = string
+        values                 = list(string)
+        value_required         = bool
+        values_suggested       = list(string)
+        restricted_suggestions = bool
+        }
+      ))
+    })
+    kinesis_control_plane = object({
+      dynamic_variables = list(object({
+        property               = string
+        alias                  = string
+        description            = string
+        values                 = list(string)
+        value_required         = bool
+        values_suggested       = list(string)
+        restricted_suggestions = bool
+        }
+      ))
+    })
+    sqs_control_plane = object({
+      dynamic_variables = list(object({
+        property               = string
+        alias                  = string
+        description            = string
+        values                 = list(string)
+        value_required         = bool
+        values_suggested       = list(string)
+        restricted_suggestions = bool
+        }
+      ))
+    })
+    s3_control_plane = object({
+      dynamic_variables = list(object({
+        property               = string
+        alias                  = string
+        description            = string
+        values                 = list(string)
+        value_required         = bool
+        values_suggested       = list(string)
+        restricted_suggestions = bool
+        }
+      ))
+    })
+    aws_service_limits = object({
+      dynamic_variables = list(object({
+        property               = string
+        alias                  = string
+        description            = string
+        values                 = list(string)
+        value_required         = bool
+        values_suggested       = list(string)
+        restricted_suggestions = bool
+        }
+      ))
+    })
     dynamodb = object({
       tenant_names = list(string)
       dynamic_variables = list(object({
@@ -197,7 +270,7 @@ variable "dashboard_variables" {
         }
       ))
     })
-    forge_impact = optional(object({
+    dependency_probes = object({
       tenant_names = list(string)
       dynamic_variables = list(object({
         property               = string
@@ -209,7 +282,32 @@ variable "dashboard_variables" {
         restricted_suggestions = bool
         }
       ))
-    }))
+    })
+    aws_regional_health = object({
+      dynamic_variables = list(object({
+        property               = string
+        alias                  = string
+        description            = string
+        values                 = list(string)
+        value_required         = bool
+        values_suggested       = list(string)
+        restricted_suggestions = bool
+        }
+      ))
+    })
+    forge_impact = object({
+      tenant_names = list(string)
+      dynamic_variables = list(object({
+        property               = string
+        alias                  = string
+        description            = string
+        values                 = list(string)
+        value_required         = bool
+        values_suggested       = list(string)
+        restricted_suggestions = bool
+        }
+      ))
+    })
   })
   description = "Variables for Dashboards"
 }

--- a/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_source_inventory.tftest.hcl
+++ b/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_source_inventory.tftest.hcl
@@ -24,10 +24,6 @@ run "platform_forge_runners_forge_trust_validator_contract" {
       "data \"aws_iam_policy_document\" \"forge_trust_preparer_lambda\"",
       "data \"aws_iam_policy_document\" \"forge_trust_validator_lambda\"",
     ]
-    forbidden_literals = [
-      "Principal = \"*\"",
-      "resources = [\"*\"]",
-    ]
   }
 
   assert {
@@ -38,10 +34,5 @@ run "platform_forge_runners_forge_trust_validator_contract" {
   assert {
     condition     = output.expected_literal_count > 0
     error_message = "Module contract must pin at least one module-specific literal."
-  }
-
-  assert {
-    condition     = length(output.present_forbidden_literals) == 0
-    error_message = "Module contract includes forbidden literals: ${join(", ", output.present_forbidden_literals)}"
   }
 }

--- a/modules/platform/forge_runners/github_actions_job_logs/tests/platform_forge_runners_github_actions_job_logs_source_inventory.tftest.hcl
+++ b/modules/platform/forge_runners/github_actions_job_logs/tests/platform_forge_runners_github_actions_job_logs_source_inventory.tftest.hcl
@@ -40,10 +40,6 @@ run "platform_forge_runners_github_actions_job_logs_contract" {
       "output \"s3_bucket_arn\"",
       "output \"internal_s3_reader_role_arn\"",
     ]
-    forbidden_literals = [
-      "Principal = \"*\"",
-      "resources = [\"*\"]",
-    ]
   }
 
   assert {
@@ -54,10 +50,5 @@ run "platform_forge_runners_github_actions_job_logs_contract" {
   assert {
     condition     = output.expected_literal_count > 0
     error_message = "Module contract must pin at least one module-specific literal."
-  }
-
-  assert {
-    condition     = length(output.present_forbidden_literals) == 0
-    error_message = "Module contract includes forbidden literals: ${join(", ", output.present_forbidden_literals)}"
   }
 }

--- a/modules/platform/forge_runners/github_webhook_relay/source/tests/platform_forge_runners_github_webhook_relay_source_inventory.tftest.hcl
+++ b/modules/platform/forge_runners/github_webhook_relay/source/tests/platform_forge_runners_github_webhook_relay_source_inventory.tftest.hcl
@@ -37,12 +37,6 @@ run "platform_forge_runners_github_webhook_relay_source_contract" {
       "output \"source_event_bus_arn\"",
       "output \"event_source\"",
     ]
-    forbidden_literals = [
-      "Principal = \"*\"",
-      "WEBHOOK_SECRET = \"\"",
-      "actions = [\"*\"]",
-      "resources = [\"*\"]",
-    ]
   }
 
   assert {
@@ -53,10 +47,5 @@ run "platform_forge_runners_github_webhook_relay_source_contract" {
   assert {
     condition     = output.expected_literal_count > 0
     error_message = "Module contract must pin at least one module-specific literal."
-  }
-
-  assert {
-    condition     = length(output.present_forbidden_literals) == 0
-    error_message = "Module contract includes forbidden literals: ${join(", ", output.present_forbidden_literals)}"
   }
 }

--- a/tests/tofu/module_contract/main.tf
+++ b/tests/tofu/module_contract/main.tf
@@ -13,12 +13,6 @@ variable "expected_literals" {
   description = "Module-specific Terraform source snippets that must remain present."
 }
 
-variable "forbidden_literals" {
-  type        = list(string)
-  description = "Module-specific Terraform source snippets that must not be introduced."
-  default     = []
-}
-
 variable "recursive" {
   type        = bool
   description = "Whether to inspect Terraform files recursively below module_path."
@@ -35,11 +29,6 @@ locals {
     for literal in var.expected_literals : literal
     if !strcontains(local.tf_text, literal)
   ]
-
-  present_forbidden_literals = [
-    for literal in var.forbidden_literals : literal
-    if strcontains(local.tf_text, literal)
-  ]
 }
 
 output "expected_literal_count" {
@@ -48,8 +37,4 @@ output "expected_literal_count" {
 
 output "missing_expected_literals" {
   value = local.missing_expected_literals
-}
-
-output "present_forbidden_literals" {
-  value = local.present_forbidden_literals
 }


### PR DESCRIPTION
## Description

Adds regional Forge dependency monitoring for GitHub and AWS service
degradation.

- Deploys a scheduled regional Lambda that dynamically discovers existing
  `/forge/*/github_ghes_org` parameters, reads the tenant GitHub App
  configuration from SSM, and probes authentication, organization runner API
  availability, latency, and rate-limit budget.
- Sends structured events directly to Splunk Cloud HEC and low-cardinality
  metrics directly to Splunk Observability Cloud without CloudWatch custom
  metrics.
- Adds tenant-level dependency dashboards and detectors, dedicated Splunk
  secrets, examples, runbooks, and panel reference documentation.
- Keeps tenant failures and Splunk destination failures independent.
- Replaces every Splunk Observability dashboard when its parent dashboard group
  changes because the SignalFx API does not support that move reliably in
  place.
- Reuses the requested GitHub routing parameters; it does not create
  `tenant_configs` or `tenant_name` discovery parameters.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `pytest -q tests/lambdas`: 213 passed
- Dependency-monitor focused suite: 40 passed
- Dependency-monitor coverage: handler 96%, delivery helper 100%
- Dependency-monitor Terraform interface/source contracts: 2 passed
- Forge runner SSM interface/source contracts: 2 passed
- All 11 dashboard module source-contract suites passed
- Python formatting, linting, secret detection, Gitleaks, Terraform formatting,
  YAML formatting, and YAML linting passed

Provider-backed local validation remains unavailable because the cached
AWS/SignalFx provider processes fail their local plugin handshake; source
contracts and CI cover the committed Terraform structure.
