### PR TITLE
feat(observability): add AWS regional health dashboard

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/main.tf
@@ -1,0 +1,245 @@
+locals {
+  aws_account_ids = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_account_id"
+  ]))
+  aws_regions = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_region"
+  ]))
+  product_family_names = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_tag_ProductFamilyName"
+  ]))
+
+  aws_account_filter = length(local.aws_account_ids) > 0 ? join(" or ", [
+    for account_id in sort(local.aws_account_ids) : "filter('aws_account_id', '${account_id}')"
+  ]) : "filter('aws_account_id', '__forge_aws_account_scope_not_configured__')"
+  aws_region_filter = length(local.aws_regions) > 0 ? join(" or ", [
+    for aws_region in sort(local.aws_regions) : "filter('aws_region', '${aws_region}')"
+  ]) : "filter('aws_region', '__forge_aws_region_scope_not_configured__')"
+  product_family_filter = length(local.product_family_names) > 0 ? join(" or ", [
+    for product_family_name in sort(local.product_family_names) : "filter('aws_tag_ProductFamilyName', '${product_family_name}')"
+  ]) : "filter('aws_tag_ProductFamilyName', '__forge_product_family_scope_not_configured__')"
+
+  aws_platform_filter = "(${local.aws_account_filter}) and (${local.aws_region_filter}) and (${local.product_family_filter})"
+  build_queue_filter  = "filter('QueueName', '*-queued-builds') and (not filter('QueueName', '*_dead_letter'))"
+}
+
+resource "signalfx_time_chart" "lambda_throttle_attempt_rate" {
+  name        = "Forge AWS Lambda throttle attempt rate"
+  description = "Regional throttled-attempt percentage for Forge production Lambda functions. Warning baselines: use1 0.5%, usw2 20%, euw1 65% sustained for 10m."
+
+  program_text = <<-EOF
+throttles = data('Throttles', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region'])
+invocations = data('Invocations', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region'])
+throttle_attempt_rate = (throttles / (throttles + invocations)).scale(100).publish(label='A')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 2
+  disable_sampling          = true
+  on_chart_legend_dimension = "aws_region"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Percent"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  viz_options {
+    display_name = "Throttle attempt rate"
+    label        = "A"
+    value_suffix = "%"
+  }
+}
+
+resource "signalfx_time_chart" "lambda_throttle_count" {
+  name        = "Forge AWS Lambda throttle count"
+  description = "Five-minute Forge Lambda throttle count by AWS region. Use with the regional throttle-attempt rate and customer-impact signals; do not page on count alone."
+
+  program_text = "A = data('Throttles', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region']).publish(label='A')"
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "aws_region"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Throttles / 5m"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  viz_options {
+    display_name = "Lambda throttles"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "build_queue_oldest_age" {
+  name        = "Forge AWS build queue oldest age"
+  description = "Maximum oldest queued-build message age by AWS region. Warning above 75s for 10m; Major above 300s for 10m; recover below 60s for 15m."
+
+  program_text = "A = data('ApproximateAgeOfOldestMessage', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter})).max(over='5m').max(by=['aws_region']).publish(label='A')"
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "aws_region"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Seconds"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  viz_options {
+    display_name = "Oldest queued build"
+    label        = "A"
+    value_unit   = "Second"
+  }
+}
+
+resource "signalfx_time_chart" "build_queue_visible_backlog" {
+  name        = "Forge AWS build queue visible backlog"
+  description = "Visible queued-build messages by AWS region. Warning when above 10 for 10m together with oldest-message age above 75s."
+
+  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter})).max(over='5m').sum(by=['aws_region']).publish(label='A')"
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "aws_region"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Messages"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  viz_options {
+    display_name = "Visible queued builds"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "build_queue_dlq_sends" {
+  name        = "Forge AWS queued-build DLQ sends"
+  description = "Queued-build dead-letter queue sends by AWS region. Any non-zero value in 5m is a Major condition; escalate only with customer impact."
+
+  program_text = "A = data('NumberOfMessagesSent', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'sum') and filter('QueueName', '*_dead_letter'), rollup='sum').sum(over='5m').sum(by=['aws_region']).publish(label='A')"
+
+  plot_type                 = "ColumnChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "aws_region"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Messages / 5m"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  viz_options {
+    display_name = "Queued-build DLQ sends"
+    label        = "A"
+  }
+}
+
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
+resource "signalfx_dashboard" "aws_regional_health" {
+  name            = "Forge AWS Regional Platform Health"
+  description     = "Regional Forge control-plane Lambda throttling and queued-build SQS health."
+  dashboard_group = var.dashboard_group
+  time_range      = "-1h"
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
+
+  dynamic "variable" {
+    for_each = var.dynamic_variables
+    iterator = var_def
+
+    content {
+      property               = var_def.value.property
+      alias                  = var_def.value.alias
+      description            = var_def.value.description
+      values                 = var_def.value.values
+      value_required         = var_def.value.value_required
+      values_suggested       = var_def.value.values_suggested
+      restricted_suggestions = var_def.value.restricted_suggestions
+    }
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.lambda_throttle_attempt_rate.id
+    row      = 0
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.lambda_throttle_count.id
+    row      = 0
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.build_queue_oldest_age.id
+    row      = 1
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.build_queue_visible_backlog.id
+    row      = 1
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.build_queue_dlq_sends.id
+    row      = 2
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_behavior.tftest.hcl
@@ -1,0 +1,85 @@
+mock_provider "signalfx" {
+  mock_resource "signalfx_time_chart" {
+    defaults = {
+      id = "time-chart-id"
+    }
+  }
+  mock_resource "signalfx_dashboard" {}
+}
+
+variables {
+  dashboard_group = "forge-dashboard-group"
+  dynamic_variables = [
+    {
+      property               = "aws_account_id"
+      alias                  = "AWS account"
+      description            = "Forge AWS accounts."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["222222222222", "111111111111"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "aws_region"
+      alias                  = "AWS region"
+      description            = "Forge AWS regions."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["us-west-2", "eu-west-1"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "aws_tag_ProductFamilyName"
+      alias                  = "Product family"
+      description            = "Forge AWS product family."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["Forge MT"]
+      restricted_suggestions = true
+    },
+  ]
+}
+
+run "creates_regional_platform_dashboard" {
+  command = plan
+
+  assert {
+    condition = (
+      signalfx_dashboard.aws_regional_health.name == "Forge AWS Regional Platform Health"
+      && signalfx_dashboard.aws_regional_health.dashboard_group == "forge-dashboard-group"
+      && length(signalfx_dashboard.aws_regional_health.chart) == 5
+      && length(signalfx_dashboard.aws_regional_health.variable) == 3
+    )
+    error_message = "The regional platform dashboard must keep its distinct name, parent group, five live panels, and dedicated variables."
+  }
+
+  assert {
+    condition = alltrue([
+      for program_text in [
+        signalfx_time_chart.lambda_throttle_attempt_rate.program_text,
+        signalfx_time_chart.lambda_throttle_count.program_text,
+        signalfx_time_chart.build_queue_oldest_age.program_text,
+        signalfx_time_chart.build_queue_visible_backlog.program_text,
+        signalfx_time_chart.build_queue_dlq_sends.program_text,
+      ] :
+      strcontains(program_text, "filter('aws_account_id', '111111111111')")
+      && strcontains(program_text, "filter('aws_account_id', '222222222222')")
+      && strcontains(program_text, "filter('aws_region', 'eu-west-1')")
+      && strcontains(program_text, "filter('aws_region', 'us-west-2')")
+      && strcontains(program_text, "filter('aws_tag_ProductFamilyName', 'Forge MT')")
+    ])
+    error_message = "Every regional platform panel must be fail-closed to its configured AWS accounts, regions, and product family."
+  }
+
+  assert {
+    condition = (
+      strcontains(signalfx_time_chart.lambda_throttle_attempt_rate.program_text, "data('Throttles'")
+      && strcontains(signalfx_time_chart.lambda_throttle_attempt_rate.program_text, "data('Invocations'")
+      && strcontains(signalfx_time_chart.lambda_throttle_attempt_rate.program_text, ".scale(100)")
+      && strcontains(signalfx_time_chart.build_queue_oldest_age.program_text, "ApproximateAgeOfOldestMessage")
+      && strcontains(signalfx_time_chart.build_queue_visible_backlog.program_text, "ApproximateNumberOfMessagesVisible")
+      && strcontains(signalfx_time_chart.build_queue_dlq_sends.program_text, "NumberOfMessagesSent")
+    )
+    error_message = "The managed dashboard must preserve the five live regional Lambda and queued-build signals."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_interface_contract.tftest.hcl
@@ -1,0 +1,39 @@
+run "aws_regional_health_dashboard_interface_contract" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_interface_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_input_variables = [
+      "dashboard_group",
+      "dynamic_variables",
+    ]
+    expected_output_values = []
+    expected_interface_literals = [
+      "variable \"dashboard_group\"",
+      "description = \"Splunk Observability dashboard group ID.\"",
+      "variable \"dynamic_variables\"",
+      "property               = string",
+      "values_suggested       = list(string)",
+      "restricted_suggestions = bool",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_input_variables) == 0 && length(output.unexpected_input_variables) == 0
+    error_message = "Regional AWS dashboard input contract is not exact."
+  }
+
+  assert {
+    condition     = length(output.missing_output_values) == 0 && length(output.unexpected_output_values) == 0
+    error_message = "Regional AWS dashboard must not expose unexpected outputs."
+  }
+
+  assert {
+    condition     = length(output.missing_interface_literals) == 0
+    error_message = "Regional AWS dashboard interface is missing expected source literals."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_source_inventory.tftest.hcl
@@ -1,0 +1,35 @@
+run "aws_regional_health_dashboard_source_inventory" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "resource \"signalfx_time_chart\" \"lambda_throttle_attempt_rate\"",
+      "resource \"signalfx_time_chart\" \"lambda_throttle_count\"",
+      "resource \"signalfx_time_chart\" \"build_queue_oldest_age\"",
+      "resource \"signalfx_time_chart\" \"build_queue_visible_backlog\"",
+      "resource \"signalfx_time_chart\" \"build_queue_dlq_sends\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
+      "resource \"signalfx_dashboard\" \"aws_regional_health\"",
+      "Forge AWS Regional Platform Health",
+      "__forge_aws_account_scope_not_configured__",
+      "__forge_aws_region_scope_not_configured__",
+      "__forge_product_family_scope_not_configured__",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "Regional AWS dashboard source inventory is missing expected Terraform or fail-closed scope literals: ${join(", ", output.missing_expected_literals)}"
+  }
+
+  assert {
+    condition     = output.expected_literal_count == 12
+    error_message = "Regional AWS dashboard source inventory count must remain pinned."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/variables.tf
@@ -1,0 +1,17 @@
+variable "dynamic_variables" {
+  description = "AWS account, region, and product-family dashboard variable definitions used to scope regional platform health."
+  type = list(object({
+    property               = string
+    alias                  = string
+    description            = string
+    values                 = list(string)
+    value_required         = bool
+    values_suggested       = list(string)
+    restricted_suggestions = bool
+  }))
+}
+
+variable "dashboard_group" {
+  description = "Splunk Observability dashboard group ID."
+  type        = string
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "< 10.0.0"
+    }
+  }
+
+  required_version = "~> 1.11"
+}


### PR DESCRIPTION
## Description

Adds the Terraform-managed `Forge AWS Regional Platform Health` dashboard module. It provides regional Lambda and build-queue control-plane health panels with focused behavior, interface, and source-inventory tests.

Shared dashboard wiring and configuration remain in PR #507.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- `tofu test` in the dashboard module (3 passed)
- Repository commit hooks
