### PR TITLE
feat(observability): improve Kubernetes control-plane health

### DIFF
--- a/docs/operations/splunk-o11y-dashboard-panel-reference.md
+++ b/docs/operations/splunk-o11y-dashboard-panel-reference.md
@@ -128,15 +128,15 @@ availability score.
 
 ## Forge Control Plane - Kubernetes
 
-| Chart                                    | Operational question                                                        |
-| ---------------------------------------- | --------------------------------------------------------------------------- |
-| Platform pod health                      | Are configured platform namespace pods running, pending, or failed?         |
-| Splunk OTel collector pod health         | Are collector pods running and stable?                                      |
-| Node pressure conditions                 | Are nodes reporting memory, disk, PID, or network pressure?                 |
-| OTel exporter queue utilization          | Is the collector exporter queue approaching capacity?                       |
-| OTel refused and failed metric points    | Is the collector dropping, refusing, or failing metric points?              |
-| Ready nodes by cluster                   | Has a cluster lost ready nodes or scheduling capacity?                      |
-| Unavailable platform deployment replicas | Which shared platform deployment has fewer available than desired replicas? |
+| Chart                                    | Operational question                                                         |
+| ---------------------------------------- | ---------------------------------------------------------------------------- |
+| Platform pod health                      | Are configured platform namespace pods running, pending, failed, or unknown? |
+| Splunk OTel collector pod health         | Are collector pods running and stable?                                       |
+| Node pressure conditions                 | Are nodes reporting memory, disk, PID, or network pressure?                  |
+| OTel exporter queue utilization          | Is the collector exporter queue approaching capacity?                        |
+| OTel refused and failed metric points    | Is the collector dropping, refusing, or failing metric points?               |
+| Ready nodes by cluster                   | Has a cluster lost ready nodes or scheduling capacity?                       |
+| Unavailable platform deployment replicas | Which shared platform deployment has fewer available than desired replicas?  |
 
 The platform namespace scope includes `k8s_platform_namespaces` plus
 `monitoring`, `prometheus`, and `splunk-otel-collector`.

--- a/docs/operations/splunk-o11y-dashboard-panel-reference.md
+++ b/docs/operations/splunk-o11y-dashboard-panel-reference.md
@@ -128,13 +128,15 @@ availability score.
 
 ## Forge Control Plane - Kubernetes
 
-| Chart                                 | Operational question                                                         |
-| ------------------------------------- | ---------------------------------------------------------------------------- |
-| Platform pod health                   | Are configured platform namespace pods running, pending, failed, or unknown? |
-| Splunk OTel collector pod health      | Are collector pods running and stable?                                       |
-| Node pressure conditions              | Are nodes reporting memory, disk, PID, or network pressure?                  |
-| OTel exporter queue utilization       | Is the collector exporter queue approaching capacity?                        |
-| OTel refused and failed metric points | Is the collector dropping, refusing, or failing metric points?               |
+| Chart                                    | Operational question                                                        |
+| ---------------------------------------- | --------------------------------------------------------------------------- |
+| Platform pod health                      | Are configured platform namespace pods running, pending, or failed?         |
+| Splunk OTel collector pod health         | Are collector pods running and stable?                                      |
+| Node pressure conditions                 | Are nodes reporting memory, disk, PID, or network pressure?                 |
+| OTel exporter queue utilization          | Is the collector exporter queue approaching capacity?                       |
+| OTel refused and failed metric points    | Is the collector dropping, refusing, or failing metric points?              |
+| Ready nodes by cluster                   | Has a cluster lost ready nodes or scheduling capacity?                      |
+| Unavailable platform deployment replicas | Which shared platform deployment has fewer available than desired replicas? |
 
 The platform namespace scope includes `k8s_platform_namespaces` plus
 `monitoring`, `prometheus`, and `splunk-otel-collector`.

--- a/docs/operations/splunk-o11y-dashboard-runbook.md
+++ b/docs/operations/splunk-o11y-dashboard-runbook.md
@@ -142,20 +142,24 @@ If several tenants share the symptom, move to `Forge Control Plane - Kubernetes`
 Purpose: separate shared cluster and telemetry health from tenant runner
 workload health.
 
-Normal: platform and collector pods run, node pressure conditions are clear,
-the exporter queue has headroom, and refused or failed metric points remain
-zero.
+Normal: platform and collector pods run, desired platform deployment replicas
+are available, ready-node counts follow each cluster baseline, node pressure
+conditions are clear, the exporter queue has headroom, and refused or failed
+metric points remain zero.
 
-Problem: platform or collector pods are pending/failed, one node reports
-pressure, exporter utilization grows, or metric points are refused.
+Problem: platform or collector pods are pending/failed, deployment replicas
+are unavailable, ready-node count drops, one node reports pressure, exporter
+utilization grows, or metric points are refused.
 
 Apocalypse: cluster-wide scheduling, networking, telemetry, or platform pod
 failure affects multiple tenants.
 
-Action: identify the cluster, namespace, pod, node, and pressure condition.
-For exporter saturation, restore the downstream path before diagnosing
-no-data charts. For platform failure, use Kubernetes events and the Splunk
-Cloud storage/network dashboard.
+Action: identify the cluster, namespace, deployment, pod, node, and pressure
+condition. Treat a ready-node drop as reduced scheduling capacity and correlate
+it with pending pods and unavailable platform replicas. For exporter
+saturation, restore the downstream path before diagnosing no-data charts. For
+platform failure, use Kubernetes events and the Splunk Cloud storage/network
+dashboard.
 
 ### Forge Tenant - Lambdas
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/README.md
@@ -2,7 +2,7 @@
 
 This module creates cluster-scoped operational charts for the Kubernetes platform that hosts Forge ARC runners.
 
-It keeps platform components such as Karpenter, networking controllers, Prometheus, and the Splunk OpenTelemetry Collector separate from tenant runner workloads. The dashboard covers configured platform namespace pod health, plus the common `monitoring`, `prometheus`, and `splunk-otel-collector` namespaces, node pressure, collector pod health, exporter queue utilization, and telemetry loss.
+It keeps platform components such as Karpenter, networking controllers, Prometheus, and the Splunk OpenTelemetry Collector separate from tenant runner workloads. The dashboard covers configured platform namespace pod and deployment health, plus the common `monitoring`, `prometheus`, and `splunk-otel-collector` namespaces, node readiness and pressure, collector pod health, exporter queue utilization, and telemetry loss.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
@@ -23,12 +23,12 @@ locals {
 
 resource "signalfx_time_chart" "platform_pod_health" {
   name        = "Platform pod health"
-  description = "Shows running, pending, failed, and unknown pods in configured Kubernetes control-plane namespaces."
+  description = "Shows running, pending, and failed pods in configured Kubernetes control-plane namespaces."
 
   program_text = <<-EOF
-A = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Running')
-B = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Pending')
-C = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Failed or unknown')
+A = data('kubernetes.pod_phase', filter=(${local.k8s_platform_filter}) and filter('k8s.pod.phase', 'Running'), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Running')
+B = data('kubernetes.pod_phase', filter=(${local.k8s_platform_filter}) and filter('k8s.pod.phase', 'Pending'), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Pending')
+C = data('kubernetes.pod_phase', filter=(${local.k8s_platform_filter}) and filter('k8s.pod.phase', 'Failed'), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Failed')
 EOF
 
   plot_type                 = "LineChart"
@@ -57,12 +57,12 @@ EOF
 
 resource "signalfx_time_chart" "otel_collector_pods" {
   name        = "Splunk OTel collector pod health"
-  description = "Shows running, pending, failed, and unknown Splunk OpenTelemetry Collector pods."
+  description = "Shows running, pending, and failed Splunk OpenTelemetry Collector pods."
 
   program_text = <<-EOF
-A = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Running')
-B = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Pending')
-C = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Failed or unknown')
+A = data('kubernetes.pod_phase', filter=(${local.k8s_otel_collector_filter}) and filter('k8s.pod.phase', 'Running'), rollup='latest').sum(by=['k8s.cluster.name']).publish(label='Running')
+B = data('kubernetes.pod_phase', filter=(${local.k8s_otel_collector_filter}) and filter('k8s.pod.phase', 'Pending'), rollup='latest').sum(by=['k8s.cluster.name']).publish(label='Pending')
+C = data('kubernetes.pod_phase', filter=(${local.k8s_otel_collector_filter}) and filter('k8s.pod.phase', 'Failed'), rollup='latest').sum(by=['k8s.cluster.name']).publish(label='Failed')
 EOF
 
   plot_type                 = "LineChart"
@@ -154,9 +154,78 @@ resource "terraform_data" "dashboard_parent" {
   triggers_replace = var.dashboard_group
 }
 
+resource "signalfx_time_chart" "ready_nodes" {
+  name        = "Ready nodes by cluster"
+  description = "Shows the number of ready Kubernetes nodes. A drop can indicate node loss or reduced scheduling capacity."
+
+  program_text = <<-EOF
+A = data('kubernetes.node_ready', filter=(${local.k8s_cluster_filter}), rollup='latest').sum(by=['k8s.cluster.name']).publish(label='A')
+EOF
+
+  plot_type                 = "LineChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "k8s.cluster.name"
+  time_range                = 86400
+
+  axis_left {
+    label     = "Ready nodes"
+    min_value = 0
+  }
+
+  viz_options {
+    display_name = "Ready nodes"
+    label        = "A"
+  }
+}
+
+resource "signalfx_time_chart" "unavailable_platform_replicas" {
+  name        = "Unavailable platform deployment replicas"
+  description = "Shows configured platform deployments where desired replicas exceed available replicas."
+
+  program_text = <<-EOF
+desired = data('kubernetes.deployment.desired', filter=(${local.k8s_platform_filter}), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.deployment.name'])
+available = data('kubernetes.deployment.available', filter=(${local.k8s_platform_filter}), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.deployment.name'])
+unavailable = (desired - available).above(0).top(count=20).publish(label='A')
+EOF
+
+  plot_type                 = "ColumnChart"
+  axes_precision            = 0
+  disable_sampling          = true
+  on_chart_legend_dimension = "k8s.deployment.name"
+  time_range                = 86400
+
+  axis_left {
+    label     = "Unavailable replicas"
+    min_value = 0
+  }
+
+  legend_options_fields {
+    enabled  = true
+    property = "k8s.cluster.name"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "k8s.namespace.name"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "k8s.deployment.name"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "sf_metric"
+  }
+
+  viz_options {
+    display_name = "Unavailable replicas"
+    label        = "A"
+  }
+}
+
 resource "signalfx_dashboard" "k8s_control_plane" {
   name            = "Forge Control Plane - Kubernetes"
-  description     = "Forge Kubernetes platform pods, node pressure, and telemetry pipeline health."
+  description     = "Forge Kubernetes platform pods, deployment availability, node readiness and pressure, and telemetry pipeline health."
   dashboard_group = var.dashboard_group
 
   lifecycle {
@@ -215,6 +284,22 @@ resource "signalfx_dashboard" "k8s_control_plane" {
   chart {
     chart_id = signalfx_time_chart.otel_telemetry_loss.id
     row      = 2
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.ready_nodes.id
+    row      = 3
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.unavailable_platform_replicas.id
+    row      = 3
     column   = 6
     width    = 6
     height   = 1

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
@@ -23,12 +23,12 @@ locals {
 
 resource "signalfx_time_chart" "platform_pod_health" {
   name        = "Platform pod health"
-  description = "Shows running, pending, and failed pods in configured Kubernetes control-plane namespaces."
+  description = "Shows running, pending, failed, and unknown pods in configured Kubernetes control-plane namespaces."
 
   program_text = <<-EOF
-A = data('kubernetes.pod_phase', filter=(${local.k8s_platform_filter}) and filter('k8s.pod.phase', 'Running'), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Running')
-B = data('kubernetes.pod_phase', filter=(${local.k8s_platform_filter}) and filter('k8s.pod.phase', 'Pending'), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Pending')
-C = data('kubernetes.pod_phase', filter=(${local.k8s_platform_filter}) and filter('k8s.pod.phase', 'Failed'), rollup='latest').sum(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Failed')
+A = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Running')
+B = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Pending')
+C = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Failed or unknown')
 EOF
 
   plot_type                 = "LineChart"
@@ -57,12 +57,12 @@ EOF
 
 resource "signalfx_time_chart" "otel_collector_pods" {
   name        = "Splunk OTel collector pod health"
-  description = "Shows running, pending, and failed Splunk OpenTelemetry Collector pods."
+  description = "Shows running, pending, failed, and unknown Splunk OpenTelemetry Collector pods."
 
   program_text = <<-EOF
-A = data('kubernetes.pod_phase', filter=(${local.k8s_otel_collector_filter}) and filter('k8s.pod.phase', 'Running'), rollup='latest').sum(by=['k8s.cluster.name']).publish(label='Running')
-B = data('kubernetes.pod_phase', filter=(${local.k8s_otel_collector_filter}) and filter('k8s.pod.phase', 'Pending'), rollup='latest').sum(by=['k8s.cluster.name']).publish(label='Pending')
-C = data('kubernetes.pod_phase', filter=(${local.k8s_otel_collector_filter}) and filter('k8s.pod.phase', 'Failed'), rollup='latest').sum(by=['k8s.cluster.name']).publish(label='Failed')
+A = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Running')
+B = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Pending')
+C = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Failed or unknown')
 EOF
 
   plot_type                 = "LineChart"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
@@ -46,8 +46,6 @@ run "k8s_control_plane_dashboard_contract" {
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'monitoring')")
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'prometheus')")
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'splunk-otel-collector')")
-      && strcontains(signalfx_time_chart.platform_pod_health.program_text, "kubernetes.pod_phase")
-      && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.pod.phase', 'Pending')")
       && strcontains(signalfx_time_chart.node_pressure.program_text, "k8s.node.condition")
       && strcontains(signalfx_time_chart.node_pressure.program_text, "rollup='max'")
       && strcontains(signalfx_time_chart.node_pressure.program_text, ".max(by=['k8s.cluster.name', 'k8s.node.name', 'condition']).above(0)")

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
@@ -34,7 +34,7 @@ run "k8s_control_plane_dashboard_contract" {
       && signalfx_dashboard.k8s_control_plane.dashboard_group == "forge-dashboard-group"
       && length(signalfx_dashboard.k8s_control_plane.variable) == 1
       && signalfx_dashboard.k8s_control_plane.variable[0].property == "k8s.cluster.name"
-      && length(signalfx_dashboard.k8s_control_plane.chart) == 5
+      && length(signalfx_dashboard.k8s_control_plane.chart) == 7
     )
     error_message = "K8S control-plane dashboard must use only the cluster selector and wire all platform charts."
   }
@@ -46,14 +46,21 @@ run "k8s_control_plane_dashboard_contract" {
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'monitoring')")
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'prometheus')")
       && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.namespace.name', 'splunk-otel-collector')")
+      && strcontains(signalfx_time_chart.platform_pod_health.program_text, "kubernetes.pod_phase")
+      && strcontains(signalfx_time_chart.platform_pod_health.program_text, "filter('k8s.pod.phase', 'Pending')")
       && strcontains(signalfx_time_chart.node_pressure.program_text, "k8s.node.condition")
       && strcontains(signalfx_time_chart.node_pressure.program_text, "rollup='max'")
       && strcontains(signalfx_time_chart.node_pressure.program_text, ".max(by=['k8s.cluster.name', 'k8s.node.name', 'condition']).above(0)")
       && one(signalfx_time_chart.node_pressure.viz_options).display_name == "Node pressure"
+      && strcontains(signalfx_time_chart.ready_nodes.program_text, "kubernetes.node_ready")
+      && strcontains(signalfx_time_chart.ready_nodes.program_text, ".sum(by=['k8s.cluster.name'])")
+      && strcontains(signalfx_time_chart.unavailable_platform_replicas.program_text, "kubernetes.deployment.desired")
+      && strcontains(signalfx_time_chart.unavailable_platform_replicas.program_text, "kubernetes.deployment.available")
+      && strcontains(signalfx_time_chart.unavailable_platform_replicas.program_text, "(desired - available).above(0)")
       && strcontains(signalfx_time_chart.otel_exporter_queue_utilization.program_text, "otelcol_exporter_queue_capacity")
       && one(signalfx_time_chart.otel_exporter_queue_utilization.viz_options).display_name == "OTel exporter queue utilization"
       && strcontains(signalfx_time_chart.otel_telemetry_loss.program_text, "otelcol_receiver_refused_metric_points")
     )
-    error_message = "K8S control-plane charts must cover configured platform namespaces, node pressure, and OTel pipeline health."
+    error_message = "K8S control-plane charts must cover configured platform namespaces, pod and deployment health, node readiness and pressure, and OTel pipeline health."
   }
 }


### PR DESCRIPTION
## Description

Improve the Terraform-managed `Forge Control Plane - Kubernetes` dashboard
using signals validated from Splunk Observability's built-in Kubernetes views
and live Forge cluster metrics.

- Add ready-node count by cluster.
- Add unavailable platform deployment replicas from desired versus available
  replicas.
- Update the dashboard behavior contract, panel reference, and runbook.

The new panels remain cluster-scoped and limited to shared platform namespaces;
tenant runner workload analysis stays in `Forge Tenant - K8S Runners`. Existing
pod-phase panels and their `k8s.pod.phase` metric remain unchanged.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: _________

## Testing

- `tofu fmt -check -recursive .`
- `tofu test -test-directory=tests` (3 passed)
- Repository pre-commit hooks passed during commit.
- Live SignalFlow validation against `srea-forge-usw2-prod-green` confirmed
  ready-node and deployment desired/available metrics.
