### PR TITLE
fix(observability): stabilize runner usage cluster filters

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_usage/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_usage/main.tf
@@ -15,10 +15,10 @@ locals {
   configured_k8s_tenant_filter = length(var.tenant_names) > 0 ? join(" or ", [
     for namespace in sort(var.tenant_names) : "filter('k8s.namespace.name', '${namespace}')"
   ]) : "filter('k8s.namespace.name', '__forge_tenant_scope_not_configured__')"
-  configured_k8s_cluster_names = distinct(flatten([
+  configured_k8s_cluster_names = sort(distinct(flatten([
     for var_def in var.dynamic_variables : var_def.values_suggested
     if var_def.property == "k8s.cluster.name"
-  ]))
+  ])))
   configured_k8s_cluster_filter = length(local.configured_k8s_cluster_names) > 0 ? join(" or ", [
     for cluster_name in local.configured_k8s_cluster_names : "filter('k8s.cluster.name', '${cluster_name}')"
   ]) : "filter('k8s.cluster.name', '__forge_cluster_scope_not_configured__')"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_usage/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_usage_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_usage/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_usage_source_inventory.tftest.hcl
@@ -21,7 +21,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_usage_source_invento
       "resource \"signalfx_list_chart\" \"k8s_runner_hours_by_tenant\"",
       "resource \"terraform_data\" \"dashboard_parent\"",
       "terraform_data.dashboard_parent,",
-      "configured_k8s_cluster_names = distinct(flatten([",
+      "configured_k8s_cluster_names = sort(distinct(flatten([",
       "for var_def in var.dynamic_variables : var_def.values_suggested",
       "if var_def.property == \"k8s.cluster.name\"",
       "resource \"signalfx_dashboard\" \"runner_usage\"",


### PR DESCRIPTION
## Description

Sort configured Kubernetes cluster names before building runner-usage SignalFlow filters. This keeps filter generation deterministic when `values_suggested` is set-derived and fixes the OpenTofu failures observed in both the minimum-supported and latest-stable jobs from [run 30134418970](https://github.com/cisco-open/forge/actions/runs/30134418970).

Update the source-inventory contract to pin the deterministic sorting behavior.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu -chdir=modules/integrations/splunk_o11y_conf_shared/dashboards/runner_usage test -no-color`
  - 3 passed, 0 failed
- Pre-commit hooks
  - All passed
