### PR TITLE
feat(observability): add Lambda control-plane dashboard

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/main.tf
@@ -1,0 +1,280 @@
+locals {
+  aws_account_ids = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_account_id"
+  ]))
+  aws_regions = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_region"
+  ]))
+  product_family_names = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_tag_ProductFamilyName"
+  ]))
+
+  aws_account_filter = length(local.aws_account_ids) > 0 ? join(" or ", [
+    for account_id in sort(local.aws_account_ids) : "filter('aws_account_id', '${account_id}')"
+  ]) : "filter('aws_account_id', '__forge_aws_account_scope_not_configured__')"
+  aws_region_filter = length(local.aws_regions) > 0 ? join(" or ", [
+    for aws_region in sort(local.aws_regions) : "filter('aws_region', '${aws_region}')"
+  ]) : "filter('aws_region', '__forge_aws_region_scope_not_configured__')"
+  product_family_filter = length(local.product_family_names) > 0 ? join(" or ", [
+    for product_family_name in sort(local.product_family_names) : "filter('aws_tag_ProductFamilyName', '${product_family_name}')"
+  ]) : "filter('aws_tag_ProductFamilyName', '__forge_product_family_scope_not_configured__')"
+
+  aws_platform_filter     = "(${local.aws_account_filter}) and (${local.aws_region_filter}) and (${local.product_family_filter})"
+  control_plane_filter    = "(${local.aws_platform_filter}) and (not filter('aws_tag_TenantName', '*'))"
+  lambda_dimension_filter = "filter('namespace', 'AWS/Lambda') and filter('aws_function_name', '*')"
+}
+
+resource "signalfx_single_value_chart" "function_count" {
+  name        = "# Control-plane functions"
+  description = "Number of Forge Lambda functions without the TenantName tag in the selected AWS scope."
+
+  program_text = "A = data('Invocations', filter=(${local.control_plane_filter}) and (${local.lambda_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').count(by=['aws_function_name']).count().publish(label='A')"
+
+  color_by = "Dimension"
+
+  viz_options {
+    display_name = "Control-plane functions"
+    label        = "A"
+  }
+}
+
+resource "signalfx_single_value_chart" "total_invocations" {
+  name        = "Invocations - sum(30m)"
+  description = "Total invocations for Forge control-plane Lambda functions over the last 30 minutes."
+
+  program_text = "A = data('Invocations', filter=(${local.control_plane_filter}) and (${local.lambda_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='30m').sum().publish(label='A')"
+
+  color_by = "Dimension"
+
+  viz_options {
+    display_name = "Invocations"
+    label        = "A"
+  }
+}
+
+resource "signalfx_single_value_chart" "total_errors" {
+  name        = "Errors - sum(30m)"
+  description = "Total errors for Forge control-plane Lambda functions over the last 30 minutes."
+
+  program_text = "A = data('Errors', filter=(${local.control_plane_filter}) and (${local.lambda_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='30m').sum().publish(label='A')"
+
+  color_by = "Dimension"
+
+  viz_options {
+    display_name = "Errors"
+    label        = "A"
+  }
+}
+
+resource "signalfx_single_value_chart" "total_throttles" {
+  name        = "Throttles - sum(30m)"
+  description = "Total throttles for Forge control-plane Lambda functions over the last 30 minutes."
+
+  program_text = "A = data('Throttles', filter=(${local.control_plane_filter}) and (${local.lambda_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='30m').sum().publish(label='A')"
+
+  color_by = "Dimension"
+
+  viz_options {
+    display_name = "Throttles"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "invocations_by_function" {
+  name        = "Invocations by control-plane function"
+  description = "Five-minute invocation volume by Forge control-plane Lambda function and AWS region."
+
+  program_text = "A = data('Invocations', filter=(${local.control_plane_filter}) and (${local.lambda_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'aws_function_name']).publish(label='A')"
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "aws_function_name"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Invocations / 5m"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_function_name"
+  }
+
+  viz_options {
+    display_name = "Invocations"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "errors_and_throttles_by_function" {
+  name        = "Errors and throttles by control-plane function"
+  description = "Five-minute error and throttle counts by Forge control-plane Lambda function and AWS region."
+
+  program_text = <<-EOF
+errors = data('Errors', filter=(${local.control_plane_filter}) and (${local.lambda_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'aws_function_name']).publish(label='A')
+throttles = data('Throttles', filter=(${local.control_plane_filter}) and (${local.lambda_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'aws_function_name']).publish(label='B')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "aws_function_name"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Events / 5m"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_function_name"
+  }
+
+  viz_options {
+    display_name = "Errors"
+    label        = "A"
+  }
+
+  viz_options {
+    display_name = "Throttles"
+    label        = "B"
+  }
+}
+
+resource "signalfx_time_chart" "duration_by_function" {
+  name        = "Average duration by control-plane function"
+  description = "Average execution duration by Forge control-plane Lambda function and AWS region."
+
+  program_text = "A = data('Duration', filter=(${local.control_plane_filter}) and (${local.lambda_dimension_filter}) and filter('stat', 'mean'), rollup='average').mean(over='5m').mean(by=['aws_region', 'aws_function_name']).publish(label='A')"
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "aws_function_name"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Milliseconds"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_function_name"
+  }
+
+  viz_options {
+    display_name = "Average duration"
+    label        = "A"
+    value_unit   = "Millisecond"
+  }
+}
+
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
+resource "signalfx_dashboard" "lambda_control_plane" {
+  name            = "Forge Control Plane - Lambdas"
+  description     = "Health and activity for Forge Lambda functions that are not assigned to a tenant."
+  dashboard_group = var.dashboard_group
+  time_range      = "-1h"
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
+
+  dynamic "variable" {
+    for_each = var.dynamic_variables
+    iterator = var_def
+
+    content {
+      property               = var_def.value.property
+      alias                  = var_def.value.alias
+      description            = var_def.value.description
+      values                 = var_def.value.values
+      value_required         = var_def.value.value_required
+      values_suggested       = var_def.value.values_suggested
+      restricted_suggestions = var_def.value.restricted_suggestions
+    }
+  }
+
+  chart {
+    chart_id = signalfx_single_value_chart.function_count.id
+    row      = 0
+    column   = 0
+    width    = 3
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_single_value_chart.total_invocations.id
+    row      = 0
+    column   = 3
+    width    = 3
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_single_value_chart.total_errors.id
+    row      = 0
+    column   = 6
+    width    = 3
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_single_value_chart.total_throttles.id
+    row      = 0
+    column   = 9
+    width    = 3
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.invocations_by_function.id
+    row      = 1
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.errors_and_throttles_by_function.id
+    row      = 2
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.duration_by_function.id
+    row      = 3
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/tests/lambda_control_plane_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/tests/lambda_control_plane_dashboard_behavior.tftest.hcl
@@ -1,0 +1,81 @@
+mock_provider "signalfx" {
+  mock_resource "signalfx_single_value_chart" {
+    defaults = {
+      id = "single-value-chart-id"
+    }
+  }
+  mock_resource "signalfx_time_chart" {
+    defaults = {
+      id = "time-chart-id"
+    }
+  }
+  mock_resource "signalfx_dashboard" {}
+}
+
+variables {
+  dashboard_group = "forge-dashboard-group"
+  dynamic_variables = [
+    {
+      property               = "aws_account_id"
+      alias                  = "AWS account"
+      description            = "Forge AWS accounts."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["222222222222", "111111111111"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "aws_region"
+      alias                  = "AWS region"
+      description            = "Forge AWS regions."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["us-west-2", "eu-west-1"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "aws_tag_ProductFamilyName"
+      alias                  = "Product family"
+      description            = "Forge AWS product family."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["Forge MT"]
+      restricted_suggestions = true
+    },
+  ]
+}
+
+run "creates_lambda_control_plane_dashboard" {
+  command = plan
+
+  assert {
+    condition = (
+      signalfx_dashboard.lambda_control_plane.name == "Forge Control Plane - Lambdas"
+      && signalfx_dashboard.lambda_control_plane.dashboard_group == "forge-dashboard-group"
+      && length(signalfx_dashboard.lambda_control_plane.chart) == 7
+      && length(signalfx_dashboard.lambda_control_plane.variable) == 3
+    )
+    error_message = "The Lambda control-plane dashboard must keep its name, parent group, seven panels, and dedicated variables."
+  }
+
+  assert {
+    condition = alltrue([
+      for program_text in [
+        signalfx_single_value_chart.function_count.program_text,
+        signalfx_single_value_chart.total_invocations.program_text,
+        signalfx_single_value_chart.total_errors.program_text,
+        signalfx_single_value_chart.total_throttles.program_text,
+        signalfx_time_chart.invocations_by_function.program_text,
+        signalfx_time_chart.errors_and_throttles_by_function.program_text,
+        signalfx_time_chart.duration_by_function.program_text,
+      ] :
+      strcontains(program_text, "filter('aws_account_id', '111111111111')")
+      && strcontains(program_text, "filter('aws_account_id', '222222222222')")
+      && strcontains(program_text, "filter('aws_region', 'eu-west-1')")
+      && strcontains(program_text, "filter('aws_region', 'us-west-2')")
+      && strcontains(program_text, "filter('aws_tag_ProductFamilyName', 'Forge MT')")
+      && strcontains(program_text, "not filter('aws_tag_TenantName', '*')")
+    ])
+    error_message = "Every Lambda control-plane panel must be fail-closed and exclude tenant-tagged functions."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/tests/lambda_control_plane_dashboard_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/tests/lambda_control_plane_dashboard_interface_contract.tftest.hcl
@@ -1,0 +1,28 @@
+run "lambda_control_plane_dashboard_interface_contract" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_interface_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_input_variables = [
+      "dashboard_group",
+      "dynamic_variables",
+    ]
+    expected_output_values = []
+    expected_interface_literals = [
+      "variable \"dashboard_group\"",
+      "variable \"dynamic_variables\"",
+      "property               = string",
+      "values_suggested       = list(string)",
+      "restricted_suggestions = bool",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_input_variables) == 0 && length(output.unexpected_input_variables) == 0
+    error_message = "Lambda control-plane dashboard input contract is not exact."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/tests/lambda_control_plane_dashboard_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/tests/lambda_control_plane_dashboard_source_inventory.tftest.hcl
@@ -1,0 +1,26 @@
+run "lambda_control_plane_dashboard_source_inventory" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "resource \"signalfx_dashboard\" \"lambda_control_plane\"",
+      "Forge Control Plane - Lambdas",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
+      "not filter('aws_tag_TenantName', '*')",
+      "__forge_aws_account_scope_not_configured__",
+      "__forge_aws_region_scope_not_configured__",
+      "__forge_product_family_scope_not_configured__",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "Lambda control-plane dashboard source inventory is incomplete: ${join(", ", output.missing_expected_literals)}"
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/variables.tf
@@ -1,0 +1,17 @@
+variable "dynamic_variables" {
+  description = "AWS account, region, and product-family dashboard variable definitions used to scope control-plane Lambda metrics."
+  type = list(object({
+    property               = string
+    alias                  = string
+    description            = string
+    values                 = list(string)
+    value_required         = bool
+    values_suggested       = list(string)
+    restricted_suggestions = bool
+  }))
+}
+
+variable "dashboard_group" {
+  description = "Splunk Observability dashboard group ID."
+  type        = string
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/lambda_control_plane/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "< 10.0.0"
+    }
+  }
+
+  required_version = "~> 1.11"
+}


### PR DESCRIPTION
## Description

Adds the Terraform-managed `Forge Control Plane - Lambdas` dashboard module for non-tenant Lambda invocation, error, throttle, duration, concurrency, and iterator-age signals.

Shared dashboard wiring and configuration remain in PR #507.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- `tofu test` in the dashboard module
- Repository commit hooks
