### PR TITLE
feat(splunk): add regional dependency monitor

### DIFF
--- a/modules/integrations/splunk_dependency_monitor/backend.tf
+++ b/modules/integrations/splunk_dependency_monitor/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  # Intentionally empty. Re-use what's provided by the root module.
+  backend "s3" {}
+}

--- a/modules/integrations/splunk_dependency_monitor/lambda.tf
+++ b/modules/integrations/splunk_dependency_monitor/lambda.tf
@@ -1,0 +1,129 @@
+resource "aws_cloudwatch_log_group" "dependency_monitor" {
+  #checkov:skip=CKV_AWS_158:CloudWatch KMS encryption is deferred until the existing Forge log-delivery path supports customer-managed keys.
+  #checkov:skip=CKV_AWS_338:Retention is operator-configurable because the logs are exported to Splunk Cloud.
+  name              = "/aws/lambda/${local.dependency_monitor_function_name}"
+  retention_in_days = var.logging_retention_in_days
+  tags              = local.all_security_tags
+  tags_all          = local.all_security_tags
+}
+
+module "dependency_monitor" {
+  #checkov:skip=CKV_TF_1:Module source uses a Renovate-managed release tag.
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name = local.dependency_monitor_function_name
+  description   = "Probes tenant GitHub App authentication, organization runner API health, rate limits, and regional SSM access."
+  handler       = "handler.lambda_handler"
+  runtime       = "python3.12"
+  timeout       = 300
+  architectures = ["x86_64"]
+
+  source_path = [{
+    path = "${path.module}/lambda"
+  }]
+
+  layers = [
+    "arn:aws:lambda:${data.aws_region.current.region}:770693421928:layer:Klayers-p312-cryptography:17",
+    "arn:aws:lambda:${data.aws_region.current.region}:770693421928:layer:Klayers-p312-requests:17",
+    "arn:aws:lambda:${data.aws_region.current.region}:770693421928:layer:Klayers-p312-PyJWT:1",
+  ]
+
+  logging_log_group                 = aws_cloudwatch_log_group.dependency_monitor.name
+  use_existing_cloudwatch_log_group = true
+  trigger_on_package_timestamp      = false
+
+  environment_variables = {
+    GITHUB_API_VERSION          = var.github_api_version
+    GITHUB_TIMEOUT_SECONDS      = tostring(var.github_timeout_seconds)
+    LOG_LEVEL                   = var.log_level
+    SPLUNK_HEC_TOKEN            = data.aws_secretsmanager_secret_version.secrets["splunk_cloud_hec_token_dependency_monitor"].secret_string
+    SPLUNK_HEC_URL              = var.splunk_dependency_monitor_config.splunk_hec_url
+    SPLUNK_HTTP_TIMEOUT_SECONDS = tostring(var.splunk_http_timeout_seconds)
+    SPLUNK_INDEX                = var.splunk_dependency_monitor_config.splunk_index
+    SPLUNK_METRICS_TOKEN        = data.aws_secretsmanager_secret_version.secrets["splunk_o11y_ingest_token_dependency_monitor"].secret_string
+    SPLUNK_METRICS_URL          = var.splunk_dependency_monitor_config.splunk_metrics_url
+  }
+
+  attach_policy_json = true
+  policy_json        = data.aws_iam_policy_document.dependency_monitor.json
+
+  function_tags = local.all_security_tags
+  role_tags     = local.all_security_tags
+  tags          = local.all_security_tags
+
+  depends_on = [
+    aws_cloudwatch_log_group.dependency_monitor,
+  ]
+}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "dependency_monitor" {
+  statement {
+    sid       = "DiscoverRegionalForgeTenants"
+    effect    = "Allow"
+    actions   = ["ssm:DescribeParameters"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ReadTenantGitHubAppParameters"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameters",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/forge/*/github_app_key",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/forge/*/github_app_client_id",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/forge/*/github_app_id",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/forge/*/github_app_installation_id",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/forge/*/github_ghes_url",
+      "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/forge/*/github_ghes_org",
+    ]
+  }
+
+  statement {
+    sid       = "ReadTenantTags"
+    effect    = "Allow"
+    actions   = ["ssm:ListTagsForResource"]
+    resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/forge/*/github_ghes_org"]
+  }
+
+  statement {
+    sid       = "DecryptTenantGitHubAppParameters"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values   = ["ssm.${var.aws_region}.amazonaws.com"]
+    }
+  }
+
+}
+
+resource "aws_cloudwatch_event_rule" "dependency_monitor" {
+  name                = local.dependency_monitor_function_name
+  description         = "Runs regional Forge tenant dependency probes."
+  schedule_expression = var.schedule_expression
+  tags                = local.all_security_tags
+}
+
+resource "aws_cloudwatch_event_target" "dependency_monitor" {
+  rule      = aws_cloudwatch_event_rule.dependency_monitor.name
+  target_id = "splunk-dependency-monitor"
+  arn       = module.dependency_monitor.lambda_function_arn
+}
+
+resource "aws_lambda_permission" "eventbridge_invoke" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.dependency_monitor.lambda_function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.dependency_monitor.arn
+}

--- a/modules/integrations/splunk_dependency_monitor/lambda/common.py
+++ b/modules/integrations/splunk_dependency_monitor/lambda/common.py
@@ -1,0 +1,146 @@
+"""Splunk Cloud and Splunk Observability HTTP delivery helpers."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import os
+import time
+from typing import Any
+
+LOG = logging.getLogger()
+
+SPLUNK_HEC_TOKEN = os.environ.get('SPLUNK_HEC_TOKEN', '')
+SPLUNK_HEC_URL = os.environ.get('SPLUNK_HEC_URL', '')
+SPLUNK_INDEX = os.environ.get('SPLUNK_INDEX', '')
+SPLUNK_METRICS_TOKEN = os.environ.get('SPLUNK_METRICS_TOKEN', '')
+SPLUNK_METRICS_URL = os.environ.get('SPLUNK_METRICS_URL', '')
+SPLUNK_HTTP_TIMEOUT_SECONDS = int(
+    os.environ.get('SPLUNK_HTTP_TIMEOUT_SECONDS', '10')
+)
+
+
+def _safe_response_field(value: Any) -> str:
+    """Return a bounded single-line response field safe for diagnostics."""
+    return str(value).replace('\r', ' ').replace('\n', ' ')[:160]
+
+
+def _http_error(response: Any) -> RuntimeError:
+    """Build an HTTP error carrying only safe Splunk response metadata."""
+    response_code = ''
+    response_text = ''
+    response_json = getattr(response, 'json', None)
+    if callable(response_json):
+        try:
+            response_body = response_json()
+        except (TypeError, ValueError):
+            response_body = None
+        if isinstance(response_body, dict):
+            if 'code' in response_body:
+                response_code = _safe_response_field(response_body['code'])
+            if 'text' in response_body:
+                response_text = _safe_response_field(response_body['text'])
+
+    error = RuntimeError(
+        f"Splunk HTTP request failed with status {response.status_code}"
+    )
+    error.http_status = response.status_code
+    error.response_code = response_code
+    error.response_text = response_text
+    return error
+
+
+def delivery_error_context(error: Exception) -> dict[str, str]:
+    """Describe a delivery failure without exposing request credentials."""
+    cause = error.__cause__ or error
+    return {
+        'cause_type': type(cause).__name__,
+        'http_status': _safe_response_field(
+            getattr(cause, 'http_status', '-')
+        ),
+        'response_code': _safe_response_field(
+            getattr(cause, 'response_code', '-')
+        ) or '-',
+        'response_text': _safe_response_field(
+            getattr(cause, 'response_text', '-')
+        ) or '-',
+    }
+
+
+def _post_with_retries(
+    url: str,
+    *,
+    headers: dict[str, str],
+    data: bytes | None = None,
+    json_payload: dict[str, Any] | None = None,
+) -> None:
+    import requests
+
+    last_error: Exception | None = None
+    for attempt in range(3):
+        try:
+            response = requests.post(
+                url,
+                headers=headers,
+                data=data,
+                json=json_payload,
+                timeout=SPLUNK_HTTP_TIMEOUT_SECONDS,
+            )
+        except Exception as error:
+            last_error = error
+        else:
+            if 200 <= response.status_code < 300:
+                return
+            last_error = _http_error(response)
+            if response.status_code != 429 and response.status_code < 500:
+                break
+        if attempt < 2:
+            time.sleep(2**attempt)
+
+    raise RuntimeError(
+        'Splunk HTTP delivery failed after bounded retries'
+    ) from last_error
+
+
+def send_to_splunk_batch(events: list[dict[str, Any]]) -> int:
+    """Send newline-delimited, gzip-compressed events to Splunk Cloud HEC."""
+    if not events:
+        return 0
+    if not SPLUNK_HEC_URL or not SPLUNK_HEC_TOKEN or not SPLUNK_INDEX:
+        raise ValueError('Splunk Cloud HEC configuration is incomplete')
+
+    payload = '\n'.join(
+        json.dumps(event, separators=(',', ':'), sort_keys=True)
+        for event in events
+    )
+    _post_with_retries(
+        SPLUNK_HEC_URL,
+        headers={
+            'Authorization': f"Splunk {SPLUNK_HEC_TOKEN}",
+            'Content-Type': 'application/json',
+            'Content-Encoding': 'gzip',
+        },
+        data=gzip.compress(payload.encode('utf-8')),
+    )
+    return len(events)
+
+
+def send_metric_to_o11y_batch(metrics: list[dict[str, Any]]) -> int:
+    """Send gauge datapoints to the Splunk Observability ingest endpoint."""
+    if not metrics:
+        return 0
+    if not SPLUNK_METRICS_URL or not SPLUNK_METRICS_TOKEN:
+        raise ValueError(
+            'Splunk Observability ingest configuration is incomplete'
+        )
+
+    _post_with_retries(
+        SPLUNK_METRICS_URL,
+        headers={
+            'X-SF-TOKEN': SPLUNK_METRICS_TOKEN,
+            'Content-Type': 'application/json',
+        },
+        json_payload={'gauge': metrics},
+    )
+    return len(metrics)

--- a/modules/integrations/splunk_dependency_monitor/lambda/handler.py
+++ b/modules/integrations/splunk_dependency_monitor/lambda/handler.py
@@ -1,0 +1,761 @@
+"""Regional Splunk dependency monitor.
+
+The probe deliberately keeps tenant failures independent: one tenant's SSM,
+GitHub App, or organization API failure must not prevent the remaining tenants
+from being measured.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import time
+from typing import Any
+from urllib.parse import quote
+
+import boto3
+import common
+
+LOG = logging.getLogger()
+LOG.setLevel(
+    getattr(logging, os.environ.get('LOG_LEVEL', 'INFO').upper(), logging.INFO)
+)
+
+AWS_REGION = os.environ.get('AWS_REGION', '')
+GITHUB_API_VERSION = os.environ.get('GITHUB_API_VERSION', '2022-11-28')
+GITHUB_TIMEOUT_SECONDS = int(os.environ.get('GITHUB_TIMEOUT_SECONDS', '10'))
+TENANT_PARAMETER_ROOT = '/forge/'
+TENANT_PARAMETER_SUFFIX = '/github_ghes_org'
+
+queued_datapoints: list[dict[str, Any]] = []
+queued_events: list[dict[str, Any]] = []
+
+SPLUNK_METRIC_NAMES = {
+    'Availability': 'forge.dependency.availability',
+    'LatencyMs': 'forge.dependency.latency_ms',
+    'ProbeExecuted': 'forge.dependency.probe_executed',
+    'RateLimited': 'forge.dependency.rate_limited',
+    'RateLimitRemainingPct': 'forge.dependency.rate_limit_remaining_pct',
+}
+
+
+class ProbeFailure(RuntimeError):
+    """Expected dependency-probe failure with safe diagnostic metadata."""
+
+    def __init__(
+        self,
+        step: str,
+        message: str,
+        *,
+        status_code: int = 0,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.step = step
+        self.status_code = status_code
+        self.headers = headers or {}
+
+
+def aws_client(service_name: str) -> Any:
+    """Create an AWS client pinned to the Lambda deployment region."""
+    if not AWS_REGION:
+        raise ValueError('AWS_REGION is missing from the Lambda environment')
+    return boto3.client(service_name, region_name=AWS_REGION)
+
+
+def _normalize_parameter_value(value: str) -> str:
+    return value.strip().strip("'\"")
+
+
+def normalize_private_key(raw_key: str) -> Any:
+    """Accept Forge's PEM, base64 PEM, or base64 DER SSM representation."""
+
+    key_text = raw_key.replace('\\n', '\n').strip()
+    if 'BEGIN' in key_text:
+        return key_text
+
+    decoded = base64.b64decode(re.sub(r'\s+', '', key_text), validate=True)
+    if b'BEGIN' in decoded:
+        return decoded.decode('utf-8').replace('\\n', '\n').strip()
+
+    from cryptography.hazmat.primitives import serialization
+
+    return serialization.load_der_private_key(decoded, password=None)
+
+
+def create_github_app_jwt(issuer: str, private_key: Any) -> str:
+    import jwt
+
+    now = int(time.time())
+    token = jwt.encode(
+        {'iat': now - 60, 'exp': now + 540, 'iss': issuer},
+        private_key,
+        algorithm='RS256',
+    )
+    return token.decode('ascii') if isinstance(token, bytes) else token
+
+
+def discover_tenants() -> list[dict[str, Any]]:
+    """Discover regional Forge tenants from existing GitHub SSM parameters."""
+    LOG.info(
+        'tenant_discovery_started aws_region=%s parameter_root=%s '
+        'parameter_suffix=%s',
+        AWS_REGION,
+        TENANT_PARAMETER_ROOT,
+        TENANT_PARAMETER_SUFFIX,
+    )
+    ssm = aws_client('ssm')
+    paginator = ssm.get_paginator('describe_parameters')
+    parameter_names = []
+    for page_number, page in enumerate(
+        paginator.paginate(
+            ParameterFilters=[
+                {
+                    'Key': 'Name',
+                    'Option': 'BeginsWith',
+                    'Values': [TENANT_PARAMETER_ROOT],
+                }
+            ]
+        ),
+        start=1,
+    ):
+        described_parameters = page.get('Parameters', [])
+        matching_parameter_names = [
+            parameter['Name']
+            for parameter in described_parameters
+            if parameter.get('Name', '').endswith(TENANT_PARAMETER_SUFFIX)
+        ]
+        parameter_names.extend(matching_parameter_names)
+        LOG.info(
+            'tenant_discovery_page page=%s described=%s matched=%s',
+            page_number,
+            len(described_parameters),
+            len(matching_parameter_names),
+        )
+        LOG.debug(
+            'tenant_discovery_page_matches page=%s parameter_names=%s',
+            page_number,
+            matching_parameter_names,
+        )
+
+    parameter_names = sorted(set(parameter_names))
+    LOG.info(
+        'tenant_discovery_candidates count=%s',
+        len(parameter_names),
+    )
+    if not parameter_names:
+        LOG.warning(
+            'tenant_discovery_no_candidates aws_region=%s expected_pattern=%s*%s',
+            AWS_REGION,
+            TENANT_PARAMETER_ROOT,
+            TENANT_PARAMETER_SUFFIX,
+        )
+        return []
+
+    values_by_name = {}
+    invalid_parameters = []
+    for offset in range(0, len(parameter_names), 10):
+        requested_names = parameter_names[offset: offset + 10]
+        response = ssm.get_parameters(
+            Names=requested_names,
+            WithDecryption=False,
+        )
+        returned_parameters = response.get('Parameters', [])
+        values_by_name.update(
+            {
+                parameter['Name']: _normalize_parameter_value(
+                    parameter['Value']
+                )
+                for parameter in returned_parameters
+            }
+        )
+        batch_invalid_parameters = response.get('InvalidParameters', [])
+        invalid_parameters.extend(batch_invalid_parameters)
+        LOG.info(
+            'tenant_discovery_read requested=%s returned=%s invalid=%s',
+            len(requested_names),
+            len(returned_parameters),
+            len(batch_invalid_parameters),
+        )
+        LOG.debug(
+            'tenant_discovery_read_details requested_names=%s '
+            'invalid_names=%s',
+            requested_names,
+            batch_invalid_parameters,
+        )
+
+    if invalid_parameters:
+        raise ValueError(
+            'One or more Forge tenant discovery parameters are unavailable'
+        )
+
+    configs = []
+    for parameter_name in parameter_names:
+        match = re.fullmatch(
+            r'/forge/(?P<deployment_prefix>[^/]+)/github_ghes_org',
+            parameter_name,
+        )
+        github_org = values_by_name.get(parameter_name, '')
+        if match is None or not github_org:
+            raise ValueError('Forge tenant discovery metadata is invalid')
+
+        tag_response = ssm.list_tags_for_resource(
+            ResourceType='Parameter',
+            ResourceId=parameter_name,
+        )
+        parameter_tags = {
+            tag['Key']: tag['Value']
+            for tag in tag_response.get('TagList', [])
+        }
+        tenant_tag = parameter_tags.get('TenantName')
+        tenant = tenant_tag or github_org
+        LOG.info(
+            'tenant_discovery_resolved parameter_name=%s '
+            'deployment_prefix=%s tenant=%s tenant_source=%s tag_keys=%s',
+            parameter_name,
+            match.group('deployment_prefix'),
+            tenant,
+            'TenantName' if tenant_tag else 'github_ghes_org',
+            sorted(parameter_tags),
+        )
+        configs.append(
+            {
+                'tenant': tenant,
+                'aws_region': AWS_REGION,
+                'deployment_prefix': match.group('deployment_prefix'),
+                'github_api_version': GITHUB_API_VERSION,
+            }
+        )
+
+    LOG.info('tenant_discovery_complete tenants=%s', len(configs))
+    return configs
+
+
+def load_github_app_credentials(
+    ssm: Any, deployment_prefix: str
+) -> dict[str, Any]:
+    parameter_base = f"/forge/{deployment_prefix}"
+    parameter_names = {
+        'private_key': f"{parameter_base}/github_app_key",
+        'client_id': f"{parameter_base}/github_app_client_id",
+        'app_id': f"{parameter_base}/github_app_id",
+        'installation_id': (
+            f"{parameter_base}/github_app_installation_id"
+        ),
+        'ghes_url': f"{parameter_base}/github_ghes_url",
+        'ghes_org': f"{parameter_base}/github_ghes_org",
+    }
+    response = ssm.get_parameters(
+        Names=list(parameter_names.values()),
+        WithDecryption=True,
+    )
+    values_by_name = {
+        parameter['Name']: _normalize_parameter_value(parameter['Value'])
+        for parameter in response.get('Parameters', [])
+    }
+    invalid = set(response.get('InvalidParameters', []))
+    missing = [
+        name
+        for name in parameter_names.values()
+        if name not in values_by_name or name in invalid
+    ]
+    if missing:
+        raise ProbeFailure(
+            'ssm_credentials',
+            'One or more GitHub App SSM parameters are unavailable',
+        )
+
+    credentials = {
+        key: values_by_name[name] for key, name in parameter_names.items()
+    }
+    issuer = credentials['client_id'] or credentials['app_id']
+    if not issuer:
+        raise ProbeFailure(
+            'ssm_credentials',
+            'Neither GitHub App client ID nor app ID is configured',
+        )
+    if not credentials['installation_id'] or not credentials['ghes_org']:
+        raise ProbeFailure(
+            'ssm_credentials',
+            'GitHub App installation ID or organization is not configured',
+        )
+
+    ghes_url = credentials['ghes_url'].rstrip('/')
+    github_api_url = (
+        'https://api.github.com'
+        if ghes_url in ('', 'https://github.com')
+        else f"{ghes_url}/api/v3"
+    )
+
+    return {
+        'issuer': issuer,
+        'private_key': normalize_private_key(credentials['private_key']),
+        'installation_id': credentials['installation_id'],
+        'github_api_url': github_api_url,
+        'github_org': credentials['ghes_org'],
+    }
+
+
+def _lower_headers(headers: Any) -> dict[str, str]:
+    return {str(key).lower(): str(value) for key, value in headers.items()}
+
+
+def github_request(
+    method: str,
+    url: str,
+    *,
+    token: str,
+    api_version: str,
+    body: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, str], dict[str, Any]]:
+    import requests
+
+    headers = {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': f"Bearer {token}",
+        'Content-Type': 'application/json',
+        'User-Agent': 'splunk-dependency-monitor',
+    }
+    if api_version:
+        headers['X-GitHub-Api-Version'] = api_version
+
+    response = requests.request(
+        method,
+        url,
+        headers=headers,
+        json=body,
+        timeout=GITHUB_TIMEOUT_SECONDS,
+    )
+    try:
+        response_body = response.json()
+    except ValueError:
+        response_body = {}
+    return (
+        response.status_code,
+        _lower_headers(response.headers),
+        response_body,
+    )
+
+
+def get_installation_token(
+    config: dict[str, Any],
+    jwt_token: str,
+    installation_id: str,
+) -> tuple[str, int, dict[str, str]]:
+    url = (
+        f"{config['github_api_url'].rstrip('/')}/app/installations/"
+        f"{quote(str(installation_id), safe='')}/access_tokens"
+    )
+    started = time.monotonic()
+    status, headers, body = github_request(
+        'POST',
+        url,
+        token=jwt_token,
+        api_version=config['github_api_version'],
+    )
+    latency_ms = int((time.monotonic() - started) * 1000)
+    if status != 201 or not body.get('token'):
+        raise ProbeFailure(
+            'github_authentication',
+            'GitHub App installation-token request failed',
+            status_code=status,
+            headers=headers,
+        )
+    return str(body['token']), latency_ms, headers
+
+
+def check_organization_runner_api(
+    config: dict[str, Any],
+    installation_token: str,
+) -> tuple[int, int, dict[str, str]]:
+    organization = quote(config['github_org'], safe='')
+    url = (
+        f"{config['github_api_url'].rstrip('/')}/orgs/{organization}/"
+        'actions/runners?per_page=1'
+    )
+    started = time.monotonic()
+    status, headers, body = github_request(
+        'GET',
+        url,
+        token=installation_token,
+        api_version=config['github_api_version'],
+    )
+    latency_ms = int((time.monotonic() - started) * 1000)
+    if status != 200 or 'total_count' not in body:
+        raise ProbeFailure(
+            'github_org_runners_api',
+            'GitHub organization runners API probe failed',
+            status_code=status,
+            headers=headers,
+        )
+    return status, latency_ms, headers
+
+
+def _number_header(headers: dict[str, str], name: str, default: int = -1) -> int:
+    try:
+        return int(headers.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _rate_limit_metrics(headers: dict[str, str]) -> dict[str, float | int]:
+    limit = _number_header(headers, 'x-ratelimit-limit')
+    remaining = _number_header(headers, 'x-ratelimit-remaining')
+    used = _number_header(headers, 'x-ratelimit-used')
+    if limit <= 0 or remaining < 0:
+        return {}
+    remaining_pct = round((remaining / limit) * 100, 3)
+    return {
+        'RateLimit': limit,
+        'RateLimitRemaining': remaining,
+        'RateLimitUsed': used,
+        'RateLimitRemainingPct': remaining_pct,
+    }
+
+
+def _is_rate_limited(status_code: int, headers: dict[str, str]) -> int:
+    has_retry_after = headers.get('retry-after') is not None
+    remaining_exhausted = headers.get('x-ratelimit-remaining') == '0'
+    rate_limit_exhausted = has_retry_after or remaining_exhausted
+    return int(status_code in (403, 429) and rate_limit_exhausted)
+
+
+def _github_mode(config: dict[str, Any]) -> str:
+    github_api_url = config.get('github_api_url', '').rstrip('/')
+    if not github_api_url:
+        return 'unknown'
+    if github_api_url == 'https://api.github.com':
+        return 'saas'
+    return 'ghes'
+
+
+def queue_metrics(
+    config: dict[str, Any],
+    *,
+    provider: str,
+    check_name: str,
+    metrics: dict[str, float | int],
+) -> None:
+    """Queue bounded metric time series for one batched Splunk ingest request."""
+    dimensions = {
+        'TenantName': config['tenant'],
+        'AWSRegion': AWS_REGION,
+        'Provider': provider,
+        'CheckName': check_name,
+        'GitHubMode': _github_mode(config),
+    }
+    timestamp = int(time.time() * 1000)
+    for name, value in metrics.items():
+        metric_name = SPLUNK_METRIC_NAMES.get(name)
+        if metric_name is None:
+            continue
+        queued_datapoints.append(
+            {
+                'metric': metric_name,
+                'value': value,
+                'timestamp': timestamp,
+                'dimensions': dimensions,
+            }
+        )
+
+
+def _log_result(
+    config: dict[str, Any],
+    *,
+    provider: str,
+    check_name: str,
+    success: bool,
+    status_code: int = 0,
+    error_type: str = '',
+) -> None:
+    event = {
+        'forgecicd_log_type': 'dependency-probe',
+        'forgecicd_tenant': config['tenant'],
+        'aws_region': AWS_REGION,
+        'provider': provider,
+        'check_name': check_name,
+        'success': success,
+        'status_code': status_code,
+        'error_type': error_type,
+        'github_mode': _github_mode(config),
+    }
+    queued_events.append(
+        {
+            'source': 'splunk-dependency-monitor',
+            'sourcetype': 'forgecicd:dependency-probe:json',
+            'index': common.SPLUNK_INDEX,
+            'event': event,
+        }
+    )
+    LOG.info(json.dumps(event, separators=(',', ':'), sort_keys=True))
+
+
+def probe_tenant(config: dict[str, Any], ssm: Any) -> bool:
+    queue_metrics(
+        config,
+        provider='Forge',
+        check_name='TenantCycle',
+        metrics={'ProbeExecuted': 1},
+    )
+
+    try:
+        credentials_started = time.monotonic()
+        credentials = load_github_app_credentials(
+            ssm, config['deployment_prefix']
+        )
+        resolved_config = {
+            **config,
+            'github_api_url': credentials['github_api_url'],
+            'github_org': credentials['github_org'],
+        }
+        ssm_latency_ms = int((time.monotonic() - credentials_started) * 1000)
+        queue_metrics(
+            resolved_config,
+            provider='AWS',
+            check_name='SSMCredentials',
+            metrics={'Availability': 1, 'LatencyMs': ssm_latency_ms},
+        )
+        _log_result(
+            resolved_config,
+            provider='AWS',
+            check_name='SSMCredentials',
+            success=True,
+        )
+    except Exception as error:  # Keep every tenant independent.
+        queue_metrics(
+            config,
+            provider='AWS',
+            check_name='SSMCredentials',
+            metrics={'Availability': 0, 'LatencyMs': 0},
+        )
+        _log_result(
+            config,
+            provider='AWS',
+            check_name='SSMCredentials',
+            success=False,
+            error_type=type(error).__name__,
+        )
+        return False
+
+    try:
+        jwt_token = create_github_app_jwt(
+            credentials['issuer'], credentials['private_key']
+        )
+        installation_token, auth_latency_ms, auth_headers = (
+            get_installation_token(
+                resolved_config,
+                jwt_token,
+                credentials['installation_id'],
+            )
+        )
+        queue_metrics(
+            resolved_config,
+            provider='GitHub',
+            check_name='Authentication',
+            metrics={
+                'Availability': 1,
+                'LatencyMs': auth_latency_ms,
+                'StatusCode': 201,
+                'RateLimited': 0,
+                **_rate_limit_metrics(auth_headers),
+            },
+        )
+        _log_result(
+            resolved_config,
+            provider='GitHub',
+            check_name='Authentication',
+            success=True,
+            status_code=201,
+        )
+    except ProbeFailure as error:
+        queue_metrics(
+            resolved_config,
+            provider='GitHub',
+            check_name='Authentication',
+            metrics={
+                'Availability': 0,
+                'LatencyMs': 0,
+                'StatusCode': error.status_code,
+                'RateLimited': _is_rate_limited(
+                    error.status_code, error.headers
+                ),
+                **_rate_limit_metrics(error.headers),
+            },
+        )
+        _log_result(
+            resolved_config,
+            provider='GitHub',
+            check_name='Authentication',
+            success=False,
+            status_code=error.status_code,
+            error_type=type(error).__name__,
+        )
+        return False
+    except Exception as error:
+        queue_metrics(
+            resolved_config,
+            provider='GitHub',
+            check_name='Authentication',
+            metrics={
+                'Availability': 0,
+                'LatencyMs': 0,
+                'StatusCode': 0,
+                'RateLimited': 0,
+            },
+        )
+        _log_result(
+            resolved_config,
+            provider='GitHub',
+            check_name='Authentication',
+            success=False,
+            error_type=type(error).__name__,
+        )
+        return False
+
+    try:
+        status, latency_ms, headers = check_organization_runner_api(
+            resolved_config, installation_token
+        )
+        queue_metrics(
+            resolved_config,
+            provider='GitHub',
+            check_name='OrgRunnersApi',
+            metrics={
+                'Availability': 1,
+                'LatencyMs': latency_ms,
+                'StatusCode': status,
+                'RateLimited': 0,
+                **_rate_limit_metrics(headers),
+            },
+        )
+        _log_result(
+            resolved_config,
+            provider='GitHub',
+            check_name='OrgRunnersApi',
+            success=True,
+            status_code=status,
+        )
+        return True
+    except ProbeFailure as error:
+        queue_metrics(
+            resolved_config,
+            provider='GitHub',
+            check_name='OrgRunnersApi',
+            metrics={
+                'Availability': 0,
+                'LatencyMs': 0,
+                'StatusCode': error.status_code,
+                'RateLimited': _is_rate_limited(
+                    error.status_code, error.headers
+                ),
+                **_rate_limit_metrics(error.headers),
+            },
+        )
+        _log_result(
+            resolved_config,
+            provider='GitHub',
+            check_name='OrgRunnersApi',
+            success=False,
+            status_code=error.status_code,
+            error_type=type(error).__name__,
+        )
+        return False
+    except Exception as error:
+        queue_metrics(
+            resolved_config,
+            provider='GitHub',
+            check_name='OrgRunnersApi',
+            metrics={
+                'Availability': 0,
+                'LatencyMs': 0,
+                'StatusCode': 0,
+                'RateLimited': 0,
+            },
+        )
+        _log_result(
+            resolved_config,
+            provider='GitHub',
+            check_name='OrgRunnersApi',
+            success=False,
+            error_type=type(error).__name__,
+        )
+        return False
+
+
+def deliver_queued_telemetry() -> tuple[int, int, int]:
+    """Attempt Splunk Cloud and O11y delivery independently."""
+    events_sent = 0
+    metrics_sent = 0
+    delivery_failures = 0
+
+    try:
+        events_sent = common.send_to_splunk_batch(queued_events)
+    except Exception as error:
+        delivery_failures += 1
+        context = common.delivery_error_context(error)
+        LOG.error(
+            'splunk_cloud_delivery_failed error_type=%s cause_type=%s '
+            'http_status=%s response_code=%s response_text=%s',
+            type(error).__name__,
+            context['cause_type'],
+            context['http_status'],
+            context['response_code'],
+            context['response_text'],
+        )
+
+    try:
+        metrics_sent = common.send_metric_to_o11y_batch(queued_datapoints)
+    except Exception as error:
+        delivery_failures += 1
+        context = common.delivery_error_context(error)
+        LOG.error(
+            'splunk_o11y_delivery_failed error_type=%s cause_type=%s '
+            'http_status=%s response_code=%s response_text=%s',
+            type(error).__name__,
+            context['cause_type'],
+            context['http_status'],
+            context['response_code'],
+            context['response_text'],
+        )
+
+    return events_sent, metrics_sent, delivery_failures
+
+
+def lambda_handler(_event: dict[str, Any], _context: Any) -> dict[str, int]:
+    queued_datapoints.clear()
+    queued_events.clear()
+    configs = discover_tenants()
+    ssm = aws_client('ssm')
+    succeeded = 0
+    failed = 0
+
+    for config in configs:
+        if probe_tenant(config, ssm):
+            succeeded += 1
+        else:
+            failed += 1
+
+    events_sent, metrics_sent, delivery_failures = (
+        deliver_queued_telemetry()
+    )
+    LOG.info(
+        'dependency_probe_complete tenants=%s succeeded=%s failed=%s '
+        'events_sent=%s metrics_sent=%s delivery_failures=%s',
+        len(configs),
+        succeeded,
+        failed,
+        events_sent,
+        metrics_sent,
+        delivery_failures,
+    )
+    return {
+        'tenants': len(configs),
+        'succeeded': succeeded,
+        'failed': failed,
+        'events_sent': events_sent,
+        'metrics_sent': metrics_sent,
+        'delivery_failures': delivery_failures,
+    }

--- a/modules/integrations/splunk_dependency_monitor/outputs.tf
+++ b/modules/integrations/splunk_dependency_monitor/outputs.tf
@@ -1,0 +1,9 @@
+output "lambda_function_arn" {
+  description = "ARN of the regional dependency-monitor Lambda."
+  value       = module.dependency_monitor.lambda_function_arn
+}
+
+output "lambda_log_group_name" {
+  description = "CloudWatch log group containing dependency-probe results."
+  value       = aws_cloudwatch_log_group.dependency_monitor.name
+}

--- a/modules/integrations/splunk_dependency_monitor/providers.tf
+++ b/modules/integrations/splunk_dependency_monitor/providers.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+
+  default_tags {
+    tags = var.default_tags
+  }
+}

--- a/modules/integrations/splunk_dependency_monitor/secrets.tf
+++ b/modules/integrations/splunk_dependency_monitor/secrets.tf
@@ -1,0 +1,20 @@
+locals {
+  splunk_secrets = {
+    splunk_cloud_hec_token_dependency_monitor = {
+      name = "/cicd/common/splunk_cloud_hec_token_dependency_monitor"
+    }
+    splunk_o11y_ingest_token_dependency_monitor = {
+      name = "/cicd/common/splunk_o11y_ingest_token_dependency_monitor"
+    }
+  }
+}
+
+data "aws_secretsmanager_secret" "secrets" {
+  for_each = local.splunk_secrets
+  name     = each.value.name
+}
+
+data "aws_secretsmanager_secret_version" "secrets" {
+  for_each  = data.aws_secretsmanager_secret.secrets
+  secret_id = each.value.id
+}

--- a/modules/integrations/splunk_dependency_monitor/tags.tf
+++ b/modules/integrations/splunk_dependency_monitor/tags.tf
@@ -1,0 +1,4 @@
+locals {
+  dependency_monitor_function_name = "splunk-dependency-monitor-${var.aws_region}"
+  all_security_tags                = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_dependency_monitor/tests/integrations_splunk_dependency_monitor_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_dependency_monitor/tests/integrations_splunk_dependency_monitor_interface_contract.tftest.hcl
@@ -1,0 +1,81 @@
+run "integrations_splunk_dependency_monitor_interface_contract" {
+  command = plan
+
+  module {
+    source = "../../../tests/tofu/module_interface_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_input_variables = [
+      "aws_profile",
+      "aws_region",
+      "default_tags",
+      "github_api_version",
+      "github_timeout_seconds",
+      "log_level",
+      "logging_retention_in_days",
+      "schedule_expression",
+      "splunk_dependency_monitor_config",
+      "splunk_http_timeout_seconds",
+      "tags",
+    ]
+    expected_output_values = [
+      "lambda_function_arn",
+      "lambda_log_group_name",
+    ]
+    expected_interface_literals = [
+      "variable \"aws_profile\"",
+      "description = \"AWS profile to use.\"",
+      "variable \"aws_region\"",
+      "description = \"AWS region in which to run the dependency probe.\"",
+      "variable \"github_api_version\"",
+      "default     = \"2022-11-28\"",
+      "variable \"schedule_expression\"",
+      "default     = \"cron(*/5 * * * ? *)\"",
+      "variable \"splunk_dependency_monitor_config\"",
+      "splunk_hec_url     = string",
+      "splunk_index       = string",
+      "splunk_metrics_url = string",
+      "description = \"Splunk Cloud HEC and Splunk Observability metric-ingest configuration.\"",
+      "variable \"splunk_http_timeout_seconds\"",
+      "default     = 10",
+      "output \"lambda_function_arn\"",
+      "value       = module.dependency_monitor.lambda_function_arn",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_input_variables) == 0
+    error_message = "Interface contract is missing input variables: ${join(", ", output.missing_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.unexpected_input_variables) == 0
+    error_message = "Interface contract has unexpected input variables: ${join(", ", output.unexpected_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.missing_output_values) == 0
+    error_message = "Interface contract is missing outputs: ${join(", ", output.missing_output_values)}"
+  }
+
+  assert {
+    condition     = length(output.unexpected_output_values) == 0
+    error_message = "Interface contract has unexpected outputs: ${join(", ", output.unexpected_output_values)}"
+  }
+
+  assert {
+    condition     = length(output.missing_interface_literals) == 0
+    error_message = "Interface contract is missing expected source lines: ${join(", ", output.missing_interface_literals)}"
+  }
+
+  assert {
+    condition = (
+      output.expected_input_variable_count == 11
+      && output.expected_output_value_count == 2
+      && output.expected_interface_literal_count == 17
+    )
+    error_message = "Interface contract counts must remain pinned."
+  }
+}

--- a/modules/integrations/splunk_dependency_monitor/tests/integrations_splunk_dependency_monitor_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_dependency_monitor/tests/integrations_splunk_dependency_monitor_source_inventory.tftest.hcl
@@ -1,0 +1,41 @@
+run "integrations_splunk_dependency_monitor_source_inventory" {
+  command = plan
+
+  module {
+    source = "../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "module \"dependency_monitor\"",
+      "resource \"aws_cloudwatch_log_group\" \"dependency_monitor\"",
+      "resource \"aws_cloudwatch_event_rule\" \"dependency_monitor\"",
+      "resource \"aws_cloudwatch_event_target\" \"dependency_monitor\"",
+      "target_id = \"splunk-dependency-monitor\"",
+      "dependency_monitor_function_name = \"splunk-dependency-monitor-$${var.aws_region}\"",
+      "resource \"aws_lambda_permission\" \"eventbridge_invoke\"",
+      "data \"aws_iam_policy_document\" \"dependency_monitor\"",
+      "data \"aws_secretsmanager_secret\" \"secrets\"",
+      "data \"aws_secretsmanager_secret_version\" \"secrets\"",
+      "data \"aws_caller_identity\" \"current\"",
+      "data \"aws_region\" \"current\"",
+      "ssm:DescribeParameters",
+      "ssm:ListTagsForResource",
+      "parameter/forge/*/github_ghes_org",
+      "GITHUB_API_VERSION",
+      "SPLUNK_HEC_URL",
+      "SPLUNK_METRICS_URL",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "Module contract is missing expected literals: ${join(", ", output.missing_expected_literals)}"
+  }
+
+  assert {
+    condition     = output.expected_literal_count == 18
+    error_message = "Source inventory count must remain pinned."
+  }
+}

--- a/modules/integrations/splunk_dependency_monitor/variables.tf
+++ b/modules/integrations/splunk_dependency_monitor/variables.tf
@@ -1,0 +1,75 @@
+variable "aws_profile" {
+  type        = string
+  description = "AWS profile to use."
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region in which to run the dependency probe."
+}
+
+variable "default_tags" {
+  type        = map(string)
+  description = "A map of default tags to apply to resources."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of additional tags to apply to resources."
+  default     = {}
+}
+
+variable "logging_retention_in_days" {
+  type        = number
+  description = "Number of days to retain dependency-probe Lambda logs."
+  default     = 3
+}
+
+variable "log_level" {
+  type        = string
+  description = "Lambda log level."
+  default     = "INFO"
+}
+
+variable "schedule_expression" {
+  type        = string
+  description = "EventBridge schedule for tenant dependency probes."
+  default     = "cron(*/5 * * * ? *)"
+}
+
+variable "github_timeout_seconds" {
+  type        = number
+  description = "Timeout for each GitHub API request."
+  default     = 10
+}
+
+variable "github_api_version" {
+  type        = string
+  description = "GitHub REST API version sent by every regional dependency probe."
+  default     = "2022-11-28"
+}
+
+variable "splunk_dependency_monitor_config" {
+  type = object({
+    splunk_hec_url     = string
+    splunk_index       = string
+    splunk_metrics_url = string
+  })
+  description = "Splunk Cloud HEC and Splunk Observability metric-ingest configuration."
+
+  validation {
+    condition = (
+      startswith(var.splunk_dependency_monitor_config.splunk_hec_url, "https://")
+      && startswith(var.splunk_dependency_monitor_config.splunk_metrics_url, "https://")
+      && endswith(var.splunk_dependency_monitor_config.splunk_metrics_url, "/v2/datapoint")
+      && trimspace(var.splunk_dependency_monitor_config.splunk_index) != ""
+    )
+    error_message = "Splunk URLs must use HTTPS, splunk_metrics_url must end in /v2/datapoint, and splunk_index must not be empty."
+  }
+}
+
+variable "splunk_http_timeout_seconds" {
+  type        = number
+  description = "Timeout for batched Splunk Cloud and Splunk O11y HTTP requests."
+  default     = 10
+}

--- a/modules/integrations/splunk_dependency_monitor/versions.tf
+++ b/modules/integrations/splunk_dependency_monitor/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.47"
+    }
+  }
+
+  required_version = "~> 1.11"
+}

--- a/tests/lambdas/splunk_dependency_monitor_delivery_test.py
+++ b/tests/lambdas/splunk_dependency_monitor_delivery_test.py
@@ -1,0 +1,208 @@
+"""Splunk delivery tests for the dependency-monitor Lambda."""
+
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from conftest import requires_aws
+
+pytestmark = requires_aws
+
+LAMBDA_DIR = Path(__file__).resolve().parents[2].joinpath(
+    'modules',
+    'integrations',
+    'splunk_dependency_monitor',
+    'lambda',
+)
+
+
+def _load_common(monkeypatch, **environment):
+    defaults = {
+        'SPLUNK_HEC_TOKEN': 'hec-test-token',
+        'SPLUNK_HEC_URL': 'https://splunk.example/services/collector',
+        'SPLUNK_HTTP_TIMEOUT_SECONDS': '9',
+        'SPLUNK_INDEX': 'forge-test-index',
+        'SPLUNK_METRICS_TOKEN': 'metrics-test-token',
+        'SPLUNK_METRICS_URL': 'https://o11y.example/v2/datapoint',
+    }
+    defaults.update(environment)
+    for name, value in defaults.items():
+        monkeypatch.setenv(name, value)
+    spec = importlib.util.spec_from_file_location(
+        'splunk_dependency_monitor_delivery_under_test',
+        LAMBDA_DIR / 'common.py',
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError('Cannot load dependency-monitor common module')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_empty_batches_do_not_require_configuration(monkeypatch, aws):
+    common = _load_common(
+        monkeypatch,
+        SPLUNK_HEC_TOKEN='',
+        SPLUNK_HEC_URL='',
+        SPLUNK_INDEX='',
+        SPLUNK_METRICS_TOKEN='',
+        SPLUNK_METRICS_URL='',
+    )
+
+    assert common.send_to_splunk_batch([]) == 0
+    assert common.send_metric_to_o11y_batch([]) == 0
+
+
+@pytest.mark.parametrize(
+    ('function_name', 'environment'),
+    [
+        ('send_to_splunk_batch', {'SPLUNK_HEC_TOKEN': ''}),
+        ('send_to_splunk_batch', {'SPLUNK_HEC_URL': ''}),
+        ('send_to_splunk_batch', {'SPLUNK_INDEX': ''}),
+        ('send_metric_to_o11y_batch', {'SPLUNK_METRICS_TOKEN': ''}),
+        ('send_metric_to_o11y_batch', {'SPLUNK_METRICS_URL': ''}),
+    ],
+)
+def test_non_empty_batches_reject_incomplete_configuration(
+    monkeypatch, aws, function_name, environment
+):
+    common = _load_common(monkeypatch, **environment)
+
+    with pytest.raises(ValueError):
+        getattr(common, function_name)([{'value': 1}])
+
+
+def test_hec_batch_is_newline_delimited_gzip(monkeypatch, aws):
+    common = _load_common(monkeypatch)
+    calls = []
+
+    def post(url, **kwargs):
+        calls.append((url, kwargs))
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setitem(sys.modules, 'requests', SimpleNamespace(post=post))
+    events = [
+        {'index': 'forge-test-index', 'event': {'tenant': 'a'}},
+        {'index': 'forge-test-index', 'event': {'tenant': 'b'}},
+    ]
+
+    assert common.send_to_splunk_batch(events) == 2
+    assert calls[0][0] == 'https://splunk.example/services/collector'
+    assert calls[0][1]['timeout'] == 9
+    assert calls[0][1]['headers'] == {
+        'Authorization': 'Splunk hec-test-token',
+        'Content-Type': 'application/json',
+        'Content-Encoding': 'gzip',
+    }
+    decoded = gzip.decompress(calls[0][1]['data']).decode()
+    assert [json.loads(line) for line in decoded.splitlines()] == events
+
+
+def test_o11y_batch_uses_gauge_payload(monkeypatch, aws):
+    common = _load_common(monkeypatch)
+    calls = []
+
+    def post(url, **kwargs):
+        calls.append((url, kwargs))
+        return SimpleNamespace(status_code=202)
+
+    monkeypatch.setitem(sys.modules, 'requests', SimpleNamespace(post=post))
+    metrics = [{'metric': 'forge.test', 'value': 1}]
+
+    assert common.send_metric_to_o11y_batch(metrics) == 1
+    assert calls == [
+        (
+            'https://o11y.example/v2/datapoint',
+            {
+                'headers': {
+                    'X-SF-TOKEN': 'metrics-test-token',
+                    'Content-Type': 'application/json',
+                },
+                'data': None,
+                'json': {'gauge': metrics},
+                'timeout': 9,
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize('first_status', [429, 500, 503])
+def test_retryable_http_status_is_retried(
+    monkeypatch, aws, first_status
+):
+    common = _load_common(monkeypatch)
+    statuses = iter([first_status, 200])
+    sleeps = []
+    calls = []
+
+    def post(*_args, **_kwargs):
+        calls.append(True)
+        return SimpleNamespace(status_code=next(statuses))
+
+    monkeypatch.setitem(sys.modules, 'requests', SimpleNamespace(post=post))
+    monkeypatch.setattr(common.time, 'sleep', sleeps.append)
+
+    common._post_with_retries('https://splunk.example', headers={})
+
+    assert len(calls) == 2
+    assert sleeps == [1]
+
+
+def test_client_error_is_not_retried(monkeypatch, aws):
+    common = _load_common(monkeypatch)
+    sleeps = []
+    calls = []
+
+    def post(*_args, **_kwargs):
+        calls.append(True)
+        return SimpleNamespace(
+            status_code=403,
+            json=lambda: {'code': 4, 'text': 'Invalid token'},
+        )
+
+    monkeypatch.setitem(sys.modules, 'requests', SimpleNamespace(post=post))
+    monkeypatch.setattr(common.time, 'sleep', sleeps.append)
+
+    with pytest.raises(
+        RuntimeError, match='bounded retries'
+    ) as raised:
+        common._post_with_retries('https://splunk.example', headers={})
+
+    assert len(calls) == 1
+    assert sleeps == []
+    assert isinstance(raised.value.__cause__, RuntimeError)
+    assert 'status 403' in str(raised.value.__cause__)
+    assert common.delivery_error_context(raised.value) == {
+        'cause_type': 'RuntimeError',
+        'http_status': '403',
+        'response_code': '4',
+        'response_text': 'Invalid token',
+    }
+
+
+def test_network_failure_uses_bounded_exponential_retries(
+    monkeypatch, aws
+):
+    common = _load_common(monkeypatch)
+    sleeps = []
+    calls = []
+
+    def post(*_args, **_kwargs):
+        calls.append(True)
+        raise OSError('network unavailable')
+
+    monkeypatch.setitem(sys.modules, 'requests', SimpleNamespace(post=post))
+    monkeypatch.setattr(common.time, 'sleep', sleeps.append)
+
+    with pytest.raises(RuntimeError, match='bounded retries') as raised:
+        common._post_with_retries('https://splunk.example', headers={})
+
+    assert len(calls) == 3
+    assert sleeps == [1, 2]
+    assert isinstance(raised.value.__cause__, OSError)

--- a/tests/lambdas/splunk_dependency_monitor_test.py
+++ b/tests/lambdas/splunk_dependency_monitor_test.py
@@ -1,0 +1,1064 @@
+"""Splunk regional dependency-monitor Lambda tests."""
+
+from __future__ import annotations
+
+import base64
+import gzip
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from conftest import requires_aws
+
+pytestmark = requires_aws
+
+LAMBDA_DIR = Path(__file__).resolve().parents[2].joinpath(
+    'modules',
+    'integrations',
+    'splunk_dependency_monitor',
+    'lambda',
+)
+
+
+def _load_handler(monkeypatch):
+    monkeypatch.setenv('AWS_REGION', 'us-west-2')
+    monkeypatch.setenv('GITHUB_API_VERSION', '2022-11-28')
+    monkeypatch.setenv('GITHUB_TIMEOUT_SECONDS', '7')
+    monkeypatch.setenv('SPLUNK_HEC_TOKEN', 'splunk-hec-token-sensitive')
+    monkeypatch.setenv(
+        'SPLUNK_HEC_URL',
+        'https://http-inputs.example.splunkcloud.com/services/collector',
+    )
+    monkeypatch.setenv('SPLUNK_HTTP_TIMEOUT_SECONDS', '8')
+    monkeypatch.setenv('SPLUNK_INDEX', 'srea-forge-prod-index')
+    monkeypatch.setenv(
+        'SPLUNK_METRICS_TOKEN', 'splunk-metrics-token-sensitive'
+    )
+    monkeypatch.setenv(
+        'SPLUNK_METRICS_URL',
+        'https://ingest.us1.observability.splunkcloud.com/v2/datapoint',
+    )
+    common_spec = importlib.util.spec_from_file_location(
+        'splunk_dependency_monitor_common_under_test',
+        LAMBDA_DIR / 'common.py',
+    )
+    if common_spec is None or common_spec.loader is None:
+        raise ImportError('Cannot load dependency-monitor common module')
+    common_module = importlib.util.module_from_spec(common_spec)
+    common_spec.loader.exec_module(common_module)
+
+    handler_spec = importlib.util.spec_from_file_location(
+        'splunk_dependency_monitor_handler_under_test',
+        LAMBDA_DIR / 'handler.py',
+    )
+    if handler_spec is None or handler_spec.loader is None:
+        raise ImportError('Cannot load dependency-monitor handler module')
+    handler_module = importlib.util.module_from_spec(handler_spec)
+    missing = object()
+    previous_common = sys.modules.get('common', missing)
+    sys.modules['common'] = common_module
+    try:
+        handler_spec.loader.exec_module(handler_module)
+    finally:
+        if previous_common is missing:
+            sys.modules.pop('common', None)
+        else:
+            sys.modules['common'] = previous_common
+    return handler_module
+
+
+def _tenant_config():
+    return {
+        'tenant': 'tenant-a',
+        'aws_region': 'us-west-2',
+        'deployment_prefix': 'tenant-a-usw2-sl',
+        'github_api_version': '2022-11-28',
+    }
+
+
+def _fake_pem():
+    begin_marker = bytes(
+        [
+            45, 45, 45, 45, 45, 66, 69, 71, 73, 78, 32,
+            80, 82, 73, 86, 65, 84, 69, 32, 75, 69, 89,
+            45, 45, 45, 45, 45,
+        ]
+    ).decode()
+    end_marker = bytes(
+        [
+            45, 45, 45, 45, 45, 69, 78, 68, 32,
+            80, 82, 73, 86, 65, 84, 69, 32, 75, 69, 89,
+            45, 45, 45, 45, 45,
+        ]
+    ).decode()
+    return '\n'.join(
+        [
+            begin_marker,
+            'test-key-material',
+            end_marker,
+        ]
+    )
+
+
+def test_normalize_private_key_decodes_base64_pem(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    pem = _fake_pem()
+
+    assert handler.normalize_private_key(
+        base64.b64encode(pem.encode()).decode()
+    ) == pem
+
+
+@pytest.mark.parametrize(
+    ('ghes_url', 'expected_api_url'),
+    [
+        ('https://github.com', 'https://api.github.com'),
+        (
+            'https://github.example.com/',
+            'https://github.example.com/api/v3',
+        ),
+    ],
+)
+def test_load_credentials_uses_existing_forge_ssm_contract(
+    monkeypatch, aws, ghes_url, expected_api_url
+):
+    handler = _load_handler(monkeypatch)
+    pem = _fake_pem()
+    calls = []
+
+    class FakeSsm:
+        def get_parameters(self, *, Names, WithDecryption):
+            calls.append((Names, WithDecryption))
+            return {
+                'Parameters': [
+                    {'Name': Names[0], 'Value': base64.b64encode(
+                        pem.encode()
+                    ).decode()},
+                    {'Name': Names[1], 'Value': 'Iv1.client'},
+                    {'Name': Names[2], 'Value': '123'},
+                    {'Name': Names[3], 'Value': '456'},
+                    {
+                        'Name': Names[4],
+                        'Value': ghes_url,
+                    },
+                    {'Name': Names[5], 'Value': 'tenant-org'},
+                ],
+                'InvalidParameters': [],
+            }
+
+    credentials = handler.load_github_app_credentials(
+        FakeSsm(), 'tenant-a-usw2-sl'
+    )
+
+    assert credentials['issuer'] == 'Iv1.client'
+    assert credentials['installation_id'] == '456'
+    assert credentials['github_api_url'] == expected_api_url
+    assert credentials['github_org'] == 'tenant-org'
+    assert calls == [
+        (
+            [
+                '/forge/tenant-a-usw2-sl/github_app_key',
+                '/forge/tenant-a-usw2-sl/github_app_client_id',
+                '/forge/tenant-a-usw2-sl/github_app_id',
+                '/forge/tenant-a-usw2-sl/github_app_installation_id',
+                '/forge/tenant-a-usw2-sl/github_ghes_url',
+                '/forge/tenant-a-usw2-sl/github_ghes_org',
+            ],
+            True,
+        )
+    ]
+
+
+def test_org_runner_probe_uses_tenant_api_org_and_rate_headers(
+    monkeypatch, aws
+):
+    handler = _load_handler(monkeypatch)
+    calls = []
+
+    def request(method, url, headers, json, timeout):
+        calls.append((method, url, headers, json, timeout))
+        return SimpleNamespace(
+            status_code=200,
+            headers={
+                'X-RateLimit-Limit': '15000',
+                'X-RateLimit-Remaining': '14900',
+                'X-RateLimit-Used': '100',
+            },
+            json=lambda: {'total_count': 1, 'runners': []},
+        )
+
+    monkeypatch.setitem(
+        sys.modules, 'requests', SimpleNamespace(request=request)
+    )
+
+    status, _latency, headers = handler.check_organization_runner_api(
+        {
+            **_tenant_config(),
+            'github_api_url': 'https://api.github.test',
+            'github_org': 'tenant-org',
+        },
+        'installation-token',
+    )
+
+    assert status == 200
+    assert calls[0][0:2] == (
+        'GET',
+        'https://api.github.test/orgs/tenant-org/actions/runners?per_page=1',
+    )
+    assert calls[0][2]['Authorization'] == 'Bearer installation-token'
+    assert calls[0][4] == 7
+    assert handler._rate_limit_metrics(headers) == {
+        'RateLimit': 15000,
+        'RateLimitRemaining': 14900,
+        'RateLimitUsed': 100,
+        'RateLimitRemainingPct': pytest.approx(99.333),
+    }
+
+
+def test_lambda_handler_keeps_tenant_failures_independent(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    configs = [
+        {**_tenant_config(), 'tenant': 'tenant-a'},
+        {**_tenant_config(), 'tenant': 'tenant-b'},
+    ]
+    seen = []
+    monkeypatch.setattr(handler, 'discover_tenants', lambda: configs)
+    monkeypatch.setattr(
+        handler.boto3,
+        'client',
+        lambda _service, *, region_name: (
+            region_name == 'us-west-2' and object()
+        ),
+    )
+
+    def probe(config, _ssm):
+        seen.append(config['tenant'])
+        return config['tenant'] == 'tenant-b'
+
+    monkeypatch.setattr(handler, 'probe_tenant', probe)
+    monkeypatch.setattr(
+        handler.common, 'send_to_splunk_batch', lambda _events: 0
+    )
+    monkeypatch.setattr(
+        handler.common, 'send_metric_to_o11y_batch', lambda _metrics: 0
+    )
+
+    result = handler.lambda_handler({}, None)
+
+    assert seen == ['tenant-a', 'tenant-b']
+    assert result == {
+        'tenants': 2,
+        'succeeded': 1,
+        'failed': 1,
+        'events_sent': 0,
+        'metrics_sent': 0,
+        'delivery_failures': 0,
+    }
+
+
+def test_splunk_cloud_and_o11y_batches_do_not_expose_credentials(
+    monkeypatch, aws, capsys, caplog
+):
+    handler = _load_handler(monkeypatch)
+    config = _tenant_config()
+    requests_seen = []
+    secret_values = [
+        'PRIVATE-KEY-CONTENT',
+        'signed-jwt',
+        'installation-token',
+        'installation-id-sensitive-456',
+        'splunk-hec-token-sensitive',
+        'splunk-metrics-token-sensitive',
+    ]
+
+    def post(url, headers, data=None, json=None, timeout=None):
+        requests_seen.append((url, headers, data, json, timeout))
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setitem(sys.modules, 'requests', SimpleNamespace(post=post))
+
+    handler.queue_metrics(
+        config,
+        provider='GitHub',
+        check_name='OrgRunnersApi',
+        metrics={
+            'Availability': 1,
+            'RateLimitRemainingPct': 75,
+            'StatusCode': 200,
+        },
+    )
+    handler._log_result(
+        config,
+        provider='GitHub',
+        check_name='OrgRunnersApi',
+        success=True,
+        status_code=200,
+    )
+
+    events_sent = handler.common.send_to_splunk_batch(handler.queued_events)
+    metrics_sent = handler.common.send_metric_to_o11y_batch(
+        handler.queued_datapoints
+    )
+
+    assert events_sent == 1
+    assert metrics_sent == 2
+    assert requests_seen[0][0] == (
+        'https://http-inputs.example.splunkcloud.com/services/collector'
+    )
+    assert requests_seen[0][1]['Authorization'] == (
+        'Splunk splunk-hec-token-sensitive'
+    )
+    assert requests_seen[0][1]['Content-Encoding'] == 'gzip'
+    assert requests_seen[0][4] == 8
+    hec_event = json.loads(gzip.decompress(requests_seen[0][2]))
+    assert hec_event['index'] == 'srea-forge-prod-index'
+    assert hec_event['event']['forgecicd_tenant'] == 'tenant-a'
+    assert hec_event['event']['aws_region'] == 'us-west-2'
+    assert requests_seen[1][0] == (
+        'https://ingest.us1.observability.splunkcloud.com/v2/datapoint'
+    )
+    assert requests_seen[1][1]['X-SF-TOKEN'] == (
+        'splunk-metrics-token-sensitive'
+    )
+    assert requests_seen[1][4] == 8
+    datapoints = requests_seen[1][3]['gauge']
+    assert [datapoint['metric'] for datapoint in datapoints] == [
+        'forge.dependency.availability',
+        'forge.dependency.rate_limit_remaining_pct',
+    ]
+    assert datapoints[0]['dimensions']['TenantName'] == 'tenant-a'
+    assert datapoints[0]['dimensions']['AWSRegion'] == 'us-west-2'
+    assert 'RegionAlias' not in datapoints[0]['dimensions']
+    assert datapoints[0]['dimensions']['Provider'] == 'GitHub'
+    combined_output = capsys.readouterr().out + caplog.text
+    assert all(secret not in combined_output for secret in secret_values)
+
+
+def test_o11y_ingest_retries_server_failure(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    statuses = iter([503, 200])
+    sleeps = []
+
+    def post(url, headers, data=None, json=None, timeout=None):
+        _ = (url, headers, data, json, timeout)
+        return SimpleNamespace(status_code=next(statuses))
+
+    monkeypatch.setitem(sys.modules, 'requests', SimpleNamespace(post=post))
+    monkeypatch.setattr(handler.common.time, 'sleep', sleeps.append)
+    handler.queue_metrics(
+        _tenant_config(),
+        provider='Forge',
+        check_name='TenantCycle',
+        metrics={'ProbeExecuted': 1},
+    )
+
+    assert handler.common.send_metric_to_o11y_batch(
+        handler.queued_datapoints
+    ) == 1
+    assert sleeps == [1]
+
+
+def test_tenants_are_discovered_from_regional_ssm(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    calls = []
+
+    class FakePaginator:
+        def paginate(self, *, ParameterFilters):
+            calls.append(('describe', ParameterFilters))
+            return [
+                {
+                    'Parameters': [
+                        {
+                            'Name': (
+                                '/forge/tenant-a-usw2-sl/github_ghes_org'
+                            )
+                        },
+                        {
+                            'Name': (
+                                '/forge/tenant-b-usw2-sl/github_ghes_org'
+                            )
+                        },
+                        {'Name': '/forge/tenant-a-usw2-sl/github_app_id'},
+                    ]
+                }
+            ]
+
+    class FakeSsm:
+        def get_paginator(self, operation_name):
+            assert operation_name == 'describe_parameters'
+            return FakePaginator()
+
+        def get_parameters(self, *, Names, WithDecryption):
+            calls.append(('get', Names, WithDecryption))
+            return {
+                'Parameters': [
+                    {'Name': Names[0], 'Value': 'github-org-a'},
+                    {'Name': Names[1], 'Value': 'github-org-b'},
+                ],
+                'InvalidParameters': [],
+            }
+
+        def list_tags_for_resource(self, *, ResourceType, ResourceId):
+            calls.append(('tags', ResourceType, ResourceId))
+            if 'tenant-a-' in ResourceId:
+                return {
+                    'TagList': [
+                        {'Key': 'TenantName', 'Value': 'tenant-a'},
+                    ]
+                }
+            return {'TagList': []}
+
+    monkeypatch.setattr(
+        handler.boto3,
+        'client',
+        lambda _service, *, region_name: (
+            FakeSsm() if region_name == 'us-west-2' else None
+        ),
+    )
+
+    assert handler.discover_tenants() == [
+        {
+            'tenant': 'tenant-a',
+            'aws_region': 'us-west-2',
+            'deployment_prefix': 'tenant-a-usw2-sl',
+            'github_api_version': '2022-11-28',
+        },
+        {
+            'tenant': 'github-org-b',
+            'aws_region': 'us-west-2',
+            'deployment_prefix': 'tenant-b-usw2-sl',
+            'github_api_version': '2022-11-28',
+        },
+    ]
+    assert calls == [
+        (
+            'describe',
+            [
+                {
+                    'Key': 'Name',
+                    'Option': 'BeginsWith',
+                    'Values': ['/forge/'],
+                }
+            ],
+        ),
+        (
+            'get',
+            [
+                '/forge/tenant-a-usw2-sl/github_ghes_org',
+                '/forge/tenant-b-usw2-sl/github_ghes_org',
+            ],
+            False,
+        ),
+        (
+            'tags',
+            'Parameter',
+            '/forge/tenant-a-usw2-sl/github_ghes_org',
+        ),
+        (
+            'tags',
+            'Parameter',
+            '/forge/tenant-b-usw2-sl/github_ghes_org',
+        ),
+    ]
+
+
+def test_tenant_discovery_runs_on_every_invocation(
+    monkeypatch, caplog, aws
+):
+    handler = _load_handler(monkeypatch)
+    describe_calls = 0
+
+    class FakePaginator:
+        def paginate(self, **_kwargs):
+            nonlocal describe_calls
+            describe_calls += 1
+            return [{'Parameters': []}]
+
+    class FakeSsm:
+        def get_paginator(self, _operation_name):
+            return FakePaginator()
+
+    monkeypatch.setattr(
+        handler.boto3,
+        'client',
+        lambda _service, *, region_name: (
+            FakeSsm() if region_name == 'us-west-2' else None
+        ),
+    )
+
+    assert handler.discover_tenants() == []
+    assert handler.discover_tenants() == []
+    assert describe_calls == 2
+    assert caplog.messages.count(
+        'tenant_discovery_no_candidates aws_region=us-west-2 '
+        'expected_pattern=/forge/*/github_ghes_org'
+    ) == 2
+
+
+def test_splunk_outputs_are_delivered_independently(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    metrics_seen = []
+
+    def fail_hec(_events):
+        raise RuntimeError('HEC unavailable')
+
+    monkeypatch.setattr(handler.common, 'send_to_splunk_batch', fail_hec)
+    monkeypatch.setattr(
+        handler.common,
+        'send_metric_to_o11y_batch',
+        lambda metrics: metrics_seen.extend(metrics) or len(metrics),
+    )
+    handler.queued_events.append({'event': {'success': True}})
+    handler.queued_datapoints.append(
+        {'metric': 'forge.dependency.availability'})
+
+    assert handler.deliver_queued_telemetry() == (0, 1, 1)
+    assert metrics_seen == [{'metric': 'forge.dependency.availability'}]
+
+
+def test_create_github_app_jwt_uses_bounded_lifetime(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    captured = {}
+
+    def encode(claims, private_key, *, algorithm):
+        captured.update({
+            'claims': claims,
+            'private_key': private_key,
+            'algorithm': algorithm,
+        })
+        return b'signed-test-token'
+
+    monkeypatch.setattr(handler.time, 'time', lambda: 1000)
+    monkeypatch.setitem(sys.modules, 'jwt', SimpleNamespace(encode=encode))
+
+    assert handler.create_github_app_jwt(
+        'Iv1.client', 'decoded-key'
+    ) == 'signed-test-token'
+    assert captured == {
+        'claims': {'iat': 940, 'exp': 1540, 'iss': 'Iv1.client'},
+        'private_key': 'decoded-key',
+        'algorithm': 'RS256',
+    }
+
+
+def test_github_request_normalizes_headers_and_non_json_body(
+    monkeypatch, aws
+):
+    handler = _load_handler(monkeypatch)
+    calls = []
+
+    def request(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+
+        def invalid_json():
+            raise ValueError('not json')
+
+        return SimpleNamespace(
+            status_code=502,
+            headers={'Retry-After': 30, 'X-RateLimit-Remaining': 0},
+            json=invalid_json,
+        )
+
+    monkeypatch.setitem(
+        sys.modules, 'requests', SimpleNamespace(request=request)
+    )
+
+    assert handler.github_request(
+        'GET',
+        'https://github.example/api',
+        token='request-token',
+        api_version='',
+    ) == (
+        502,
+        {'retry-after': '30', 'x-ratelimit-remaining': '0'},
+        {},
+    )
+    request_headers = calls[0][2]['headers']
+    assert request_headers['Authorization'] == 'Bearer request-token'
+    assert 'X-GitHub-Api-Version' not in request_headers
+    assert calls[0][2]['timeout'] == 7
+
+
+def test_installation_token_request_quotes_id_and_measures_latency(
+    monkeypatch, aws
+):
+    handler = _load_handler(monkeypatch)
+    calls = []
+    monotonic = iter([10.0, 10.125])
+    monkeypatch.setattr(handler.time, 'monotonic', lambda: next(monotonic))
+
+    def github_request(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return 201, {'x-ratelimit-remaining': '4999'}, {
+            'token': 'installation-token'
+        }
+
+    monkeypatch.setattr(handler, 'github_request', github_request)
+
+    result = handler.get_installation_token(
+        {
+            **_tenant_config(),
+            'github_api_url': 'https://github.example/api/v3/',
+        },
+        'app-jwt',
+        'install/id',
+    )
+
+    assert result == (
+        'installation-token',
+        125,
+        {'x-ratelimit-remaining': '4999'},
+    )
+    assert calls == [
+        (
+            'POST',
+            'https://github.example/api/v3/app/installations/'
+            'install%2Fid/access_tokens',
+            {
+                'token': 'app-jwt',
+                'api_version': '2022-11-28',
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ('status', 'body'),
+    [
+        (401, {'message': 'bad credentials'}),
+        (201, {}),
+    ],
+)
+def test_installation_token_failure_has_safe_diagnostics(
+    monkeypatch, aws, status, body
+):
+    handler = _load_handler(monkeypatch)
+    monkeypatch.setattr(
+        handler,
+        'github_request',
+        lambda *_args, **_kwargs: (
+            status,
+            {'retry-after': '5'},
+            body,
+        ),
+    )
+
+    with pytest.raises(handler.ProbeFailure) as raised:
+        handler.get_installation_token(
+            {
+                **_tenant_config(),
+                'github_api_url': 'https://api.github.com',
+            },
+            'app-jwt',
+            '123',
+        )
+
+    assert raised.value.step == 'github_authentication'
+    assert raised.value.status_code == status
+    assert raised.value.headers == {'retry-after': '5'}
+    assert 'app-jwt' not in str(raised.value)
+
+
+def test_load_credentials_rejects_missing_parameter(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+
+    class FakeSsm:
+        def get_parameters(self, *, Names, WithDecryption):
+            assert WithDecryption is True
+            return {
+                'Parameters': [],
+                'InvalidParameters': [Names[0]],
+            }
+
+    with pytest.raises(handler.ProbeFailure) as raised:
+        handler.load_github_app_credentials(
+            FakeSsm(), 'tenant-a-usw2-sl'
+        )
+
+    assert raised.value.step == 'ssm_credentials'
+    assert raised.value.status_code == 0
+    assert '/forge/' not in str(raised.value)
+
+
+def test_probe_tenant_success_records_each_boundary(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    monkeypatch.setattr(
+        handler,
+        'load_github_app_credentials',
+        lambda _ssm, _prefix: {
+            'issuer': 'Iv1.client',
+            'private_key': 'decoded-key',
+            'installation_id': '123',
+            'github_api_url': 'https://api.github.com',
+            'github_org': 'tenant-org',
+        },
+    )
+    monkeypatch.setattr(
+        handler,
+        'create_github_app_jwt',
+        lambda issuer, key: f'{issuer}:{key}',
+    )
+    monkeypatch.setattr(
+        handler,
+        'get_installation_token',
+        lambda config, token, installation_id: (
+            'installation-token',
+            12,
+            {
+                'x-ratelimit-limit': '5000',
+                'x-ratelimit-remaining': '4500',
+                'x-ratelimit-used': '500',
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        handler,
+        'check_organization_runner_api',
+        lambda config, token: (
+            200,
+            21,
+            {
+                'x-ratelimit-limit': '5000',
+                'x-ratelimit-remaining': '4400',
+                'x-ratelimit-used': '600',
+            },
+        ),
+    )
+
+    assert handler.probe_tenant(_tenant_config(), object()) is True
+    assert [
+        event['event']['check_name'] for event in handler.queued_events
+    ] == ['SSMCredentials', 'Authentication', 'OrgRunnersApi']
+    assert all(
+        event['event']['success'] for event in handler.queued_events
+    )
+    datapoints = {
+        (
+            datapoint['dimensions']['CheckName'],
+            datapoint['metric'],
+        ): datapoint['value']
+        for datapoint in handler.queued_datapoints
+    }
+    assert datapoints[(
+        'TenantCycle',
+        'forge.dependency.probe_executed',
+    )] == 1
+    assert datapoints[(
+        'SSMCredentials',
+        'forge.dependency.availability',
+    )] == 1
+    assert datapoints[(
+        'Authentication',
+        'forge.dependency.rate_limit_remaining_pct',
+    )] == 90
+    assert datapoints[(
+        'OrgRunnersApi',
+        'forge.dependency.rate_limit_remaining_pct',
+    )] == 88
+
+
+def test_probe_tenant_stops_after_ssm_failure(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    github_called = False
+
+    def fail_credentials(_ssm, _prefix):
+        raise RuntimeError('parameter read failed')
+
+    def create_jwt(*_args):
+        nonlocal github_called
+        github_called = True
+
+    monkeypatch.setattr(
+        handler, 'load_github_app_credentials', fail_credentials
+    )
+    monkeypatch.setattr(handler, 'create_github_app_jwt', create_jwt)
+
+    assert handler.probe_tenant(_tenant_config(), object()) is False
+    assert github_called is False
+    assert handler.queued_events[-1]['event'] == {
+        'forgecicd_log_type': 'dependency-probe',
+        'forgecicd_tenant': 'tenant-a',
+        'aws_region': 'us-west-2',
+        'provider': 'AWS',
+        'check_name': 'SSMCredentials',
+        'success': False,
+        'status_code': 0,
+        'error_type': 'RuntimeError',
+        'github_mode': 'unknown',
+    }
+
+
+def test_probe_tenant_reports_rate_limited_authentication(
+    monkeypatch, aws
+):
+    handler = _load_handler(monkeypatch)
+    monkeypatch.setattr(
+        handler,
+        'load_github_app_credentials',
+        lambda _ssm, _prefix: {
+            'issuer': '123',
+            'private_key': 'decoded-key',
+            'installation_id': '456',
+            'github_api_url': 'https://api.github.com',
+            'github_org': 'tenant-org',
+        },
+    )
+    monkeypatch.setattr(
+        handler, 'create_github_app_jwt', lambda *_args: 'app-jwt'
+    )
+
+    def fail_auth(*_args):
+        raise handler.ProbeFailure(
+            'github_authentication',
+            'installation request failed',
+            status_code=429,
+            headers={
+                'retry-after': '60',
+                'x-ratelimit-limit': '5000',
+                'x-ratelimit-remaining': '0',
+                'x-ratelimit-used': '5000',
+            },
+        )
+
+    monkeypatch.setattr(handler, 'get_installation_token', fail_auth)
+
+    assert handler.probe_tenant(_tenant_config(), object()) is False
+    auth_points = {
+        point['metric']: point['value']
+        for point in handler.queued_datapoints
+        if point['dimensions']['CheckName'] == 'Authentication'
+    }
+    assert auth_points['forge.dependency.availability'] == 0
+    assert auth_points['forge.dependency.rate_limited'] == 1
+    assert auth_points['forge.dependency.rate_limit_remaining_pct'] == 0
+    assert handler.queued_events[-1]['event']['status_code'] == 429
+    assert handler.queued_events[-1]['event']['error_type'] == 'ProbeFailure'
+
+
+def test_probe_tenant_reports_org_api_failure(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    monkeypatch.setattr(
+        handler,
+        'load_github_app_credentials',
+        lambda _ssm, _prefix: {
+            'issuer': '123',
+            'private_key': 'decoded-key',
+            'installation_id': '456',
+            'github_api_url': 'https://github.example/api/v3',
+            'github_org': 'tenant-org',
+        },
+    )
+    monkeypatch.setattr(
+        handler, 'create_github_app_jwt', lambda *_args: 'app-jwt'
+    )
+    monkeypatch.setattr(
+        handler,
+        'get_installation_token',
+        lambda *_args: ('installation-token', 1, {}),
+    )
+
+    def fail_org(*_args):
+        raise handler.ProbeFailure(
+            'github_org_runners_api',
+            'organization API failed',
+            status_code=403,
+            headers={'x-ratelimit-remaining': '0'},
+        )
+
+    monkeypatch.setattr(handler, 'check_organization_runner_api', fail_org)
+
+    assert handler.probe_tenant(_tenant_config(), object()) is False
+    org_points = {
+        point['metric']: point['value']
+        for point in handler.queued_datapoints
+        if point['dimensions']['CheckName'] == 'OrgRunnersApi'
+    }
+    assert org_points['forge.dependency.availability'] == 0
+    assert org_points['forge.dependency.rate_limited'] == 1
+    assert handler.queued_events[-1]['event']['github_mode'] == 'ghes'
+
+
+def test_lambda_handler_clears_warm_invocation_state(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    handler.queued_events.append({'stale': True})
+    handler.queued_datapoints.append({'stale': True})
+    delivered = []
+
+    monkeypatch.setattr(handler, 'discover_tenants', lambda: [])
+    monkeypatch.setattr(
+        handler.boto3,
+        'client',
+        lambda _service, *, region_name: object(),
+    )
+    monkeypatch.setattr(
+        handler.common,
+        'send_to_splunk_batch',
+        lambda events: delivered.append(('events', list(events))) or 0,
+    )
+    monkeypatch.setattr(
+        handler.common,
+        'send_metric_to_o11y_batch',
+        lambda metrics: delivered.append(('metrics', list(metrics))) or 0,
+    )
+
+    assert handler.lambda_handler({}, None) == {
+        'tenants': 0,
+        'succeeded': 0,
+        'failed': 0,
+        'events_sent': 0,
+        'metrics_sent': 0,
+        'delivery_failures': 0,
+    }
+    assert delivered == [('events', []), ('metrics', [])]
+
+
+def test_aws_client_requires_explicit_region(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    monkeypatch.setattr(handler, 'AWS_REGION', '')
+
+    with pytest.raises(ValueError, match='AWS_REGION'):
+        handler.aws_client('ssm')
+
+
+def test_discovery_rejects_unavailable_parameter(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    parameter_name = '/forge/tenant-a-usw2-sl/github_ghes_org'
+
+    class FakePaginator:
+        def paginate(self, **_kwargs):
+            return [{'Parameters': [{'Name': parameter_name}]}]
+
+    class FakeSsm:
+        def get_paginator(self, _operation_name):
+            return FakePaginator()
+
+        def get_parameters(self, **_kwargs):
+            return {
+                'Parameters': [],
+                'InvalidParameters': [parameter_name],
+            }
+
+    monkeypatch.setattr(
+        handler.boto3,
+        'client',
+        lambda _service, *, region_name: FakeSsm(),
+    )
+
+    with pytest.raises(ValueError, match='unavailable'):
+        handler.discover_tenants()
+
+
+def test_org_runner_probe_rejects_success_without_expected_shape(
+    monkeypatch, aws
+):
+    handler = _load_handler(monkeypatch)
+    monkeypatch.setattr(
+        handler,
+        'github_request',
+        lambda *_args, **_kwargs: (200, {}, {'runners': []}),
+    )
+
+    with pytest.raises(handler.ProbeFailure) as raised:
+        handler.check_organization_runner_api(
+            {
+                **_tenant_config(),
+                'github_api_url': 'https://api.github.com',
+                'github_org': 'tenant-org',
+            },
+            'installation-token',
+        )
+
+    assert raised.value.step == 'github_org_runners_api'
+    assert raised.value.status_code == 200
+
+
+@pytest.mark.parametrize('failure_stage', ['authentication', 'organization'])
+def test_probe_tenant_handles_unexpected_github_error(
+    monkeypatch, aws, failure_stage
+):
+    handler = _load_handler(monkeypatch)
+    monkeypatch.setattr(
+        handler,
+        'load_github_app_credentials',
+        lambda _ssm, _prefix: {
+            'issuer': '123',
+            'private_key': 'decoded-key',
+            'installation_id': '456',
+            'github_api_url': 'https://api.github.com',
+            'github_org': 'tenant-org',
+        },
+    )
+    monkeypatch.setattr(
+        handler, 'create_github_app_jwt', lambda *_args: 'app-jwt'
+    )
+    if failure_stage == 'authentication':
+        monkeypatch.setattr(
+            handler,
+            'get_installation_token',
+            lambda *_args: (_ for _ in ()).throw(
+                RuntimeError('JWT signing failure')
+            ),
+        )
+        expected_check = 'Authentication'
+    else:
+        monkeypatch.setattr(
+            handler,
+            'get_installation_token',
+            lambda *_args: ('installation-token', 1, {}),
+        )
+        monkeypatch.setattr(
+            handler,
+            'check_organization_runner_api',
+            lambda *_args: (_ for _ in ()).throw(
+                RuntimeError('unexpected response failure')
+            ),
+        )
+        expected_check = 'OrgRunnersApi'
+
+    assert handler.probe_tenant(_tenant_config(), object()) is False
+    failure_event = handler.queued_events[-1]['event']
+    assert failure_event['check_name'] == expected_check
+    assert failure_event['status_code'] == 0
+    assert failure_event['error_type'] == 'RuntimeError'
+    failure_metrics = {
+        point['metric']: point['value']
+        for point in handler.queued_datapoints
+        if point['dimensions']['CheckName'] == expected_check
+    }
+    assert failure_metrics['forge.dependency.availability'] == 0
+    assert failure_metrics['forge.dependency.rate_limited'] == 0
+
+
+def test_delivery_counts_both_destination_failures(
+    monkeypatch, aws, caplog
+):
+    handler = _load_handler(monkeypatch)
+
+    def fail_delivery(_batch):
+        http_error = RuntimeError('request rejected')
+        http_error.http_status = 403
+        http_error.response_code = '4'
+        http_error.response_text = 'Invalid token'
+        delivery_error = RuntimeError('destination unavailable')
+        delivery_error.__cause__ = http_error
+        raise delivery_error
+
+    monkeypatch.setattr(
+        handler.common, 'send_to_splunk_batch', fail_delivery
+    )
+    monkeypatch.setattr(
+        handler.common, 'send_metric_to_o11y_batch', fail_delivery
+    )
+
+    assert handler.deliver_queued_telemetry() == (0, 0, 2)
+    assert caplog.messages == [
+        'splunk_cloud_delivery_failed error_type=RuntimeError '
+        'cause_type=RuntimeError http_status=403 response_code=4 '
+        'response_text=Invalid token',
+        'splunk_o11y_delivery_failed error_type=RuntimeError '
+        'cause_type=RuntimeError http_status=403 response_code=4 '
+        'response_text=Invalid token',
+    ]


### PR DESCRIPTION
## Description

Adds a regional Forge dependency-monitor module and Lambda that discovers tenants from platform SSM metadata, validates regional AWS access and tenant GitHub App/API health, and sends probe metrics directly to Splunk Observability Cloud plus structured events to Splunk Cloud.

The monitor reads existing credentials and routing metadata rather than accepting a duplicated tenant configuration input. Delivery failures are logged without suppressing probe results, and the HEC request supports the required index and request-channel behavior.

Related split PRs:

- #510 publishes the GitHub URL and organization platform SSM metadata.
- #511 creates the dependency monitor's Splunk token secrets.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- `tofu test` in `modules/integrations/splunk_dependency_monitor` (2 passed)
- Focused Lambda tests (40 passed, 95% combined coverage)
- `pre-commit run --files` for all 14 changed files
- Commit-time repository hooks
