### PR TITLE
docs(observability): document EC2 runner right-sizing

### DIFF
--- a/docs/operations/splunk-o11y-dashboard-panel-reference.md
+++ b/docs/operations/splunk-o11y-dashboard-panel-reference.md
@@ -80,33 +80,46 @@ availability score.
 
 ## Forge Tenant - EC2 Runners
 
-| Chart                                   | Operational question                                         |
-| --------------------------------------- | ------------------------------------------------------------ |
-| # Disk ops                              | What is the aggregate read/write operation rate?             |
-| Total memory overview (bytes)           | How much host memory is used, cached, buffered, or free?     |
-| Network out (bytes) vs. 24h change (%)  | Did outbound traffic change materially from the prior day?   |
-| Network out (bytes)                     | Which hosts or tenants produce outbound traffic?             |
-| Top instances by CPU utilization (%)    | Which EC2 runners have the highest CPU utilization?          |
-| Disk utilization (%)                    | Which runner filesystems are approaching capacity?           |
-| Disk metrics 24h change (%)             | Which tenants have unusual disk changes?                     |
-| Top images by mean CPU utilization (%)  | Are particular runner images associated with high CPU?       |
-| Network in (bytes)                      | Which hosts or tenants receive the most traffic?             |
-| Memory utilization (%)                  | Which hosts are under memory pressure?                       |
-| Top instances by memory utilization (%) | Which individual runners use the most memory?                |
-| Disk I/O (bytes)                        | Which tenants generate the most disk I/O?                    |
-| Network in (bytes) vs. 24h change (%)   | Did inbound traffic change materially from the prior day?    |
-| Network errors/sec                      | Are host interfaces reporting receive or transmit errors?    |
-| Top memory page swaps/sec               | Which hosts are swapping memory?                             |
-| # Active hosts per instance type        | What instance types make up live runner capacity?            |
-| CPU utilization (%)                     | How is CPU changing by instance?                             |
-| # Active hosts by availability zone     | Is runner capacity distributed across availability zones?    |
-| Disk summary utilization (%)            | Which mountpoints and hosts have the highest utilization?    |
-| # Hosts with agent installed            | How many runner hosts emit host-level OTel metrics?          |
-| Top 5 network out (bytes)               | Which hosts send the most traffic?                           |
-| # Active hosts                          | How many EC2 runners are visible through AWS metrics?        |
-| Active hosts missing Splunk OTel agent  | Which AWS-visible runners lack corresponding host telemetry? |
-| Top 5 network in (bytes)                | Which hosts receive the most traffic?                        |
-| EC2 status check failures               | Are instance or AWS system status checks failing?            |
+| Chart                                                | Operational question                                                                             |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| # Disk ops                                           | What is the aggregate read/write operation rate?                                                 |
+| Total memory overview (bytes)                        | How much host memory is used, cached, buffered, or free?                                         |
+| Network out (bytes) vs. 24h change (%)               | Did outbound traffic change materially from the prior day?                                       |
+| Network out (bytes)                                  | Which hosts or tenants produce outbound traffic?                                                 |
+| Top instances by CPU utilization (%)                 | Which EC2 runners have the highest CPU utilization?                                              |
+| Disk utilization (%)                                 | Which runner filesystems are approaching capacity?                                               |
+| Disk metrics 24h change (%)                          | Which tenants have unusual disk changes?                                                         |
+| Top images by mean CPU utilization (%)               | Are particular runner images associated with high CPU?                                           |
+| Network in (bytes)                                   | Which hosts or tenants receive the most traffic?                                                 |
+| Memory utilization (%)                               | Which hosts are under memory pressure?                                                           |
+| Top instances by memory utilization (%)              | Which individual runners use the most memory?                                                    |
+| Disk I/O (bytes)                                     | Which tenants generate the most disk I/O?                                                        |
+| Network in (bytes) vs. 24h change (%)                | Did inbound traffic change materially from the prior day?                                        |
+| Network errors/sec                                   | Are host interfaces reporting receive or transmit errors?                                        |
+| Top memory page swaps/sec                            | Which hosts are swapping memory?                                                                 |
+| # Active hosts per instance type                     | What instance types make up live runner capacity?                                                |
+| CPU utilization (%)                                  | How is CPU changing by instance?                                                                 |
+| # Active hosts by availability zone                  | Is runner capacity distributed across availability zones?                                        |
+| Disk summary utilization (%)                         | Which mountpoints and hosts have the highest utilization?                                        |
+| # Hosts with agent installed                         | How many runner hosts emit host-level OTel metrics?                                              |
+| Top 5 network out (bytes)                            | Which hosts send the most traffic?                                                               |
+| # Active hosts                                       | How many EC2 runners are visible through AWS metrics?                                            |
+| Active hosts missing Splunk OTel agent               | Which AWS-visible runners lack corresponding host telemetry?                                     |
+| Top 5 network in (bytes)                             | Which hosts receive the most traffic?                                                            |
+| EC2 status check failures                            | Are instance or AWS system status checks failing?                                                |
+| Job runs: high peak CPU utilization (%)              | Which job executions reached at least 85% peak CPU in the last 24 hours?                         |
+| Job runs: low peak CPU utilization (%)               | Which job executions stayed below 20% peak CPU in the last 24 hours?                             |
+| Job runs: high peak memory utilization (%)           | Which job executions on OTel-instrumented hosts reached at least 85% peak memory?                |
+| Job runs: low peak memory utilization (%)            | Which job executions on OTel-instrumented hosts stayed below 40% peak memory?                    |
+| Runner classes: mean job peak CPU utilization (%)    | Which repeated tenant, workflow, job, label, and instance-type combinations use the most CPU?    |
+| Runner classes: mean job peak memory utilization (%) | Which repeated tenant, workflow, job, label, and instance-type combinations use the most memory? |
+| Job runs: high peak filesystem utilization (%)       | Which job filesystems on OTel-instrumented hosts reached at least 80% utilization?               |
+
+The job-run panels require the GitHub runner job URL tag and retain tenant,
+repository, workflow, job, runner-label, instance-type, and drill-down
+dimensions. Memory and filesystem panels also require the Splunk OTel host
+agent. Treat the runner-class panels as repeated sizing evidence; a single
+high or low job execution is not enough to change a runner class.
 
 ## Forge Tenant - K8S Runners
 

--- a/docs/operations/splunk-o11y-dashboard-runbook.md
+++ b/docs/operations/splunk-o11y-dashboard-runbook.md
@@ -104,22 +104,39 @@ runner dashboard for health. This dashboard is not an incident severity score.
 ### Forge Tenant - EC2 Runners
 
 Purpose: inspect AWS EC2 and host-level telemetry for runner CPU, memory, disk,
-network, status checks, capacity distribution, and OTel agent coverage.
+network, status checks, capacity distribution, OTel agent coverage, and
+job-level right-sizing evidence.
 
 Normal: status checks are zero, memory and filesystem headroom exist, network
-errors and swapping are low, and active AWS hosts also emit host telemetry.
+errors and swapping are low, active AWS hosts also emit host telemetry, and
+repeated job runs fit their configured runner class without sustained
+saturation.
 
 Problem: sustained CPU or memory pressure, high filesystem utilization,
 swapping, network errors, EC2 status failures, or active hosts listed as
-missing the OTel agent.
+missing the OTel agent. Repeated job runs at a high threshold can indicate an
+undersized runner; repeated low CPU and memory peaks can indicate an oversized
+runner.
 
 Apocalypse: status checks, telemetry loss, or resource exhaustion affect many
 tenants or availability zones.
 
-Action: capture tenant, instance ID, image ID, instance type, availability
-zone, and time window. For a missing agent, check the runner image and agent
-service before treating host charts as proof the instance is idle. Correlate
-with EC2 lifecycle and capacity logs.
+Action: capture tenant, repository, workflow, job, runner labels, job URL,
+instance ID, image ID, instance type, availability zone, and time window. For a
+missing agent, check the runner image and agent service before treating host
+charts as proof the instance is idle. Correlate with EC2 lifecycle and capacity
+logs.
+
+For right-sizing, the job-run panels use 24-hour peaks. High CPU and memory
+start at `85%`, low CPU is below `20%`, low memory is below `40%`, and high
+filesystem utilization starts at `80%`. Memory and filesystem evidence exists
+only for hosts running the Splunk OTel agent.
+
+Do not resize from one anomalous execution. Confirm the same tenant,
+repository, workflow, job, runner-label, and instance-type combination across
+repeated runs in both runner-class CPU and memory panels. Use high filesystem
+utilization to review EBS capacity separately from the runner instance class,
+then validate the change against job duration and failure rate.
 
 ### Forge Tenant - K8S Runners
 


### PR DESCRIPTION
## Description

Document the Splunk Observability dashboard changes reviewed across current
`main`, #513, and #522.

- Add all seven EC2 job right-sizing charts from #513 to the dashboard panel
  reference.
- Record the CPU, memory, and filesystem thresholds and required job/runner
  dimensions.
- Explain the Splunk OTel host-agent dependency for memory and filesystem
  evidence.
- Add operator guidance to use repeated runner-class CPU and memory evidence
  rather than a single anomalous job run.
- Confirm the dashboard inventory and the Kubernetes control-plane panels from
  merged #522 are already covered.

PR #513 is now merged, so the documented charts are present on `main`.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `pre-commit run mdformat --files docs/operations/splunk-o11y-dashboard-panel-reference.md docs/operations/splunk-o11y-dashboard-runbook.md`
- `git diff --check`
- Repository pre-commit hooks passed during commit.
- Verified every Terraform-managed dashboard on `main` has an inventory entry,
  panel-reference section, and runbook section.
- Verified all seven chart names added by #513 appear in the panel reference.
