### PR TITLE
feat(splunk): add dependency monitor secrets

### DIFF
--- a/modules/integrations/splunk_secrets/main.tf
+++ b/modules/integrations/splunk_secrets/main.tf
@@ -58,6 +58,16 @@ locals {
       recovery_days = 7
     },
     {
+      name          = "${local.cicd_secrets_prefix}/splunk_o11y_ingest_token_dependency_monitor"
+      description   = "Splunk O11y ingest token for the Splunk dependency monitor"
+      recovery_days = 7
+    },
+    {
+      name          = "${local.cicd_secrets_prefix}/splunk_cloud_hec_token_dependency_monitor"
+      description   = "Splunk Cloud HEC token for the Splunk dependency monitor"
+      recovery_days = 7
+    },
+    {
       name          = "${local.cicd_secrets_prefix}/splunk_cloud_hec_token_s3_integration"
       description   = "Splunk Cloud HEC token for S3 Integration"
       recovery_days = 7

--- a/modules/integrations/splunk_secrets/tests/integrations_splunk_secrets_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_secrets/tests/integrations_splunk_secrets_source_inventory.tftest.hcl
@@ -14,6 +14,8 @@ run "integrations_splunk_secrets_contract" {
       "resource \"time_sleep\" \"wait_60_seconds\"",
       "resource \"aws_secretsmanager_secret_version\" \"cicd_secrets\"",
       "data \"aws_secretsmanager_random_password\" \"secret_seeds\"",
+      "splunk_o11y_ingest_token_dependency_monitor",
+      "splunk_cloud_hec_token_dependency_monitor",
       "provider \"aws\"",
     ]
   }


### PR DESCRIPTION
## Description

Adds dedicated AWS Secrets Manager entries for the dependency monitor's Splunk Observability Cloud ingest token and Splunk Cloud HEC token. The module creates the secret containers through the existing shared secret lifecycle without embedding token values in Terraform.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- `tofu test` in `modules/integrations/splunk_secrets` (2 passed)
- `pre-commit run --files` for both changed files
- Commit-time repository hooks
