### PR TITLE
feat(observability): add dependency probes dashboard

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/main.tf
@@ -1,0 +1,255 @@
+locals {
+  tenant_filter = length(var.tenant_names) > 0 ? join(" or ", [
+    for tenant_name in sort(var.tenant_names) :
+    "filter('TenantName', '${tenant_name}')"
+  ]) : "filter('TenantName', '__forge_tenant_scope_not_configured__')"
+  metric_filter = "(${local.tenant_filter})"
+}
+
+resource "signalfx_list_chart" "github_availability" {
+  name                    = "GitHub checks by tenant"
+  description             = "Latest GitHub authentication and organization runner API availability. Zero indicates a failed check."
+  color_by                = "Scale"
+  hide_missing_values     = false
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "+value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  program_text = "A = data('forge.dependency.availability', filter=(${local.metric_filter}) and filter('Provider', 'GitHub'), rollup='latest').min(by=['TenantName', 'AWSRegion', 'CheckName']).publish(label='A')"
+
+  color_scale {
+    color = "red"
+    lt    = 1
+  }
+  color_scale {
+    color = "green"
+    gte   = 1
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "TenantName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "CheckName"
+  }
+
+  viz_options {
+    display_name = "GitHub availability"
+    label        = "A"
+  }
+}
+
+resource "signalfx_list_chart" "ssm_availability" {
+  name                    = "AWS SSM access by tenant"
+  description             = "Latest regional access result for the tenant GitHub App and routing parameters."
+  color_by                = "Scale"
+  hide_missing_values     = false
+  max_precision           = 0
+  secondary_visualization = "Sparkline"
+  sort_by                 = "+value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  program_text = "A = data('forge.dependency.availability', filter=(${local.metric_filter}) and filter('Provider', 'AWS') and filter('CheckName', 'SSMCredentials'), rollup='latest').min(by=['TenantName', 'AWSRegion']).publish(label='A')"
+
+  color_scale {
+    color = "red"
+    lt    = 1
+  }
+  color_scale {
+    color = "green"
+    gte   = 1
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "TenantName"
+  }
+
+  viz_options {
+    display_name = "SSM availability"
+    label        = "A"
+  }
+}
+
+resource "signalfx_list_chart" "rate_limit_budget" {
+  name                    = "GitHub API rate-limit budget"
+  description             = "Latest percentage of the installation token's GitHub API rate-limit budget remaining."
+  color_by                = "Scale"
+  hide_missing_values     = false
+  max_precision           = 2
+  secondary_visualization = "Sparkline"
+  sort_by                 = "+value"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  program_text = "A = data('forge.dependency.rate_limit_remaining_pct', filter=(${local.metric_filter}) and filter('Provider', 'GitHub') and filter('CheckName', 'OrgRunnersApi'), rollup='latest').min(by=['TenantName', 'AWSRegion']).publish(label='A')"
+
+  color_scale {
+    color = "red"
+    lt    = 10
+  }
+  color_scale {
+    color = "orange"
+    gte   = 10
+    lt    = 25
+  }
+  color_scale {
+    color = "green"
+    gte   = 25
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "TenantName"
+  }
+
+  viz_options {
+    display_name = "Rate-limit remaining"
+    label        = "A"
+    value_suffix = "%"
+  }
+}
+
+resource "signalfx_time_chart" "latency" {
+  name        = "Dependency check latency"
+  description = "SSM, GitHub App authentication, and organization runner API latency by tenant and region."
+
+  program_text = "A = data('forge.dependency.latency_ms', filter=(${local.metric_filter}), rollup='average').mean(by=['TenantName', 'AWSRegion', 'Provider', 'CheckName']).publish(label='A')"
+
+  plot_type        = "LineChart"
+  show_event_lines = false
+  time_range       = 3600
+  unit_prefix      = "Metric"
+
+  axis_left {
+    label = "Milliseconds"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "TenantName"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "Provider"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "CheckName"
+  }
+
+  viz_options {
+    display_name = "Latency"
+    label        = "A"
+    value_unit   = "Millisecond"
+  }
+}
+
+resource "signalfx_time_chart" "probe_execution" {
+  name        = "Regional probe execution"
+  description = "Scheduled dependency-probe executions by tenant and AWS region. Missing series indicate absent telemetry."
+
+  program_text = "A = data('forge.dependency.probe_executed', filter=(${local.metric_filter}) and filter('Provider', 'Forge') and filter('CheckName', 'TenantCycle'), rollup='sum').sum(by=['TenantName', 'AWSRegion']).publish(label='A')"
+
+  plot_type        = "ColumnChart"
+  show_event_lines = false
+  time_range       = 3600
+  unit_prefix      = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "TenantName"
+  }
+
+  viz_options {
+    display_name = "Probe executions"
+    label        = "A"
+  }
+}
+
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
+resource "signalfx_dashboard" "dependency_health" {
+  name            = "Forge External Dependency Health"
+  description     = "Tenant-level GitHub and AWS dependency availability, latency, rate-limit budget, and regional probe telemetry."
+  dashboard_group = var.dashboard_group
+  time_range      = "-1h"
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
+
+  variable {
+    property               = "aws_tag_TenantName"
+    alias                  = "ForgeCICD Tenant Name"
+    description            = ""
+    values                 = []
+    value_required         = false
+    values_suggested       = sort(var.tenant_names)
+    restricted_suggestions = true
+  }
+
+  dynamic "variable" {
+    for_each = var.dynamic_variables
+    iterator = var_def
+
+    content {
+      property               = var_def.value.property
+      alias                  = var_def.value.alias
+      description            = var_def.value.description
+      values                 = var_def.value.values
+      value_required         = var_def.value.value_required
+      values_suggested       = var_def.value.values_suggested
+      restricted_suggestions = var_def.value.restricted_suggestions
+    }
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.github_availability.id
+    row      = 0
+    column   = 0
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.ssm_availability.id
+    row      = 0
+    column   = 4
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.rate_limit_budget.id
+    row      = 0
+    column   = 8
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.latency.id
+    row      = 1
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.probe_execution.id
+    row      = 2
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/dependency_probes_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/dependency_probes_dashboard_behavior.tftest.hcl
@@ -1,0 +1,70 @@
+mock_provider "signalfx" {
+  mock_resource "signalfx_list_chart" {
+    defaults = {
+      id = "list-chart-id"
+    }
+  }
+  mock_resource "signalfx_time_chart" {
+    defaults = {
+      id = "time-chart-id"
+    }
+  }
+  mock_resource "signalfx_dashboard" {}
+}
+
+variables {
+  dashboard_group = "forge-dashboard-group"
+  tenant_names    = ["tenant-b", "tenant-a"]
+  dynamic_variables = [{
+    property               = "AWSRegion"
+    alias                  = "AWS region"
+    description            = "Regional dependency probe scope."
+    values                 = ["eu-west-1"]
+    value_required         = true
+    values_suggested       = ["eu-west-1"]
+    restricted_suggestions = true
+  }]
+}
+
+run "creates_dependency_health_dashboard" {
+  command = plan
+
+  assert {
+    condition     = signalfx_dashboard.dependency_health.name == "Forge External Dependency Health"
+    error_message = "The dependency-health dashboard must keep its operator-facing name."
+  }
+
+  assert {
+    condition     = length(signalfx_dashboard.dependency_health.chart) == 5
+    error_message = "The dashboard must retain GitHub, AWS, rate-limit, latency, and telemetry coverage."
+  }
+
+  assert {
+    condition = (
+      signalfx_dashboard.dependency_health.variable[0].property == "aws_tag_TenantName"
+      && signalfx_dashboard.dependency_health.variable[0].alias == "ForgeCICD Tenant Name"
+      && length(signalfx_dashboard.dependency_health.variable[0].values) == 0
+      && signalfx_dashboard.dependency_health.variable[0].values_suggested == toset(["tenant-a", "tenant-b"])
+    )
+    error_message = "The dashboard tenant selector must use the Forge AWS tag convention and suggest the configured tenant names without selecting them by default."
+  }
+
+  assert {
+    condition = (
+      length(signalfx_dashboard.dependency_health.variable) == 2
+      && signalfx_dashboard.dependency_health.variable[1].property == "AWSRegion"
+      && signalfx_dashboard.dependency_health.variable[1].values == toset(["eu-west-1"])
+    )
+    error_message = "The dependency dashboard must render its own configured dynamic variables."
+  }
+
+  assert {
+    condition = (
+      strcontains(signalfx_list_chart.github_availability.program_text, "forge.dependency.availability")
+      && !strcontains(signalfx_list_chart.github_availability.program_text, "filter('namespace'")
+      && strcontains(signalfx_list_chart.github_availability.program_text, "filter('TenantName', 'tenant-a')")
+      && strcontains(signalfx_list_chart.github_availability.program_text, "filter('TenantName', 'tenant-b')")
+    )
+    error_message = "Dependency charts must use direct Splunk metric names and remain scoped to configured tenants."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/dependency_probes_dashboard_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/dependency_probes_dashboard_source_inventory.tftest.hcl
@@ -1,0 +1,34 @@
+run "dependency_probes_dashboard_source_inventory" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "resource \"signalfx_dashboard\" \"dependency_health\"",
+      "resource \"signalfx_list_chart\" \"github_availability\"",
+      "resource \"signalfx_list_chart\" \"ssm_availability\"",
+      "resource \"signalfx_list_chart\" \"rate_limit_budget\"",
+      "resource \"signalfx_time_chart\" \"latency\"",
+      "resource \"signalfx_time_chart\" \"probe_execution\"",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
+      "forge.dependency.availability",
+      "forge.dependency.latency_ms",
+      "forge.dependency.probe_executed",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "Dependency dashboard is missing expected resources: ${join(", ", output.missing_expected_literals)}"
+  }
+
+  assert {
+    condition     = output.expected_literal_count == 11
+    error_message = "Dependency dashboard source inventory count must remain pinned."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface_contract.tftest.hcl
@@ -1,0 +1,71 @@
+run "integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface_contract" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_interface_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_input_variables = [
+      "dashboard_group",
+      "dynamic_variables",
+      "tenant_names",
+    ]
+    expected_output_values = []
+    expected_interface_literals = [
+      "variable \"dashboard_group\"",
+      "description = \"Splunk Observability dashboard group ID.\"",
+      "type        = string",
+      "variable \"dynamic_variables\"",
+      "description = \"Additional dynamic variable definitions for the dashboard.\"",
+      "type = list(object({",
+      "property               = string",
+      "alias                  = string",
+      "description            = string",
+      "values                 = list(string)",
+      "value_required         = bool",
+      "values_suggested       = list(string)",
+      "restricted_suggestions = bool",
+      "}))",
+      "default = []",
+      "variable \"tenant_names\"",
+      "description = \"Forge tenants available in the dashboard selector.\"",
+      "type        = list(string)",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_input_variables) == 0
+    error_message = "Interface contract is missing input variables: ${join(", ", output.missing_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.unexpected_input_variables) == 0
+    error_message = "Interface contract has unexpected input variables: ${join(", ", output.unexpected_input_variables)}"
+  }
+
+  assert {
+    condition     = length(output.missing_output_values) == 0
+    error_message = "Interface contract is missing outputs: ${join(", ", output.missing_output_values)}"
+  }
+
+  assert {
+    condition     = length(output.unexpected_output_values) == 0
+    error_message = "Interface contract has unexpected outputs: ${join(", ", output.unexpected_output_values)}"
+  }
+
+  assert {
+    condition     = length(output.missing_interface_literals) == 0
+    error_message = "Interface contract is missing expected variable/output source lines: ${join(", ", output.missing_interface_literals)}"
+  }
+
+  assert {
+    condition = (
+      output.expected_input_variable_count == 3
+      && output.expected_output_value_count == 0
+      && output.expected_interface_literal_count == 18
+    )
+    error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/variables.tf
@@ -1,0 +1,23 @@
+variable "dashboard_group" {
+  description = "Splunk Observability dashboard group ID."
+  type        = string
+}
+
+variable "dynamic_variables" {
+  description = "Additional dynamic variable definitions for the dashboard."
+  type = list(object({
+    property               = string
+    alias                  = string
+    description            = string
+    values                 = list(string)
+    value_required         = bool
+    values_suggested       = list(string)
+    restricted_suggestions = bool
+  }))
+  default = []
+}
+
+variable "tenant_names" {
+  description = "Forge tenants available in the dashboard selector."
+  type        = list(string)
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "< 10.0.0"
+    }
+  }
+
+  required_version = "~> 1.11"
+}


### PR DESCRIPTION
## Description

Adds the Terraform-managed `Forge External Dependency Health` dashboard module for tenant GitHub and regional AWS dependency-probe results, with focused behavior, interface, and source-inventory tests.

Shared dashboard wiring and configuration remain in PR #507.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- `tofu test` in the dashboard module
- Repository commit hooks
