### PR TITLE
feat(observability): add SQS control-plane dashboard

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/main.tf
@@ -1,0 +1,359 @@
+locals {
+  aws_account_ids = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_account_id"
+  ]))
+  aws_regions = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_region"
+  ]))
+  product_family_names = distinct(flatten([
+    for var_def in var.dynamic_variables : var_def.values_suggested
+    if var_def.property == "aws_tag_ProductFamilyName"
+  ]))
+
+  aws_account_filter = length(local.aws_account_ids) > 0 ? join(" or ", [
+    for account_id in sort(local.aws_account_ids) : "filter('aws_account_id', '${account_id}')"
+  ]) : "filter('aws_account_id', '__forge_aws_account_scope_not_configured__')"
+  aws_region_filter = length(local.aws_regions) > 0 ? join(" or ", [
+    for aws_region in sort(local.aws_regions) : "filter('aws_region', '${aws_region}')"
+  ]) : "filter('aws_region', '__forge_aws_region_scope_not_configured__')"
+  product_family_filter = length(local.product_family_names) > 0 ? join(" or ", [
+    for product_family_name in sort(local.product_family_names) : "filter('aws_tag_ProductFamilyName', '${product_family_name}')"
+  ]) : "filter('aws_tag_ProductFamilyName', '__forge_product_family_scope_not_configured__')"
+
+  aws_platform_filter  = "(${local.aws_account_filter}) and (${local.aws_region_filter}) and (${local.product_family_filter})"
+  control_plane_filter = "(${local.aws_platform_filter}) and (not filter('aws_tag_TenantName', '*'))"
+  sqs_dimension_filter = "filter('namespace', 'AWS/SQS') and filter('QueueName', '*')"
+  dlq_filter           = "filter('QueueName', '*dead-letter*', '*dead_letter*', '*dlq*', '*DLQ*')"
+}
+
+resource "signalfx_single_value_chart" "queue_count" {
+  name        = "# Control-plane queues"
+  description = "Number of Forge SQS queues without the TenantName tag in the selected AWS scope."
+
+  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=(${local.control_plane_filter}) and (${local.sqs_dimension_filter}) and filter('stat', 'upper'), rollup='latest').count(by=['QueueName']).count().publish(label='A')"
+
+  color_by = "Dimension"
+
+  viz_options {
+    display_name = "Control-plane queues"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "visible_messages" {
+  name        = "Visible messages by control-plane queue"
+  description = "Visible backlog by Forge control-plane SQS queue and AWS region."
+
+  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=(${local.control_plane_filter}) and (${local.sqs_dimension_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').sum(by=['aws_region', 'QueueName']).publish(label='A')"
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "QueueName"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Messages"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "QueueName"
+  }
+
+  viz_options {
+    display_name = "Visible messages"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "oldest_message_age" {
+  name        = "Oldest message age by control-plane queue"
+  description = "Oldest visible message age by Forge control-plane SQS queue and AWS region."
+
+  program_text = "A = data('ApproximateAgeOfOldestMessage', filter=(${local.control_plane_filter}) and (${local.sqs_dimension_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').max(by=['aws_region', 'QueueName']).publish(label='A')"
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "QueueName"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Seconds"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "QueueName"
+  }
+
+  viz_options {
+    display_name = "Oldest message"
+    label        = "A"
+    value_unit   = "Second"
+  }
+}
+
+resource "signalfx_time_chart" "messages_by_operation" {
+  name        = "Message operations by control-plane queue"
+  description = "Messages sent, received, and deleted by Forge control-plane SQS queue and AWS region."
+
+  program_text = <<-EOF
+sent = data('NumberOfMessagesSent', filter=(${local.control_plane_filter}) and (${local.sqs_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'QueueName']).publish(label='A')
+received = data('NumberOfMessagesReceived', filter=(${local.control_plane_filter}) and (${local.sqs_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'QueueName']).publish(label='B')
+deleted = data('NumberOfMessagesDeleted', filter=(${local.control_plane_filter}) and (${local.sqs_dimension_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'QueueName']).publish(label='C')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "QueueName"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Messages / 5m"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "QueueName"
+  }
+
+  viz_options {
+    display_name = "Sent"
+    label        = "A"
+  }
+
+  viz_options {
+    display_name = "Received"
+    label        = "B"
+  }
+
+  viz_options {
+    display_name = "Deleted"
+    label        = "C"
+  }
+}
+
+resource "signalfx_time_chart" "messages_by_state" {
+  name        = "Messages by control-plane queue state"
+  description = "Visible, delayed, and in-flight messages by Forge control-plane SQS queue and AWS region."
+
+  program_text = <<-EOF
+visible = data('ApproximateNumberOfMessagesVisible', filter=(${local.control_plane_filter}) and (${local.sqs_dimension_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').sum(by=['aws_region', 'QueueName']).publish(label='A')
+delayed = data('ApproximateNumberOfMessagesDelayed', filter=(${local.control_plane_filter}) and (${local.sqs_dimension_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').sum(by=['aws_region', 'QueueName']).publish(label='B')
+in_flight = data('ApproximateNumberOfMessagesNotVisible', filter=(${local.control_plane_filter}) and (${local.sqs_dimension_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').sum(by=['aws_region', 'QueueName']).publish(label='C')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "QueueName"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Messages"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "QueueName"
+  }
+
+  viz_options {
+    display_name = "Visible"
+    label        = "A"
+  }
+
+  viz_options {
+    display_name = "Delayed"
+    label        = "B"
+  }
+
+  viz_options {
+    display_name = "In flight"
+    label        = "C"
+  }
+}
+
+resource "signalfx_time_chart" "dlq_visible_messages" {
+  name        = "Control-plane DLQ visible messages"
+  description = "Visible messages in Forge control-plane dead-letter queues."
+
+  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=(${local.control_plane_filter}) and filter('namespace', 'AWS/SQS') and (${local.dlq_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').sum(by=['aws_region', 'QueueName']).publish(label='A')"
+
+  plot_type                 = "ColumnChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "QueueName"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Messages"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "QueueName"
+  }
+
+  viz_options {
+    display_name = "DLQ messages"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "dlq_oldest_message_age" {
+  name        = "Control-plane DLQ oldest message age"
+  description = "Oldest visible message age in Forge control-plane dead-letter queues."
+
+  program_text = "A = data('ApproximateAgeOfOldestMessage', filter=(${local.control_plane_filter}) and filter('namespace', 'AWS/SQS') and (${local.dlq_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').max(by=['aws_region', 'QueueName']).publish(label='A')"
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "QueueName"
+  time_range                = 3600
+
+  axis_left {
+    label     = "Seconds"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "aws_region"
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "QueueName"
+  }
+
+  viz_options {
+    display_name = "Oldest DLQ message"
+    label        = "A"
+    value_unit   = "Second"
+  }
+}
+
+resource "terraform_data" "dashboard_parent" {
+  triggers_replace = var.dashboard_group
+}
+
+resource "signalfx_dashboard" "sqs_control_plane" {
+  name            = "Forge Control Plane - SQS"
+  description     = "Health and activity for Forge SQS queues that are not assigned to a tenant."
+  dashboard_group = var.dashboard_group
+  time_range      = "-1h"
+
+  lifecycle {
+    replace_triggered_by = [
+      terraform_data.dashboard_parent,
+    ]
+  }
+
+  dynamic "variable" {
+    for_each = var.dynamic_variables
+    iterator = var_def
+
+    content {
+      property               = var_def.value.property
+      alias                  = var_def.value.alias
+      description            = var_def.value.description
+      values                 = var_def.value.values
+      value_required         = var_def.value.value_required
+      values_suggested       = var_def.value.values_suggested
+      restricted_suggestions = var_def.value.restricted_suggestions
+    }
+  }
+
+  chart {
+    chart_id = signalfx_single_value_chart.queue_count.id
+    row      = 0
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.visible_messages.id
+    row      = 1
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.oldest_message_age.id
+    row      = 1
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.messages_by_operation.id
+    row      = 2
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.messages_by_state.id
+    row      = 2
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.dlq_visible_messages.id
+    row      = 3
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.dlq_oldest_message_age.id
+    row      = 3
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/tests/sqs_control_plane_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/tests/sqs_control_plane_dashboard_behavior.tftest.hcl
@@ -1,0 +1,90 @@
+mock_provider "signalfx" {
+  mock_resource "signalfx_single_value_chart" {
+    defaults = {
+      id = "single-value-chart-id"
+    }
+  }
+  mock_resource "signalfx_time_chart" {
+    defaults = {
+      id = "time-chart-id"
+    }
+  }
+  mock_resource "signalfx_dashboard" {}
+}
+
+variables {
+  dashboard_group = "forge-dashboard-group"
+  dynamic_variables = [
+    {
+      property               = "aws_account_id"
+      alias                  = "AWS account"
+      description            = "Forge AWS accounts."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["222222222222", "111111111111"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "aws_region"
+      alias                  = "AWS region"
+      description            = "Forge AWS regions."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["us-west-2", "eu-west-1"]
+      restricted_suggestions = true
+    },
+    {
+      property               = "aws_tag_ProductFamilyName"
+      alias                  = "Product family"
+      description            = "Forge AWS product family."
+      values                 = []
+      value_required         = false
+      values_suggested       = ["Forge MT"]
+      restricted_suggestions = true
+    },
+  ]
+}
+
+run "creates_sqs_control_plane_dashboard" {
+  command = plan
+
+  assert {
+    condition = (
+      signalfx_dashboard.sqs_control_plane.name == "Forge Control Plane - SQS"
+      && signalfx_dashboard.sqs_control_plane.dashboard_group == "forge-dashboard-group"
+      && length(signalfx_dashboard.sqs_control_plane.chart) == 7
+      && length(signalfx_dashboard.sqs_control_plane.variable) == 3
+    )
+    error_message = "The SQS control-plane dashboard must keep its name, parent group, seven panels, and dedicated variables."
+  }
+
+  assert {
+    condition = alltrue([
+      for program_text in [
+        signalfx_single_value_chart.queue_count.program_text,
+        signalfx_time_chart.visible_messages.program_text,
+        signalfx_time_chart.oldest_message_age.program_text,
+        signalfx_time_chart.messages_by_operation.program_text,
+        signalfx_time_chart.messages_by_state.program_text,
+        signalfx_time_chart.dlq_visible_messages.program_text,
+        signalfx_time_chart.dlq_oldest_message_age.program_text,
+      ] :
+      strcontains(program_text, "filter('aws_account_id', '111111111111')")
+      && strcontains(program_text, "filter('aws_account_id', '222222222222')")
+      && strcontains(program_text, "filter('aws_region', 'eu-west-1')")
+      && strcontains(program_text, "filter('aws_region', 'us-west-2')")
+      && strcontains(program_text, "filter('aws_tag_ProductFamilyName', 'Forge MT')")
+      && strcontains(program_text, "not filter('aws_tag_TenantName', '*')")
+    ])
+    error_message = "Every SQS control-plane panel must be fail-closed and exclude tenant-tagged queues."
+  }
+
+  assert {
+    condition = (
+      strcontains(signalfx_time_chart.dlq_visible_messages.program_text, "*dead_letter*")
+      && strcontains(signalfx_time_chart.dlq_visible_messages.program_text, "*dead-letter*")
+      && strcontains(signalfx_time_chart.dlq_visible_messages.program_text, "*dlq*")
+    )
+    error_message = "Control-plane DLQ panels must support Forge dead-letter and DLQ queue naming patterns."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/tests/sqs_control_plane_dashboard_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/tests/sqs_control_plane_dashboard_interface_contract.tftest.hcl
@@ -1,0 +1,28 @@
+run "sqs_control_plane_dashboard_interface_contract" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_interface_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_input_variables = [
+      "dashboard_group",
+      "dynamic_variables",
+    ]
+    expected_output_values = []
+    expected_interface_literals = [
+      "variable \"dashboard_group\"",
+      "variable \"dynamic_variables\"",
+      "property               = string",
+      "values_suggested       = list(string)",
+      "restricted_suggestions = bool",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_input_variables) == 0 && length(output.unexpected_input_variables) == 0
+    error_message = "SQS control-plane dashboard input contract is not exact."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/tests/sqs_control_plane_dashboard_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/tests/sqs_control_plane_dashboard_source_inventory.tftest.hcl
@@ -1,0 +1,26 @@
+run "sqs_control_plane_dashboard_source_inventory" {
+  command = plan
+
+  module {
+    source = "../../../../../tests/tofu/module_contract"
+  }
+
+  variables {
+    module_path = "."
+    expected_literals = [
+      "resource \"signalfx_dashboard\" \"sqs_control_plane\"",
+      "Forge Control Plane - SQS",
+      "resource \"terraform_data\" \"dashboard_parent\"",
+      "terraform_data.dashboard_parent,",
+      "not filter('aws_tag_TenantName', '*')",
+      "__forge_aws_account_scope_not_configured__",
+      "__forge_aws_region_scope_not_configured__",
+      "__forge_product_family_scope_not_configured__",
+    ]
+  }
+
+  assert {
+    condition     = length(output.missing_expected_literals) == 0
+    error_message = "SQS control-plane dashboard source inventory is incomplete: ${join(", ", output.missing_expected_literals)}"
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/variables.tf
@@ -1,0 +1,17 @@
+variable "dynamic_variables" {
+  description = "AWS account, region, and product-family dashboard variable definitions used to scope control-plane SQS metrics."
+  type = list(object({
+    property               = string
+    alias                  = string
+    description            = string
+    values                 = list(string)
+    value_required         = bool
+    values_suggested       = list(string)
+    restricted_suggestions = bool
+  }))
+}
+
+variable "dashboard_group" {
+  description = "Splunk Observability dashboard group ID."
+  type        = string
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/versions.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/sqs_control_plane/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = "< 10.0.0"
+    }
+  }
+
+  required_version = "~> 1.11"
+}


### PR DESCRIPTION
## Description

Adds the Terraform-managed `Forge Control Plane - SQS` dashboard module for non-tenant queue backlog, age, throughput, in-flight messages, and dead-letter activity.

Shared dashboard wiring and configuration remain in PR #507.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- `tofu test` in the dashboard module
- Repository commit hooks
