### PR TITLE
fix(lambdas): ignore terminal runner lifecycle errors

### DIFF
--- a/modules/platform/ec2_deployment/ec2_update_runner_tags/lambda/ec2_update_runner_tags.py
+++ b/modules/platform/ec2_deployment/ec2_update_runner_tags/lambda/ec2_update_runner_tags.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 import boto3
+from botocore.exceptions import ClientError
 
 LOG = logging.getLogger()
 level_str = os.environ.get('LOG_LEVEL', 'INFO').upper()
@@ -22,38 +23,65 @@ def lambda_handler(event, context):
             return {'statusCode': 200, 'body': json.dumps({'message': 'ignored event'})}
 
         detail = event.get('detail', {})
+        workflow_job = detail.get('workflow_job') or {}
 
-        runner_name = detail.get('workflow_job').get('runner_name')
+        runner_name = workflow_job.get('runner_name')
         if not runner_name:
-            LOG.error('runner_name missing in event detail: %s', detail)
-            raise ValueError('runner_name missing')
+            LOG.info(
+                'Ignoring workflow_job event without a runner_name: %s',
+                detail,
+            )
+            return {
+                'statusCode': 200,
+                'body': json.dumps({'message': 'ignored missing runner'}),
+            }
 
         if not (isinstance(runner_name, str) and runner_name.startswith('i-')):
             LOG.info(
                 'Runner name %s is not an EC2 instance ID, ignoring', runner_name)
             return {'statusCode': 200, 'body': json.dumps({'message': 'ignored non-EC2 runner'})}
 
-        LOG.info('Looking up EC2 instance by ID: %s', runner_name)
-        resp = ec2.describe_instances(InstanceIds=[runner_name])
-        instance_ids = [inst['InstanceId'] for res in resp.get(
-            'Reservations', []) for inst in res.get('Instances', [])]
+        try:
+            LOG.info('Looking up EC2 instance by ID: %s', runner_name)
+            resp = ec2.describe_instances(InstanceIds=[runner_name])
+            instance_ids = [inst['InstanceId'] for res in resp.get(
+                'Reservations', []) for inst in res.get('Instances', [])]
 
-        LOG.info('Described instances, found IDs: %s', instance_ids)
-        if not instance_ids:
-            LOG.info('No instances found with Name tag %s', runner_name)
-            return {'statusCode': 200, 'body': json.dumps({'message': 'no instances found'})}
+            LOG.info('Described instances, found IDs: %s', instance_ids)
+            if not instance_ids:
+                LOG.info('No instance found for runner %s', runner_name)
+                return {
+                    'statusCode': 200,
+                    'body': json.dumps({'message': 'no instance found'}),
+                }
 
-        job_url = detail.get('workflow_job', {}).get('html_url', '')
-        job_id = str(detail.get('workflow_job', {}).get('id', ''))
-        LOG.info('GitHub job URL: %s, job ID: %s', job_url, job_id)
+            job_url = workflow_job.get('html_url', '')
+            job_id = str(workflow_job.get('id', ''))
+            LOG.info('GitHub job URL: %s, job ID: %s', job_url, job_id)
 
-        # Tag instances with found flag and GitHub URLs
-        LOG.info(
-            'Tagging instances %s with tags job_url, job_id', instance_ids)
-        ec2.create_tags(Resources=instance_ids, Tags=[
-            {'Key': 'ghr:job_id', 'Value': job_id},
-            {'Key': 'ghr:job_url', 'Value': job_url}
-        ])
+            # Tag instances with found flag and GitHub URLs
+            LOG.info(
+                'Tagging instances %s with tags job_url, job_id', instance_ids)
+            ec2.create_tags(Resources=instance_ids, Tags=[
+                {'Key': 'ghr:job_id', 'Value': job_id},
+                {'Key': 'ghr:job_url', 'Value': job_url}
+            ])
+        except ClientError as error:
+            error_code = error.response.get('Error', {}).get('Code')
+            if error_code == 'InvalidInstanceID.NotFound':
+                LOG.info(
+                    'EC2 runner %s no longer exists; ignoring workflow_job '
+                    'event',
+                    runner_name,
+                )
+                return {
+                    'statusCode': 200,
+                    'body': json.dumps(
+                        {'message': 'ignored missing EC2 instance'}
+                    ),
+                }
+            raise
+
         LOG.info('Successfully tagged instances: %s', instance_ids)
         return {'statusCode': 200, 'body': json.dumps({'tagged_instances': instance_ids})}
     except Exception as e:

--- a/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
+++ b/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
@@ -22,12 +22,17 @@ S3 = boto3.client('s3')
 MAX_S3_TAGS = 10
 GITHUB_RETRY_ATTEMPTS = 3
 GITHUB_RETRY_DELAY = 2
+GITHUB_LOG_NOT_FOUND_RETRY_ATTEMPTS = 3
 METADATA_SUFFIX = '.fields'
 METADATA_TAG_KEY = 'metadata_key'
 MAX_METADATA_FIELDS = 500
 MAX_METADATA_LIST_ITEMS = 100
 MAX_METADATA_VALUE_LENGTH = 1024
 FIELD_NAME_RE = re.compile(r'[^A-Za-z0-9_]+')
+
+
+class JobLogsNotFound(RuntimeError):
+    """GitHub has no downloadable log archive for a completed job."""
 
 
 def _get_secret_value(parameter_name: str) -> str:
@@ -71,11 +76,22 @@ def _download_job_logs(owner: str, repo: str, job_id: int, token: str, api: str)
     headers = {'Authorization': f"token {token}",
                'Accept': 'application/vnd.github+json'}
 
-    r = _retry_request(requests.get, url=url, headers=headers, timeout=60)
-    if r.status_code == 404:
-        raise RuntimeError(f"Job logs not found (job_id={job_id})")
-    r.raise_for_status()
-    return r.content
+    for attempt in range(GITHUB_LOG_NOT_FOUND_RETRY_ATTEMPTS):
+        r = _retry_request(requests.get, url=url, headers=headers, timeout=60)
+        if r.status_code != 404:
+            r.raise_for_status()
+            return r.content
+        if attempt < GITHUB_LOG_NOT_FOUND_RETRY_ATTEMPTS - 1:
+            delay = GITHUB_RETRY_DELAY * (2 ** attempt)
+            LOG.warning(
+                'GitHub job logs are not available yet for job_id=%s; '
+                'retrying in %s seconds',
+                job_id,
+                delay,
+            )
+            time.sleep(delay)
+
+    raise JobLogsNotFound(f"Job logs not found (job_id={job_id})")
 
 
 def _serialize_tags(tags: Dict[str, str]) -> str:
@@ -279,9 +295,21 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:  # p
         run_attempt = workflow_job.get('run_attempt')
         workflow_name = workflow_job.get('workflow_name')
 
-        if not all([runner_name, run_id, job_id]):
-            LOG.info('Missing required IDs: runner_name=%s run_id=%s job_id=%s. Workflow job: %s',
-                     runner_name, run_id, job_id, workflow_job)
+        if not runner_name:
+            LOG.info(
+                'Workflow job has no runner, skipping log archival. '
+                'Workflow job: %s',
+                workflow_job,
+            )
+            return {'status': 'ignored', 'reason': 'missing_runner'}
+
+        if not all([run_id, job_id]):
+            LOG.info(
+                'Missing required IDs: run_id=%s job_id=%s. Workflow job: %s',
+                run_id,
+                job_id,
+                workflow_job,
+            )
             raise ValueError('missing_ids')
 
         try:
@@ -317,6 +345,20 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:  # p
                 'event_key': event_key,
                 'metadata_key': metadata_key,
                 'size': size
+            }
+        except JobLogsNotFound as e:
+            LOG.warning(
+                'Skipping log archival because GitHub has no logs for '
+                'job_id=%s run_id=%s after retries: %s',
+                job_id,
+                run_id,
+                e,
+            )
+            return {
+                'status': 'ignored',
+                'reason': 'job_logs_not_found',
+                'job_id': job_id,
+                'run_id': run_id,
             }
         except Exception as e:
             raise ValueError(

--- a/tests/lambdas/ec2_update_runner_tags_test.py
+++ b/tests/lambdas/ec2_update_runner_tags_test.py
@@ -6,6 +6,7 @@ import json
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from conftest import AWS_REGION, requires_aws
 from support import load_handler_module
 
@@ -43,11 +44,59 @@ def test_non_ec2_runner_name_is_ignored(monkeypatch, aws):
     assert json.loads(result['body']) == {'message': 'ignored non-EC2 runner'}
 
 
-def test_missing_runner_name_raises(monkeypatch, aws):
+def test_missing_runner_name_is_ignored(monkeypatch, aws):
     mod = load_handler_module('ec2_update_runner_tags')
 
-    with pytest.raises(ValueError, match='runner_name missing'):
-        mod.lambda_handler(_event(''), None)
+    result = mod.lambda_handler(_event(''), None)
+
+    assert result['statusCode'] == 200
+    assert json.loads(result['body']) == {
+        'message': 'ignored missing runner',
+    }
+
+
+def test_missing_ec2_instance_is_ignored(monkeypatch, aws):
+    mod = load_handler_module('ec2_update_runner_tags')
+
+    def _missing_instance(**_kwargs):
+        raise ClientError(
+            {
+                'Error': {
+                    'Code': 'InvalidInstanceID.NotFound',
+                    'Message': 'The instance ID does not exist',
+                },
+            },
+            'DescribeInstances',
+        )
+
+    monkeypatch.setattr(mod.ec2, 'describe_instances', _missing_instance)
+
+    result = mod.lambda_handler(_event('i-0123456789abcdef0'), None)
+
+    assert result['statusCode'] == 200
+    assert json.loads(result['body']) == {
+        'message': 'ignored missing EC2 instance',
+    }
+
+
+def test_unexpected_ec2_error_still_raises(monkeypatch, aws):
+    mod = load_handler_module('ec2_update_runner_tags')
+
+    def _access_denied(**_kwargs):
+        raise ClientError(
+            {
+                'Error': {
+                    'Code': 'UnauthorizedOperation',
+                    'Message': 'not authorized',
+                },
+            },
+            'DescribeInstances',
+        )
+
+    monkeypatch.setattr(mod.ec2, 'describe_instances', _access_denied)
+
+    with pytest.raises(ClientError):
+        mod.lambda_handler(_event('i-0123456789abcdef0'), None)
 
 
 def test_ec2_runner_instance_is_tagged_with_job_metadata(monkeypatch, aws):

--- a/tests/lambdas/job_log_archiver_test.py
+++ b/tests/lambdas/job_log_archiver_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 import json
+from types import SimpleNamespace
 
 import pytest
 from conftest import requires_aws
@@ -341,6 +342,78 @@ def test_skipped_jobs_are_not_archived(monkeypatch, s3_kms, ssm):
     evt['Records'][0]['body'] = json.dumps(body)
     result = mod.lambda_handler(evt, None)
     assert result == {'status': 'ignored'}
+    assert s3_kms['s3'].list_objects_v2(Bucket=alpha).get('Contents', []) == []
+
+
+def test_runnerless_jobs_are_not_archived(monkeypatch, s3_kms, ssm):
+    alpha = s3_kms['buckets']['alpha']
+    mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)
+    monkeypatch.setattr(
+        mod,
+        '_download_job_logs',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError('runnerless jobs must not call GitHub')
+        ),
+    )
+    evt = _completed_event()
+    body = json.loads(evt['Records'][0]['body'])
+    body['detail']['workflow_job']['runner_name'] = None
+    evt['Records'][0]['body'] = json.dumps(body)
+
+    result = mod.lambda_handler(evt, None)
+
+    assert result == {'status': 'ignored', 'reason': 'missing_runner'}
+    assert s3_kms['s3'].list_objects_v2(Bucket=alpha).get('Contents', []) == []
+
+
+def test_job_log_download_retries_404_before_marking_logs_unavailable(
+    monkeypatch, aws
+):
+    mod = load_handler_module('job_log_archiver')
+    responses = []
+    sleeps = []
+
+    def _not_found(**_kwargs):
+        responses.append(404)
+        return SimpleNamespace(status_code=404)
+
+    monkeypatch.setattr(mod.requests, 'get', _not_found)
+    monkeypatch.setattr(mod.time, 'sleep', sleeps.append)
+
+    with pytest.raises(mod.JobLogsNotFound, match='Job logs not found'):
+        mod._download_job_logs(
+            'acme',
+            'app',
+            4242,
+            'ghs_faketoken',
+            'https://api.github.test',
+        )
+
+    assert responses == [404, 404, 404]
+    assert sleeps == [2, 4]
+
+
+def test_missing_job_logs_are_terminal_after_retries(
+    monkeypatch, s3_kms, ssm
+):
+    alpha = s3_kms['buckets']['alpha']
+    mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)
+    monkeypatch.setattr(
+        mod,
+        '_download_job_logs',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            mod.JobLogsNotFound('Job logs not found (job_id=4242)')
+        ),
+    )
+
+    result = mod.lambda_handler(_completed_event(), None)
+
+    assert result == {
+        'status': 'ignored',
+        'reason': 'job_logs_not_found',
+        'job_id': 4242,
+        'run_id': 99,
+    }
     assert s3_kms['s3'].list_objects_v2(Bucket=alpha).get('Contents', []) == []
 
 


### PR DESCRIPTION
## Description

Treat expected runner lifecycle conditions as successful no-ops instead of
unhandled Lambda failures.

- Ignore `workflow_job` events that have no assigned runner in the EC2 tagger
  and job-log archiver.
- Ignore `InvalidInstanceID.NotFound` when an ephemeral EC2 runner terminates
  before its workflow-job tags are applied.
- Retry GitHub job-log `404` responses with exponential backoff, then stop
  redriving the message when GitHub has no downloadable archive.
- Preserve retries for unexpected EC2 errors, GitHub network and server errors,
  authentication failures, and S3/KMS failures.

Production log correlation showed these terminal lifecycle cases accounted for
nearly all Lambda errors in the affected dashboard window. Repeated redrives
could not recover runnerless jobs, terminated instances, or job-log archives
that remained unavailable.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `uv run --group lambda-tests pytest -q tests/lambdas tests/mutation/job_log_archiver_mutation_test.py`
  - 181 passed
- Repository pre-commit checks passed during commit.
