### PR TITLE
fix(observability): link detectors to dashboard charts

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
@@ -33,6 +33,10 @@ module "dashboard_runner_k8s" {
   tenant_names      = var.dashboard_variables.runner_k8s.tenant_names
   dynamic_variables = var.dashboard_variables.runner_k8s.dynamic_variables
   dashboard_group   = signalfx_dashboard_group.forgecicd.id
+  detector_ids = {
+    otel_no_data        = module.detector_k8s.detector_ids.otel_no_data
+    tenant_pods_pending = module.detector_k8s.detector_ids.tenant_pods_pending
+  }
 }
 
 module "dashboard_k8s_control_plane" {
@@ -45,6 +49,10 @@ module "dashboard_k8s_control_plane" {
   dynamic_variables   = var.dashboard_variables.runner_k8s.dynamic_variables
   platform_namespaces = var.k8s_platform_namespaces
   dashboard_group     = signalfx_dashboard_group.forgecicd.id
+  detector_ids = {
+    otel_collector_health   = module.detector_k8s.detector_ids.otel_collector_health
+    platform_pods_unhealthy = module.detector_k8s.detector_ids.platform_pods_unhealthy
+  }
 }
 
 module "dashboard_lambda" {
@@ -91,6 +99,7 @@ module "dashboard_dependency_probes" {
   tenant_names      = var.dashboard_variables.dependency_probes.tenant_names
   dynamic_variables = var.dashboard_variables.dependency_probes.dynamic_variables
   dashboard_group   = signalfx_dashboard_group.forgecicd.id
+  detector_ids      = module.detector_dependency_probes.detector_ids
 }
 
 module "dashboard_aws_regional_health" {
@@ -102,6 +111,7 @@ module "dashboard_aws_regional_health" {
 
   dynamic_variables = var.dashboard_variables.aws_regional_health.dynamic_variables
   dashboard_group   = signalfx_dashboard_group.forgecicd.id
+  detector_id       = module.detector_aws_regional_health.detector_id
 }
 
 # Messaging and storage

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/README.md
@@ -123,6 +123,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_dashboard_group"></a> [dashboard\_group](#input\_dashboard\_group) | Splunk Observability dashboard group ID. | `string` | n/a | yes |
+| <a name="input_detector_id"></a> [detector\_id](#input\_detector\_id) | AWS regional platform detector ID linked to queue-health charts. | `string` | n/a | yes |
 | <a name="input_dynamic_variables"></a> [dynamic\_variables](#input\_dynamic\_variables) | AWS account, region, and product-family dashboard variable definitions used to scope regional platform health. | <pre>list(object({<br/>    property               = string<br/>    alias                  = string<br/>    description            = string<br/>    values                 = list(string)<br/>    value_required         = bool<br/>    values_suggested       = list(string)<br/>    restricted_suggestions = bool<br/>  }))</pre> | n/a | yes |
 
 ## Outputs

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/main.tf
@@ -91,7 +91,10 @@ resource "signalfx_time_chart" "build_queue_oldest_age" {
   name        = "Forge AWS build queue oldest age"
   description = "Maximum oldest queued-build message age by AWS region. Warning above 75s for 10m; Major above 300s for 10m; recover below 60s for 15m."
 
-  program_text = "A = data('ApproximateAgeOfOldestMessage', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter})).max(over='5m').max(by=['aws_region']).publish(label='A')"
+  program_text = <<-EOF
+A = data('ApproximateAgeOfOldestMessage', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter})).max(over='5m').max(by=['aws_region']).publish(label='A')
+alerts(detector_id='${var.detector_id}').publish(label='Regional queue-health alerts')
+EOF
 
   plot_type                 = "LineChart"
   axes_precision            = 0
@@ -120,7 +123,10 @@ resource "signalfx_time_chart" "build_queue_visible_backlog" {
   name        = "Forge AWS build queue visible backlog"
   description = "Visible queued-build messages by AWS region. Warning when above 10 for 10m together with oldest-message age above 75s."
 
-  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter})).max(over='5m').sum(by=['aws_region']).publish(label='A')"
+  program_text = <<-EOF
+A = data('ApproximateNumberOfMessagesVisible', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter})).max(over='5m').sum(by=['aws_region']).publish(label='A')
+alerts(detector_id='${var.detector_id}').publish(label='Regional queue-health alerts')
+EOF
 
   plot_type                 = "LineChart"
   axes_precision            = 0
@@ -148,7 +154,10 @@ resource "signalfx_time_chart" "build_queue_dlq_sends" {
   name        = "Forge AWS queued-build DLQ sends"
   description = "Queued-build dead-letter queue sends by AWS region. Any non-zero value in 5m is a Major condition; escalate only with customer impact."
 
-  program_text = "A = data('NumberOfMessagesSent', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'sum') and filter('QueueName', '*_dead_letter'), rollup='sum').sum(over='5m').sum(by=['aws_region']).publish(label='A')"
+  program_text = <<-EOF
+A = data('NumberOfMessagesSent', filter=(${local.aws_platform_filter}) and filter('namespace', 'AWS/SQS') and filter('stat', 'sum') and filter('QueueName', '*_dead_letter'), rollup='sum').sum(over='5m').sum(by=['aws_region']).publish(label='A')
+alerts(detector_id='${var.detector_id}').publish(label='Regional queue-health alerts')
+EOF
 
   plot_type                 = "ColumnChart"
   axes_precision            = 0

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_behavior.tftest.hcl
@@ -9,6 +9,7 @@ mock_provider "signalfx" {
 
 variables {
   dashboard_group = "forge-dashboard-group"
+  detector_id     = "regional-queue-detector-id"
   dynamic_variables = [
     {
       property               = "aws_account_id"
@@ -81,5 +82,20 @@ run "creates_regional_platform_dashboard" {
       && strcontains(signalfx_time_chart.build_queue_dlq_sends.program_text, "NumberOfMessagesSent")
     )
     error_message = "The managed dashboard must preserve the five live regional Lambda and queued-build signals."
+  }
+
+  assert {
+    condition = (
+      alltrue([
+        for program_text in [
+          signalfx_time_chart.build_queue_oldest_age.program_text,
+          signalfx_time_chart.build_queue_visible_backlog.program_text,
+          signalfx_time_chart.build_queue_dlq_sends.program_text,
+        ] : strcontains(program_text, "alerts(detector_id='regional-queue-detector-id')")
+      ])
+      && !strcontains(signalfx_time_chart.lambda_throttle_attempt_rate.program_text, "alerts(detector_id=")
+      && !strcontains(signalfx_time_chart.lambda_throttle_count.program_text, "alerts(detector_id=")
+    )
+    error_message = "The regional queue detector must link only queue-health charts, not diagnostic Lambda throttle charts."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_interface_contract.tftest.hcl
@@ -9,6 +9,7 @@ run "aws_regional_health_dashboard_interface_contract" {
     module_path = "."
     expected_input_variables = [
       "dashboard_group",
+      "detector_id",
       "dynamic_variables",
     ]
     expected_output_values = []
@@ -19,6 +20,8 @@ run "aws_regional_health_dashboard_interface_contract" {
       "property               = string",
       "values_suggested       = list(string)",
       "restricted_suggestions = bool",
+      "variable \"detector_id\"",
+      "description = \"AWS regional platform detector ID linked to queue-health charts.\"",
     ]
   }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/variables.tf
@@ -15,3 +15,8 @@ variable "dashboard_group" {
   description = "Splunk Observability dashboard group ID."
   type        = string
 }
+
+variable "detector_id" {
+  description = "AWS regional platform detector ID linked to queue-health charts."
+  type        = string
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/README.md
@@ -52,6 +52,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_dashboard_group"></a> [dashboard\_group](#input\_dashboard\_group) | Splunk Observability dashboard group ID. | `string` | n/a | yes |
+| <a name="input_detector_ids"></a> [detector\_ids](#input\_detector\_ids) | Dependency detector IDs keyed by tenant for linking dashboard charts. | `map(string)` | n/a | yes |
 | <a name="input_dynamic_variables"></a> [dynamic\_variables](#input\_dynamic\_variables) | Additional dynamic variable definitions for the dashboard. | <pre>list(object({<br/>    property               = string<br/>    alias                  = string<br/>    description            = string<br/>    values                 = list(string)<br/>    value_required         = bool<br/>    values_suggested       = list(string)<br/>    restricted_suggestions = bool<br/>  }))</pre> | `[]` | no |
 | <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | Forge tenants available in the dashboard selector. | `list(string)` | n/a | yes |
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/main.tf
@@ -4,6 +4,10 @@ locals {
     "filter('TenantName', '${tenant_name}')"
   ]) : "filter('TenantName', '__forge_tenant_scope_not_configured__')"
   metric_filter = "(${local.tenant_filter})"
+  detector_alerts = join("\n", [
+    for tenant_name, detector_id in var.detector_ids :
+    "alerts(detector_id='${detector_id}').publish(label='${tenant_name} dependency alerts')"
+  ])
 }
 
 resource "signalfx_list_chart" "github_availability" {
@@ -17,7 +21,10 @@ resource "signalfx_list_chart" "github_availability" {
   time_range              = 3600
   unit_prefix             = "Metric"
 
-  program_text = "A = data('forge.dependency.availability', filter=(${local.metric_filter}) and filter('Provider', 'GitHub'), rollup='latest').min(by=['TenantName', 'AWSRegion', 'CheckName']).publish(label='A')"
+  program_text = <<-EOF
+A = data('forge.dependency.availability', filter=(${local.metric_filter}) and filter('Provider', 'GitHub'), rollup='latest').min(by=['TenantName', 'AWSRegion', 'CheckName']).publish(label='A')
+${local.detector_alerts}
+EOF
 
   color_scale {
     color = "red"
@@ -54,7 +61,10 @@ resource "signalfx_list_chart" "ssm_availability" {
   time_range              = 3600
   unit_prefix             = "Metric"
 
-  program_text = "A = data('forge.dependency.availability', filter=(${local.metric_filter}) and filter('Provider', 'AWS') and filter('CheckName', 'SSMCredentials'), rollup='latest').min(by=['TenantName', 'AWSRegion']).publish(label='A')"
+  program_text = <<-EOF
+A = data('forge.dependency.availability', filter=(${local.metric_filter}) and filter('Provider', 'AWS') and filter('CheckName', 'SSMCredentials'), rollup='latest').min(by=['TenantName', 'AWSRegion']).publish(label='A')
+${local.detector_alerts}
+EOF
 
   color_scale {
     color = "red"
@@ -87,7 +97,10 @@ resource "signalfx_list_chart" "rate_limit_budget" {
   time_range              = 3600
   unit_prefix             = "Metric"
 
-  program_text = "A = data('forge.dependency.rate_limit_remaining_pct', filter=(${local.metric_filter}) and filter('Provider', 'GitHub') and filter('CheckName', 'OrgRunnersApi'), rollup='latest').min(by=['TenantName', 'AWSRegion']).publish(label='A')"
+  program_text = <<-EOF
+A = data('forge.dependency.rate_limit_remaining_pct', filter=(${local.metric_filter}) and filter('Provider', 'GitHub') and filter('CheckName', 'OrgRunnersApi'), rollup='latest').min(by=['TenantName', 'AWSRegion']).publish(label='A')
+${local.detector_alerts}
+EOF
 
   color_scale {
     color = "red"
@@ -154,7 +167,10 @@ resource "signalfx_time_chart" "probe_execution" {
   name        = "Regional probe execution"
   description = "Scheduled dependency-probe executions by tenant and AWS region. Missing series indicate absent telemetry."
 
-  program_text = "A = data('forge.dependency.probe_executed', filter=(${local.metric_filter}) and filter('Provider', 'Forge') and filter('CheckName', 'TenantCycle'), rollup='sum').sum(by=['TenantName', 'AWSRegion']).publish(label='A')"
+  program_text = <<-EOF
+A = data('forge.dependency.probe_executed', filter=(${local.metric_filter}) and filter('Provider', 'Forge') and filter('CheckName', 'TenantCycle'), rollup='sum').sum(by=['TenantName', 'AWSRegion']).publish(label='A')
+${local.detector_alerts}
+EOF
 
   plot_type        = "ColumnChart"
   show_event_lines = false

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/dependency_probes_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/dependency_probes_dashboard_behavior.tftest.hcl
@@ -15,6 +15,10 @@ mock_provider "signalfx" {
 variables {
   dashboard_group = "forge-dashboard-group"
   tenant_names    = ["tenant-b", "tenant-a"]
+  detector_ids = {
+    tenant-a = "tenant-a-detector-id"
+    tenant-b = "tenant-b-detector-id"
+  }
   dynamic_variables = [{
     property               = "AWSRegion"
     alias                  = "AWS region"
@@ -66,5 +70,22 @@ run "creates_dependency_health_dashboard" {
       && strcontains(signalfx_list_chart.github_availability.program_text, "filter('TenantName', 'tenant-b')")
     )
     error_message = "Dependency charts must use direct Splunk metric names and remain scoped to configured tenants."
+  }
+
+  assert {
+    condition = (
+      alltrue([
+        for program_text in [
+          signalfx_list_chart.github_availability.program_text,
+          signalfx_list_chart.ssm_availability.program_text,
+          signalfx_list_chart.rate_limit_budget.program_text,
+          signalfx_time_chart.probe_execution.program_text,
+        ] :
+        strcontains(program_text, "alerts(detector_id='tenant-a-detector-id')")
+        && strcontains(program_text, "alerts(detector_id='tenant-b-detector-id')")
+      ])
+      && !strcontains(signalfx_time_chart.latency.program_text, "alerts(detector_id=")
+    )
+    error_message = "Dependency detectors must link the four matching rule charts without linking the diagnostic-only latency chart."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface_contract.tftest.hcl
@@ -9,6 +9,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface
     module_path = "."
     expected_input_variables = [
       "dashboard_group",
+      "detector_ids",
       "dynamic_variables",
       "tenant_names",
     ]
@@ -32,6 +33,9 @@ run "integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface
       "variable \"tenant_names\"",
       "description = \"Forge tenants available in the dashboard selector.\"",
       "type        = list(string)",
+      "variable \"detector_ids\"",
+      "description = \"Dependency detector IDs keyed by tenant for linking dashboard charts.\"",
+      "type        = map(string)",
     ]
   }
 
@@ -62,9 +66,9 @@ run "integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface
 
   assert {
     condition = (
-      output.expected_input_variable_count == 3
+      output.expected_input_variable_count == 4
       && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 18
+      && output.expected_interface_literal_count == 21
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/variables.tf
@@ -21,3 +21,8 @@ variable "tenant_names" {
   description = "Forge tenants available in the dashboard selector."
   type        = list(string)
 }
+
+variable "detector_ids" {
+  description = "Dependency detector IDs keyed by tenant for linking dashboard charts."
+  type        = map(string)
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/README.md
@@ -40,6 +40,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_dashboard_group"></a> [dashboard\_group](#input\_dashboard\_group) | Dashboard group name for organizing dashboards. | `string` | n/a | yes |
+| <a name="input_detector_ids"></a> [detector\_ids](#input\_detector\_ids) | Kubernetes detector IDs linked to control-plane health charts. | <pre>object({<br/>    otel_collector_health   = string<br/>    platform_pods_unhealthy = string<br/>  })</pre> | n/a | yes |
 | <a name="input_dynamic_variables"></a> [dynamic\_variables](#input\_dynamic\_variables) | Dashboard variable definitions; only the Kubernetes cluster variable is used. | <pre>list(object({<br/>    property               = string<br/>    alias                  = string<br/>    description            = string<br/>    values                 = list(string)<br/>    value_required         = bool<br/>    values_suggested       = list(string)<br/>    restricted_suggestions = bool<br/>  }))</pre> | `[]` | no |
 | <a name="input_platform_namespaces"></a> [platform\_namespaces](#input\_platform\_namespaces) | Namespaces that contain platform pods required for runner scheduling, networking, and telemetry. | `list(string)` | n/a | yes |
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/main.tf
@@ -29,6 +29,7 @@ resource "signalfx_time_chart" "platform_pod_health" {
 A = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Running')
 B = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Pending')
 C = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Failed or unknown')
+alerts(detector_id='${var.detector_ids.platform_pods_unhealthy}').publish(label='Platform pod alerts')
 EOF
 
   plot_type                 = "LineChart"
@@ -63,6 +64,7 @@ resource "signalfx_time_chart" "otel_collector_pods" {
 A = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(1.5, 2.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Running')
 B = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Pending')
 C = data('k8s.pod.phase', filter=(${local.k8s_otel_collector_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name']).publish(label='Failed or unknown')
+alerts(detector_id='${var.detector_ids.otel_collector_health}').publish(label='Splunk OTel collector alerts')
 EOF
 
   plot_type                 = "LineChart"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_interface_contract.tftest.hcl
@@ -9,6 +9,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_interface
     module_path = "."
     expected_input_variables = [
       "dashboard_group",
+      "detector_ids",
       "dynamic_variables",
       "platform_namespaces",
     ]
@@ -32,6 +33,10 @@ run "integrations_splunk_o11y_conf_shared_dashboards_k8s_control_plane_interface
       "variable \"platform_namespaces\"",
       "description = \"Namespaces that contain platform pods required for runner scheduling, networking, and telemetry.\"",
       "type        = list(string)",
+      "variable \"detector_ids\"",
+      "description = \"Kubernetes detector IDs linked to control-plane health charts.\"",
+      "otel_collector_health   = string",
+      "platform_pods_unhealthy = string",
     ]
   }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/tests/k8s_control_plane_dashboard_behavior.tftest.hcl
@@ -3,6 +3,10 @@ mock_provider "signalfx" {}
 variables {
   dashboard_group     = "forge-dashboard-group"
   platform_namespaces = ["karpenter", "kube-system", "monitoring"]
+  detector_ids = {
+    otel_collector_health   = "otel-collector-detector-id"
+    platform_pods_unhealthy = "platform-pods-detector-id"
+  }
   dynamic_variables = [
     {
       property               = "k8s.cluster.name"
@@ -60,5 +64,14 @@ run "k8s_control_plane_dashboard_contract" {
       && strcontains(signalfx_time_chart.otel_telemetry_loss.program_text, "otelcol_receiver_refused_metric_points")
     )
     error_message = "K8S control-plane charts must cover configured platform namespaces, pod and deployment health, node readiness and pressure, and OTel pipeline health."
+  }
+
+  assert {
+    condition = (
+      strcontains(signalfx_time_chart.platform_pod_health.program_text, "alerts(detector_id='platform-pods-detector-id')")
+      && strcontains(signalfx_time_chart.otel_collector_pods.program_text, "alerts(detector_id='otel-collector-detector-id')")
+      && !strcontains(signalfx_time_chart.node_pressure.program_text, "alerts(detector_id=")
+    )
+    error_message = "Only the matching platform and collector pod-health charts may link Kubernetes detectors."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/k8s_control_plane/variables.tf
@@ -21,3 +21,11 @@ variable "dashboard_group" {
   description = "Dashboard group name for organizing dashboards."
   type        = string
 }
+
+variable "detector_ids" {
+  description = "Kubernetes detector IDs linked to control-plane health charts."
+  type = object({
+    otel_collector_health   = string
+    platform_pods_unhealthy = string
+  })
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/README.md
@@ -65,6 +65,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_dashboard_group"></a> [dashboard\_group](#input\_dashboard\_group) | Dashboard group name for organizing dashboards. | `string` | n/a | yes |
+| <a name="input_detector_ids"></a> [detector\_ids](#input\_detector\_ids) | Kubernetes detector IDs linked to tenant pod-phase charts. | <pre>object({<br/>    otel_no_data        = string<br/>    tenant_pods_pending = string<br/>  })</pre> | n/a | yes |
 | <a name="input_dynamic_variables"></a> [dynamic\_variables](#input\_dynamic\_variables) | Additional dynamic variable definitions for the dashboard. | <pre>list(object({<br/>    property               = string<br/>    alias                  = string<br/>    description            = string<br/>    values                 = list(string)<br/>    value_required         = bool<br/>    values_suggested       = list(string)<br/>    restricted_suggestions = bool<br/>  }))</pre> | `[]` | no |
 | <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | List of tenant names used for the dashboard. | `list(string)` | n/a | yes |
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/main.tf
@@ -469,6 +469,8 @@ B = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').
 C = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(2.5, 3.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Succeeded')
 D = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(3.5, 4.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Failed')
 E = data('k8s.pod.phase', filter=(${local.k8s_tenant_filter}), rollup='latest').between(4.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.cluster.name', 'k8s.namespace.name']).publish(label='Unknown')
+alerts(detector_id='${var.detector_ids.otel_no_data}').publish(label='Kubernetes telemetry alerts')
+alerts(detector_id='${var.detector_ids.tenant_pods_pending}').publish(label='Tenant pending-pod alerts')
 EOF
 
   plot_type                 = "LineChart"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_interface_contract.tftest.hcl
@@ -9,6 +9,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_interface_contra
     module_path = "."
     expected_input_variables = [
       "dashboard_group",
+      "detector_ids",
       "dynamic_variables",
       "tenant_names",
     ]
@@ -32,6 +33,10 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_interface_contra
       "variable \"tenant_names\"",
       "description = \"List of tenant names used for the dashboard.\"",
       "type        = list(string)",
+      "variable \"detector_ids\"",
+      "description = \"Kubernetes detector IDs linked to tenant pod-phase charts.\"",
+      "otel_no_data        = string",
+      "tenant_pods_pending = string",
     ]
   }
 
@@ -62,9 +67,9 @@ run "integrations_splunk_o11y_conf_shared_dashboards_runner_k8s_interface_contra
 
   assert {
     condition = (
-      output.expected_input_variable_count == 3
+      output.expected_input_variable_count == 4
       && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 18
+      && output.expected_interface_literal_count == 22
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/tests/runner_k8s_dashboard_behavior.tftest.hcl
@@ -3,6 +3,10 @@ mock_provider "signalfx" {}
 variables {
   tenant_names    = ["tenant-b", "tenant-a"]
   dashboard_group = "forge-dashboard-group"
+  detector_ids = {
+    otel_no_data        = "k8s-no-data-detector-id"
+    tenant_pods_pending = "tenant-pending-detector-id"
+  }
   dynamic_variables = [
     {
       property               = "k8s.cluster.name"
@@ -57,6 +61,15 @@ run "runner_k8s_dashboard_contract" {
       ] : strcontains(program_text, "filter('k8s.namespace.name', 'tenant-a') or filter('k8s.namespace.name', 'tenant-b')")
     ])
     error_message = "Every K8S runner chart must explicitly restrict telemetry to configured Forge tenant namespaces."
+  }
+
+  assert {
+    condition = (
+      strcontains(signalfx_time_chart.k8s_pod_phase_trend.program_text, "alerts(detector_id='k8s-no-data-detector-id')")
+      && strcontains(signalfx_time_chart.k8s_pod_phase_trend.program_text, "alerts(detector_id='tenant-pending-detector-id')")
+      && length(regexall("alerts\\(detector_id=", signalfx_time_chart.k8s_pod_phase_trend.program_text)) == 2
+    )
+    error_message = "The pod-phase trend must link the Kubernetes telemetry and tenant pending-pod detectors."
   }
 }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_k8s/variables.tf
@@ -22,3 +22,11 @@ variable "dashboard_group" {
   description = "Dashboard group name for organizing dashboards."
   type        = string
 }
+
+variable "detector_ids" {
+  description = "Kubernetes detector IDs linked to tenant pod-phase charts."
+  type = object({
+    otel_no_data        = string
+    tenant_pods_pending = string
+  })
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/README.md
@@ -77,5 +77,7 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_detector_id"></a> [detector\_id](#output\_detector\_id) | AWS regional platform detector ID for linking queue-health charts. |
 <!-- END_TF_DOCS -->

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/outputs.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/outputs.tf
@@ -1,0 +1,4 @@
+output "detector_id" {
+  description = "AWS regional platform detector ID for linking queue-health charts."
+  value       = signalfx_detector.aws_regional_platform_health.id
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_interface_contract.tftest.hcl
@@ -13,7 +13,9 @@ run "aws_regional_health_detector_interface_contract" {
       "dynamic_variables",
       "team",
     ]
-    expected_output_values = []
+    expected_output_values = [
+      "detector_id",
+    ]
     expected_interface_literals = [
       "variable \"detector_notifications\"",
       "variable \"detector_name_prefix\"",
@@ -26,6 +28,8 @@ run "aws_regional_health_detector_interface_contract" {
       "value_required         = bool",
       "values_suggested       = list(string)",
       "restricted_suggestions = bool",
+      "output \"detector_id\"",
+      "description = \"AWS regional platform detector ID for linking queue-health charts.\"",
     ]
   }
 
@@ -47,8 +51,8 @@ run "aws_regional_health_detector_interface_contract" {
   assert {
     condition = (
       output.expected_input_variable_count == 4
-      && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 11
+      && output.expected_output_value_count == 1
+      && output.expected_interface_literal_count == 13
     )
     error_message = "Interface contract counts must remain pinned."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/README.md
@@ -10,3 +10,44 @@ rules for:
 
 The detector keeps `AWSRegion` in the output MTS so a tenant
 incident identifies the affected Forge deployment region.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.11 |
+| <a name="requirement_signalfx"></a> [signalfx](#requirement\_signalfx) | < 10.0.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.33.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [signalfx_detector.tenant_dependency_health](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_detector_config"></a> [detector\_config](#input\_detector\_config) | Thresholds and durations for tenant dependency detectors. | <pre>object({<br/>    failure_duration                   = string<br/>    no_data_duration                   = string<br/>    no_data_fill_duration              = string<br/>    rate_limit_duration                = string<br/>    rate_limit_remaining_pct_threshold = number<br/>  })</pre> | n/a | yes |
+| <a name="input_detector_name_prefix"></a> [detector\_name\_prefix](#input\_detector\_name\_prefix) | Prefix to use for Splunk Observability detector names. | `string` | n/a | yes |
+| <a name="input_detector_notifications"></a> [detector\_notifications](#input\_detector\_notifications) | Detector notification destinations. | `list(string)` | n/a | yes |
+| <a name="input_team"></a> [team](#input\_team) | Splunk Observability team ID. | `string` | n/a | yes |
+| <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | Forge tenants that require independent dependency detectors. | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_detector_ids"></a> [detector\_ids](#output\_detector\_ids) | Dependency detector IDs keyed by tenant for linking dashboard charts. |
+<!-- END_TF_DOCS -->

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/outputs.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/outputs.tf
@@ -1,0 +1,7 @@
+output "detector_ids" {
+  description = "Dependency detector IDs keyed by tenant for linking dashboard charts."
+  value = {
+    for tenant_name, detector in signalfx_detector.tenant_dependency_health :
+    tenant_name => detector.id
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_interface_contract.tftest.hcl
@@ -14,7 +14,9 @@ run "dependency_probes_interface_contract" {
       "team",
       "tenant_names",
     ]
-    expected_output_values = []
+    expected_output_values = [
+      "detector_ids",
+    ]
     expected_interface_literals = [
       "variable \"detector_notifications\"",
       "variable \"detector_name_prefix\"",
@@ -26,6 +28,8 @@ run "dependency_probes_interface_contract" {
       "no_data_fill_duration              = string",
       "rate_limit_duration                = string",
       "rate_limit_remaining_pct_threshold = number",
+      "output \"detector_ids\"",
+      "description = \"Dependency detector IDs keyed by tenant for linking dashboard charts.\"",
     ]
   }
 
@@ -47,8 +51,8 @@ run "dependency_probes_interface_contract" {
   assert {
     condition = (
       output.expected_input_variable_count == 5
-      && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 10
+      && output.expected_output_value_count == 1
+      && output.expected_interface_literal_count == 12
     )
     error_message = "Interface contract counts must remain pinned."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
@@ -62,5 +62,7 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_detector_ids"></a> [detector\_ids](#output\_detector\_ids) | Kubernetes detector IDs for linking the matching dashboard charts. |
 <!-- END_TF_DOCS -->

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/outputs.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/outputs.tf
@@ -1,0 +1,9 @@
+output "detector_ids" {
+  description = "Kubernetes detector IDs for linking the matching dashboard charts."
+  value = {
+    otel_no_data            = signalfx_detector.k8s_otel_no_data.id
+    otel_collector_health   = signalfx_detector.k8s_otel_collector_health.id
+    tenant_pods_pending     = signalfx_detector.k8s_tenant_pods_pending.id
+    platform_pods_unhealthy = signalfx_detector.k8s_platform_pods_unhealthy.id
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract.tftest.hcl
@@ -17,7 +17,9 @@ run "integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract" {
       "team",
       "tenant_names",
     ]
-    expected_output_values = []
+    expected_output_values = [
+      "detector_ids",
+    ]
     expected_interface_literals = [
       "variable \"detector_name_prefix\"",
       "description = \"Prefix to use for Splunk Observability detector names.\"",
@@ -66,6 +68,8 @@ run "integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract" {
       "description = \"Team ID.\"",
       "variable \"tenant_names\"",
       "description = \"List of Forge tenant namespaces.\"",
+      "output \"detector_ids\"",
+      "description = \"Kubernetes detector IDs for linking the matching dashboard charts.\"",
     ]
   }
 
@@ -97,8 +101,8 @@ run "integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract" {
   assert {
     condition = (
       output.expected_input_variable_count == 8
-      && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 47
+      && output.expected_output_value_count == 1
+      && output.expected_interface_literal_count == 49
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }


### PR DESCRIPTION
## Description

Link the existing Splunk Observability detectors to the dashboard charts that
visualize their monitored signals.

- Export detector IDs from the Kubernetes, dependency-probe, and AWS regional-health detector modules.
- Add `alerts(detector_id=...)` streams to the matching Kubernetes pod-health, dependency-health, and regional queue-health charts.
- Keep diagnostic-only dependency latency and Lambda throttle charts unlinked because no corresponding detector rules exist.
- Add behavior and interface-contract coverage for the detector-to-chart mappings and refresh generated module documentation.

This makes active detector state visible from the relevant dashboard charts
while retaining the detectors as independently managed alerting resources.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: _________

## Testing

- `tofu test` in all seven affected dashboard and detector submodules: 22 tests passed.
- `tofu test` in `modules/integrations/splunk_o11y_conf_shared`: 3 tests passed.
- Repository pre-commit hooks passed, including Tofu formatting/validation,
  Terraform formatting/lint/validation, Gitleaks, Bandit, and pip-audit.
