### PR TITLE
fix(observability): extract shared Lambda fields

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
@@ -3,6 +3,7 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs" {
   name = "props/aws:cloudwatchlogs"
 
   variables = {
+    "REPORT-forgecicd_shared_lambda_fields"                           = "forgecicd_shared_lambda_fields"
     "REPORT-forgecicd_cloudwatchlogs_lambda_tenant_fields"            = "forgecicd_cloudwatchlogs_lambda_tenant_fields"
     "REPORT-forgecicd_cloudwatchlogs_global_lambda_tenant_fields"     = "forgecicd_cloudwatchlogs_global_lambda_tenant_fields"
     "REPORT-forgecicd_dispatch_to_runner_rejection_fields"            = "forgecicd_dispatch_to_runner_rejection_fields"
@@ -97,6 +98,7 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs" {
     ]
   }
   depends_on = [
+    splunk_configs_conf.forgecicd_shared_lambda_fields,
     splunk_configs_conf.forgecicd_cloudwatchlogs_lambda_tenant_fields,
     splunk_configs_conf.forgecicd_cloudwatchlogs_global_lambda_tenant_fields,
     splunk_configs_conf.forgecicd_dispatch_to_runner_rejection_fields,

--- a/modules/integrations/splunk_cloud_conf_shared/tests/integrations_splunk_cloud_conf_shared_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/integrations_splunk_cloud_conf_shared_source_inventory.tftest.hcl
@@ -63,6 +63,7 @@ run "integrations_splunk_cloud_conf_shared_contract" {
       "resource \"splunk_configs_conf\" \"forgecicd_kube_container_manager_tenant_fields\"",
       "resource \"splunk_configs_conf\" \"forgecicd_kube_container_runner_ci_result\"",
       "resource \"splunk_configs_conf\" \"forgecicd_kube_container_runner_gh_runner_version\"",
+      "resource \"splunk_configs_conf\" \"forgecicd_shared_lambda_fields\"",
       "resource \"splunk_configs_conf\" \"forgecicd_extra_lambda_tenant_fields\"",
       "resource \"splunk_configs_conf\" \"forgecicd_extra_lambda_ec2_tenant_fields\"",
       "resource \"splunk_configs_conf\" \"forgecicd_trust_validation\"",

--- a/modules/integrations/splunk_cloud_conf_shared/tests/splunk_cloud_conf_shared_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/splunk_cloud_conf_shared_behavior.tftest.hcl
@@ -70,4 +70,21 @@ run "splunk_cloud_shared_dashboard_and_props_contract" {
     )
     error_message = "Splunk shared props must keep JSON runner log sourcetype transforms for tenant, EC2, and ARC metadata."
   }
+
+  assert {
+    condition = (
+      splunk_configs_conf.forgecicd_cloudwatchlogs.variables["REPORT-forgecicd_shared_lambda_fields"] == "forgecicd_shared_lambda_fields"
+      && splunk_configs_conf.forgecicd_shared_lambda_fields.name == "transforms/forgecicd_shared_lambda_fields"
+      && strcontains(splunk_configs_conf.forgecicd_shared_lambda_fields.variables["REGEX"], "splunk-dependency-monitor")
+      && strcontains(splunk_configs_conf.forgecicd_shared_lambda_fields.variables["REGEX"], "splunk-s3-runner-logs-lambda")
+      && strcontains(splunk_configs_conf.forgecicd_shared_lambda_fields.variables["REGEX"], "forge-aws-billing-per-service")
+      && strcontains(splunk_configs_conf.forgecicd_shared_lambda_fields.variables["REGEX"], "forge-aws-billing-per-resource-process")
+      && strcontains(splunk_configs_conf.forgecicd_shared_lambda_fields.variables["REGEX"], "forge-aws-billing-per-resource")
+      && strcontains(splunk_configs_conf.forgecicd_shared_lambda_fields.variables["REGEX"], "webex-webhook-relay-destination-receiver")
+      && strcontains(splunk_configs_conf.forgecicd_shared_lambda_fields.variables["REGEX"], "SplunkDMMetadataEC2InstPatternTags")
+      && strcontains(splunk_configs_conf.forgecicd_shared_lambda_fields.variables["REGEX"], "SplunkDMMetadataEC2Inst")
+      && splunk_configs_conf.forgecicd_shared_lambda_fields.variables["FORMAT"] == "aws_region::$1 forgecicd_log_type::$2"
+    )
+    error_message = "Splunk shared Lambda extraction must cover every Forge-managed shared Lambda and normalize its region and log type fields."
+  }
 }

--- a/modules/integrations/splunk_cloud_conf_shared/transforms_lambda.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/transforms_lambda.tf
@@ -1,3 +1,35 @@
+resource "splunk_configs_conf" "forgecicd_shared_lambda_fields" {
+  name = "transforms/forgecicd_shared_lambda_fields"
+
+  variables = {
+    "REGEX"      = "(?<aws_region>[^:]+):\\/aws\\/lambda\\/(?<forgecicd_log_type>splunk-dependency-monitor|splunk-s3-runner-logs-lambda|forge-aws-billing-per-service|forge-aws-billing-per-resource-process|forge-aws-billing-per-resource|webex-webhook-relay-destination-receiver|SplunkDMMetadataEC2InstPatternTags|SplunkDMMetadataEC2Inst)(?:-[a-z]{2}(?:-[a-z]+)+-[0-9]+)?:"
+    "FORMAT"     = "aws_region::$1 forgecicd_log_type::$2"
+    "SOURCE_KEY" = "source"
+    "CLEAN_KEYS" = "0"
+  }
+  acl {
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
+  }
+  lifecycle {
+    ignore_changes = [
+      variables["CAN_OPTIMIZE"],
+      variables["DEFAULT_VALUE"],
+      variables["DEPTH_LIMIT"],
+      variables["DEST_KEY"],
+      variables["KEEP_EMPTY_VALS"],
+      variables["LOOKAHEAD"],
+      variables["MATCH_LIMIT"],
+      variables["MV_ADD"],
+      variables["WRITE_META"],
+      variables["disabled"]
+    ]
+  }
+}
+
 resource "splunk_configs_conf" "forgecicd_extra_lambda_tenant_fields" {
   name = "transforms/forgecicd_extra_lambda_tenant_fields"
 


### PR DESCRIPTION
## Description

Add Splunk Cloud source-field extraction for Forge-managed shared Lambdas that do not use the tenant-prefixed naming convention.

The new transform extracts `aws_region` and a normalized `forgecicd_log_type` for:

- `splunk-dependency-monitor-${aws_region}`
- `splunk-s3-runner-logs-lambda-${aws_region}`
- `forge-aws-billing-per-service`
- `forge-aws-billing-per-resource`
- `forge-aws-billing-per-resource-process`
- `webex-webhook-relay-destination-receiver`
- `SplunkDMMetadataEC2InstPatternTags`
- `SplunkDMMetadataEC2Inst`

Register the transform with `props/aws:cloudwatchlogs` and add source-inventory and behavior coverage so the allowlist remains explicit.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu test` in `modules/integrations/splunk_cloud_conf_shared` — 3 passed
- Repository pre-commit hooks — passed
