### PR TITLE
feat(observability): add AWS service limits dashboard

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/main.tf
@@ -1,0 +1,162 @@
+locals {
+  aws_account_ids = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_account_id"
+  ]))
+  aws_regions = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "Region"
+  ]))
+
+  aws_account_filter = length(local.aws_account_ids) > 0 ? join(" or ", [
+    for account_id in sort(local.aws_account_ids) : "filter('aws_account_id', '${account_id}')"
+  ]) : "filter('aws_account_id', '__forge_aws_account_scope_not_configured__')"
+  aws_region_filter = length(local.aws_regions) > 0 ? join(" or ", concat(
+    ["filter('Region', '-')"],
+    [for aws_region in sort(local.aws_regions) : "filter('Region', '${aws_region}')"],
+  )) : "filter('Region', '__forge_aws_region_scope_not_configured__')"
+
+  aws_service_limit_filter = "(${local.aws_account_filter}) and (${local.aws_region_filter}) and filter('namespace', 'AWS/TrustedAdvisor') and filter('stat', 'upper')"
+
+  forge_services = {
+    autoscaling = {
+      column       = 6
+      display_name = "Auto Scaling"
+      row          = 1
+      service_name = "AutoScaling"
+    }
+    cloudformation = {
+      column       = 0
+      display_name = "CloudFormation"
+      row          = 3
+      service_name = "CloudFormation"
+    }
+    dynamodb = {
+      column       = 0
+      display_name = "DynamoDB"
+      row          = 2
+      service_name = "DynamoDB"
+    }
+    ebs = {
+      column       = 6
+      display_name = "EBS"
+      row          = 0
+      service_name = "EBS"
+    }
+    ec2 = {
+      column       = 0
+      display_name = "EC2"
+      row          = 0
+      service_name = "EC2"
+    }
+    iam = {
+      column       = 6
+      display_name = "IAM"
+      row          = 2
+      service_name = "IAM"
+    }
+    route53 = {
+      column       = 6
+      display_name = "Route 53"
+      row          = 3
+      service_name = "Route53"
+    }
+    vpc = {
+      column       = 0
+      display_name = "VPC"
+      row          = 1
+      service_name = "VPC"
+    }
+  }
+}
+
+resource "signalfx_list_chart" "service_limit" {
+  for_each = local.forge_services
+
+  name        = "${each.value.display_name} service-limit usage"
+  description = "One-day average AWS Trusted Advisor service-limit usage for ${each.value.display_name}, by region and limit."
+
+  program_text = "A = data('ServiceLimitUsage', filter=(${local.aws_service_limit_filter}) and filter('ServiceName', '${each.value.service_name}'), rollup='average').mean(over='1d').scale(100).max(by=['Region', 'ServiceLimit']).publish(label='A')"
+  sort_by      = "-value"
+
+  color_by                = "Scale"
+  disable_sampling        = true
+  hide_missing_values     = true
+  max_precision           = 2
+  secondary_visualization = "Sparkline"
+  time_range              = 86400
+
+  color_scale {
+    color = "green"
+    lt    = 80
+  }
+  color_scale {
+    color = "orange"
+    gte   = 80
+    lt    = 100
+  }
+  color_scale {
+    color = "red"
+    gte   = 100
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "Region"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "ServiceLimit"
+  }
+
+  viz_options {
+    display_name = "${each.value.display_name} limit usage"
+    label        = "A"
+    value_suffix = "%"
+  }
+}
+
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
+resource "signalfx_dashboard" "aws_service_limits" {
+  name            = "Forge Control Plane - AWS Service Limits"
+  description     = "AWS Trusted Advisor service-limit usage for AWS services used by Forge."
+  dashboard_group = var.dashboard_group
+  time_range      = "-24h"
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
+
+  dynamic "variable" {
+    for_each = var.dynamic_variables
+    iterator = var_def
+
+    content {
+      property               = var_def.value.property
+      alias                  = var_def.value.alias
+      description            = var_def.value.description
+      values                 = var_def.value.values
+      value_required         = var_def.value.value_required
+      values_suggested       = var_def.value.values_suggested
+      restricted_suggestions = var_def.value.restricted_suggestions
+    }
+  }
+
+  dynamic "chart" {
+    for_each = local.forge_services
+    iterator = service
+
+    content {
+      chart_id = signalfx_list_chart.service_limit[service.key].id
+      row      = service.value.row
+      column   = service.value.column
+      width    = 6
+      height   = 1
+    }
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_behavior.tftest.hcl
@@ -1,0 +1,79 @@
+mock_provider "signalfx" {
+  mock_resource "signalfx_list_chart" {
+    defaults = { id = "list-chart-id" }
+  }
+  mock_resource "signalfx_dashboard" {}
+}
+
+variables {
+  dashboard_group = "forge-dashboard-group"
+  dynamic_variables = [
+    {
+      property               = "aws_account_id"
+      alias                  = "AWS account"
+      description            = ""
+      values                 = []
+      value_required         = false
+      values_suggested       = ["111111111111"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "Region"
+      alias                  = "AWS region"
+      description            = ""
+      values                 = []
+      value_required         = false
+      values_suggested       = ["eu-west-1", "us-west-2"]
+      restricted_suggestions = true
+    },
+  ]
+}
+
+run "creates_aws_service_limits_dashboard" {
+  command = plan
+
+  assert {
+    condition = (
+      signalfx_dashboard.aws_service_limits.name == "Forge Control Plane - AWS Service Limits"
+      && length(signalfx_dashboard.aws_service_limits.chart) == 8
+      && length(signalfx_dashboard.aws_service_limits.variable) == 2
+      && length(signalfx_list_chart.service_limit) == 8
+    )
+    error_message = "The AWS service-limits dashboard must create one chart for each supported Forge AWS service."
+  }
+
+  assert {
+    condition = alltrue([
+      for chart in values(signalfx_list_chart.service_limit) :
+      strcontains(chart.program_text, "filter('aws_account_id', '111111111111')")
+      && strcontains(chart.program_text, "filter('Region', '-')")
+      && strcontains(chart.program_text, "filter('Region', 'eu-west-1')")
+      && strcontains(chart.program_text, "filter('namespace', 'AWS/TrustedAdvisor')")
+      && strcontains(chart.program_text, "filter('stat', 'upper')")
+      && strcontains(chart.program_text, "data('ServiceLimitUsage'")
+      && strcontains(chart.program_text, ".mean(over='1d').scale(100)")
+      && strcontains(chart.program_text, ".max(by=['Region', 'ServiceLimit'])")
+      && chart.color_by == "Scale"
+      && anytrue([for scale in chart.color_scale : scale.gte == 80 && scale.lt == 100])
+      && anytrue([for scale in chart.color_scale : scale.gte == 100])
+    ])
+    error_message = "Every service-limit chart must preserve the built-in Trusted Advisor percentage calculation and warning/critical thresholds."
+  }
+
+  assert {
+    condition = toset([
+      for chart in values(signalfx_list_chart.service_limit) :
+      regex("filter\\('ServiceName', '([^']+)'\\)", chart.program_text)[0]
+      ]) == toset([
+      "AutoScaling",
+      "CloudFormation",
+      "DynamoDB",
+      "EBS",
+      "EC2",
+      "IAM",
+      "Route53",
+      "VPC",
+    ])
+    error_message = "The dashboard must have one chart for every Trusted Advisor service used by Forge."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_interface_contract.tftest.hcl
@@ -1,0 +1,22 @@
+run "aws_service_limits_dashboard_interface_contract" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_interface_contract"
+  }
+
+  variables {
+    module_path              = "."
+    expected_input_variables = ["dashboard_group", "dynamic_variables"]
+    expected_output_values   = []
+    expected_interface_literals = [
+      "variable \"dashboard_group\"",
+      "variable \"dynamic_variables\"",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_input_variables) == 0 && length(output.unexpected_input_variables) == 0
+    error_message = "AWS service-limits dashboard input contract is not exact."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_source_inventory.tftest.hcl
@@ -1,0 +1,29 @@
+run "aws_service_limits_dashboard_source_inventory" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "resource \"signalfx_dashboard\" \"aws_service_limits\"",
+      "Forge Control Plane - AWS Service Limits",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "filter('namespace', 'AWS/TrustedAdvisor')",
+      "data('ServiceLimitUsage'",
+      "service_name = \"EC2\"",
+      "service_name = \"VPC\"",
+      "service_name = \"IAM\"",
+      ".mean(over='1d').scale(100)",
+      "__forge_aws_account_scope_not_configured__",
+      "__forge_aws_region_scope_not_configured__",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "AWS service-limits dashboard source inventory is incomplete: ${join(", ", output.missing_expected_literals)}"
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/variables.tf
@@ -1,0 +1,17 @@
+variable "dynamic_variables" {
+  description = "AWS account and Trusted Advisor Region dashboard variable definitions used to scope AWS service-limit metrics."
+  type = list(object({
+    property               = string
+    alias                  = string
+    description            = string
+    values                 = list(string)
+    value_required         = bool
+    values_suggested       = list(string)
+    restricted_suggestions = bool
+  }))
+}
+
+variable "dashboard_group" {
+  description = "Splunk Observability dashboard group ID."
+  type        = string
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "< 10.0.0"
+    }
+  }
+
+  required_version = "~> 1.11"
+}


### PR DESCRIPTION
## Description

Adds the Terraform-managed `Forge AWS Service Limits` dashboard module, with one utilization chart for each AWS service used by Forge and focused behavior, interface, and source-inventory tests.

Shared dashboard wiring and configuration remain in PR #507.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- `tofu test` in the dashboard module
- Repository commit hooks
