### PR TITLE
fix(job-logs): mitigate archiver out-of-memory failures

### DIFF
--- a/modules/platform/forge_runners/github_actions_job_logs/job_log_archiver.tf
+++ b/modules/platform/forge_runners/github_actions_job_logs/job_log_archiver.tf
@@ -11,7 +11,7 @@ module "job_log_archiver" {
   function_name = local.resource_name_archiver
   handler       = "job_log_archiver.lambda_handler"
   runtime       = "python3.12"
-  memory_size   = 1024
+  memory_size   = 2048
   timeout       = 900
   architectures = ["x86_64"]
 

--- a/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
+++ b/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
@@ -1,15 +1,17 @@
 import base64
+import io
 import json
 import logging
 import os
 import re
 import time
-from typing import Any, Dict, Tuple
+from typing import Any, BinaryIO, Dict, Tuple
 from urllib.parse import quote
 
 import boto3
 import jwt
 import requests
+from boto3.s3.transfer import TransferConfig
 from requests.exceptions import RequestException
 
 LOG = logging.getLogger()
@@ -18,6 +20,7 @@ LOG.setLevel(getattr(logging, level_str, logging.INFO))
 
 SSM = boto3.client('ssm')
 S3 = boto3.client('s3')
+S3_TRANSFER_CONFIG = TransferConfig(use_threads=False)
 
 MAX_S3_TAGS = 10
 GITHUB_RETRY_ATTEMPTS = 3
@@ -71,16 +74,44 @@ def _get_installation_token(installation_id: str, jwt_token: str, api: str) -> s
     return r.json()['token']
 
 
-def _download_job_logs(owner: str, repo: str, job_id: int, token: str, api: str) -> bytes:
+class CountingReader(io.RawIOBase):
+    """Count bytes read while preserving a non-seekable streaming interface."""
+
+    def __init__(self, stream: BinaryIO):
+        self._stream = stream
+        self.bytes_read = 0
+
+    def readable(self) -> bool:
+        return True
+
+    def read(self, size: int = -1) -> bytes:
+        chunk = self._stream.read(size)
+        self.bytes_read += len(chunk)
+        return chunk
+
+
+def _download_job_logs(owner: str, repo: str, job_id: int, token: str, api: str) -> requests.Response:
     url = f"{api}/repos/{owner}/{repo}/actions/jobs/{job_id}/logs"
     headers = {'Authorization': f"token {token}",
                'Accept': 'application/vnd.github+json'}
 
     for attempt in range(GITHUB_LOG_NOT_FOUND_RETRY_ATTEMPTS):
-        r = _retry_request(requests.get, url=url, headers=headers, timeout=60)
+        r = _retry_request(
+            requests.get,
+            url=url,
+            headers=headers,
+            timeout=60,
+            stream=True,
+        )
         if r.status_code != 404:
-            r.raise_for_status()
-            return r.content
+            try:
+                r.raise_for_status()
+            except Exception:
+                r.close()
+                raise
+            r.raw.decode_content = True
+            return r
+        r.close()
         if attempt < GITHUB_LOG_NOT_FOUND_RETRY_ATTEMPTS - 1:
             delay = GITHUB_RETRY_DELAY * (2 ** attempt)
             LOG.warning(
@@ -101,14 +132,28 @@ def _serialize_tags(tags: Dict[str, str]) -> str:
     return '&'.join(f"{quote(k, safe='')}={quote(v, safe='')}" for k, v in safe_tags.items())
 
 
-def _put_log_object(bucket: str, key: str, body: bytes, kms_key_arn: str, tags: Dict[str, str]) -> None:
+def _put_log_object(
+    bucket: str,
+    key: str,
+    body: BinaryIO,
+    kms_key_arn: str,
+    tags: Dict[str, str],
+) -> int:
     extra: Dict[str, Any] = {
         'ContentType': 'text/plain',
         'ServerSideEncryption': 'aws:kms',
         'SSEKMSKeyId': kms_key_arn,
         'Tagging': _serialize_tags(tags),
     }
-    S3.put_object(Bucket=bucket, Key=key, Body=body, **extra)
+    counted_body = CountingReader(body)
+    S3.upload_fileobj(
+        counted_body,
+        bucket,
+        key,
+        ExtraArgs=extra,
+        Config=S3_TRANSFER_CONFIG,
+    )
+    return counted_body.bytes_read
 
 
 def _put_json_object(bucket: str, key: str, payload: Dict[str, Any], kms_key_arn: str, tags: Dict[str, str]) -> None:
@@ -331,14 +376,21 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:  # p
                 job_id,
                 run_attempt or 1,
             )
-            body = _download_job_logs(owner, repo, int(
+            response = _download_job_logs(owner, repo, int(
                 job_id), install_token, env['GITHUB_API'])
-            _put_json_object(env['BUCKET_NAME'], metadata_key,
-                             _metadata_payload(detail, log_key, event_key),
-                             env['KMS_KEY_ARN'], obj_tags)
-            _put_log_object(env['BUCKET_NAME'], log_key, body,
-                            env['KMS_KEY_ARN'], data_obj_tags)
-            size = len(body)
+            try:
+                _put_json_object(env['BUCKET_NAME'], metadata_key,
+                                 _metadata_payload(detail, log_key, event_key),
+                                 env['KMS_KEY_ARN'], obj_tags)
+                size = _put_log_object(
+                    env['BUCKET_NAME'],
+                    log_key,
+                    response.raw,
+                    env['KMS_KEY_ARN'],
+                    data_obj_tags,
+                )
+            finally:
+                response.close()
             _put_json_object(env['BUCKET_NAME'], event_key,
                              detail, env['KMS_KEY_ARN'], data_obj_tags)
 
@@ -369,8 +421,9 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:  # p
                 'run_id': run_id,
             }
         except Exception as e:
-            raise ValueError(
-                'archiver_error: job_id=%s run_id=%s. Error: %s', job_id, run_id, str(e))
+            raise RuntimeError(
+                f'archiver_error: job_id={job_id} run_id={run_id}. Error: {e}'
+            ) from e
     except Exception as e:
         LOG.exception(
             'Unhandled exception in job_log_archiver lambda. Error: %s', str(e))

--- a/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
+++ b/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
@@ -323,6 +323,14 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:  # p
                 **obj_tags,
                 METADATA_TAG_KEY: metadata_key,
             }
+            LOG.info(
+                'Downloading GitHub job logs repository=%s run_id=%s '
+                'job_id=%s run_attempt=%s',
+                repo_full_name,
+                run_id,
+                job_id,
+                run_attempt or 1,
+            )
             body = _download_job_logs(owner, repo, int(
                 job_id), install_token, env['GITHUB_API'])
             _put_json_object(env['BUCKET_NAME'], metadata_key,

--- a/tests/iac/terraform_contract_test.py
+++ b/tests/iac/terraform_contract_test.py
@@ -200,6 +200,7 @@ def test_job_log_pipeline_wires_runtime_env_and_event_contract() -> None:
     assert 'handler       = "job_log_archiver.lambda_handler"' in archiver_module
     assert 'runtime       = "python3.12"' in dispatcher_module
     assert 'runtime       = "python3.12"' in archiver_module
+    assert 'memory_size   = 2048' in archiver_module
 
     assert_contains_all(
         dispatcher_tf,

--- a/tests/lambdas/job_log_archiver_test.py
+++ b/tests/lambdas/job_log_archiver_test.py
@@ -417,11 +417,21 @@ def test_missing_job_logs_are_terminal_after_retries(
     assert s3_kms['s3'].list_objects_v2(Bucket=alpha).get('Contents', []) == []
 
 
-def test_archival_failure_propagates_for_sqs_retry(monkeypatch, s3_kms, ssm):
+def test_archival_failure_propagates_for_sqs_retry(
+    monkeypatch, s3_kms, ssm, caplog
+):
     alpha = s3_kms['buckets']['alpha']
     mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)
+    expected_message = (
+        'Downloading GitHub job logs repository=acme/app '
+        'run_id=99 job_id=4242 run_attempt=1'
+    )
 
     def _boom(*a, **k):
+        assert any(
+            record.getMessage() == expected_message
+            for record in caplog.records
+        )
         raise RuntimeError('github 500')
 
     monkeypatch.setattr(mod, '_download_job_logs', _boom)

--- a/tests/lambdas/job_log_archiver_test.py
+++ b/tests/lambdas/job_log_archiver_test.py
@@ -8,8 +8,6 @@ Two behaviours matter most (register P1-8, P0-5):
     tenant's bucket.
   * Failure handling: if archival fails, the handler must propagate the error so
     the SQS event-source mapping retries and ultimately routes to the DLQ.
-    Today the handler swallows the exception (returns None) so the message is
-    deleted and logs are lost silently — encoded as xfail(P0-5).
 
 GitHub network calls are monkeypatched out; only AWS (moto) is exercised.
 """
@@ -17,6 +15,7 @@ GitHub network calls are monkeypatched out; only AWS (moto) is exercised.
 from __future__ import annotations
 
 import base64
+import io
 import json
 from types import SimpleNamespace
 
@@ -70,6 +69,17 @@ def _load_archiver(monkeypatch, s3_kms, ssm, *, bucket):
     return mod
 
 
+def _log_response(body=b'log-bytes', status_code=200):
+    raw = io.BytesIO(body)
+    raw.decode_content = False
+    return SimpleNamespace(
+        status_code=status_code,
+        raw=raw,
+        close=lambda: None,
+        raise_for_status=lambda: None,
+    )
+
+
 def test_logs_written_only_to_configured_tenant_bucket(
     monkeypatch, s3_kms, ssm
 ):
@@ -77,7 +87,7 @@ def test_logs_written_only_to_configured_tenant_bucket(
     bravo = s3_kms['buckets']['bravo']
     mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)
     monkeypatch.setattr(mod, '_download_job_logs',
-                        lambda *a, **k: b'log-bytes')
+                        lambda *a, **k: _log_response())
 
     mod.lambda_handler(_completed_event(repo='acme/app', job_id=4242), None)
 
@@ -101,7 +111,7 @@ def test_log_object_is_kms_encrypted(monkeypatch, s3_kms, ssm):
     alpha = s3_kms['buckets']['alpha']
     mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)
     monkeypatch.setattr(mod, '_download_job_logs',
-                        lambda *a, **k: b'log-bytes')
+                        lambda *a, **k: _log_response())
     mod.lambda_handler(_completed_event(), None)
     s3 = s3_kms['s3']
     key = next(
@@ -116,7 +126,7 @@ def test_metadata_sidecar_contains_flat_fields(monkeypatch, s3_kms, ssm):
     alpha = s3_kms['buckets']['alpha']
     mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)
     monkeypatch.setattr(mod, '_download_job_logs',
-                        lambda *a, **k: b'log-bytes')
+                        lambda *a, **k: _log_response())
 
     evt = _completed_event()
     body = json.loads(evt['Records'][0]['body'])
@@ -335,7 +345,8 @@ def test_missing_repository_is_rejected_without_github_or_s3_side_effects(
 def test_skipped_jobs_are_not_archived(monkeypatch, s3_kms, ssm):
     alpha = s3_kms['buckets']['alpha']
     mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)
-    monkeypatch.setattr(mod, '_download_job_logs', lambda *a, **k: b'x')
+    monkeypatch.setattr(
+        mod, '_download_job_logs', lambda *a, **k: _log_response(b'x'))
     evt = _completed_event()
     body = json.loads(evt['Records'][0]['body'])
     body['detail']['workflow_job']['conclusion'] = 'skipped'
@@ -375,7 +386,7 @@ def test_job_log_download_retries_404_before_marking_logs_unavailable(
 
     def _not_found(**_kwargs):
         responses.append(404)
-        return SimpleNamespace(status_code=404)
+        return SimpleNamespace(status_code=404, close=lambda: None)
 
     monkeypatch.setattr(mod.requests, 'get', _not_found)
     monkeypatch.setattr(mod.time, 'sleep', sleeps.append)
@@ -391,6 +402,85 @@ def test_job_log_download_retries_404_before_marking_logs_unavailable(
 
     assert responses == [404, 404, 404]
     assert sleeps == [2, 4]
+
+
+def test_job_log_download_enables_streaming_and_content_decoding(
+    monkeypatch, aws
+):
+    mod = load_handler_module('job_log_archiver')
+    calls = []
+    response = _log_response()
+
+    def _ok(**kwargs):
+        calls.append(kwargs)
+        return response
+
+    monkeypatch.setattr(mod.requests, 'get', _ok)
+
+    result = mod._download_job_logs(
+        'acme',
+        'app',
+        4242,
+        'ghs_faketoken',
+        'https://api.github.test',
+    )
+
+    assert result is response
+    assert calls[0]['stream'] is True
+    assert response.raw.decode_content is True
+
+
+def test_log_upload_is_single_threaded_and_counts_streamed_bytes(
+    monkeypatch, aws
+):
+    mod = load_handler_module('job_log_archiver')
+    calls = []
+
+    def _upload(fileobj, bucket, key, **kwargs):
+        calls.append({
+            'bucket': bucket,
+            'key': key,
+            'body': fileobj.read(),
+            **kwargs,
+        })
+
+    monkeypatch.setattr(mod.S3, 'upload_fileobj', _upload)
+
+    size = mod._put_log_object(
+        'logs-bucket',
+        'acme/app/99/1/4242.log',
+        io.BytesIO(b'streamed-log'),
+        'arn:aws:kms:us-west-2:123456789012:key/test',
+        {'status': 'completed'},
+    )
+
+    assert size == len(b'streamed-log')
+    assert calls[0]['body'] == b'streamed-log'
+    assert calls[0]['Config'].use_threads is False
+
+
+def test_managed_upload_failure_propagates_for_sqs_redrive(
+    monkeypatch, s3_kms, ssm
+):
+    alpha = s3_kms['buckets']['alpha']
+    mod = _load_archiver(monkeypatch, s3_kms, ssm, bucket=alpha)
+    response = _log_response()
+    closed = []
+    response.close = lambda: closed.append(True)
+    monkeypatch.setattr(
+        mod, '_download_job_logs', lambda *_args, **_kwargs: response)
+    monkeypatch.setattr(
+        mod.S3,
+        'upload_fileobj',
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError('multipart upload failed')
+        ),
+    )
+
+    with pytest.raises(Exception, match='archiver_error'):
+        mod.lambda_handler(_completed_event(), None)
+
+    assert closed == [True]
 
 
 def test_missing_job_logs_are_terminal_after_retries(
@@ -435,6 +525,6 @@ def test_archival_failure_propagates_for_sqs_retry(
         raise RuntimeError('github 500')
 
     monkeypatch.setattr(mod, '_download_job_logs', _boom)
-    # A correct handler surfaces the failure to SQS (raises); today it swallows.
+    # The handler must surface the failure to SQS so the message is retried.
     with pytest.raises(Exception):
         mod.lambda_handler(_completed_event(), None)


### PR DESCRIPTION
## Description

Prevent GitHub job-log archiver out-of-memory failures and preserve enough context to retry or diagnose failed messages.

- Increase Lambda memory from 1,024 MB to 2,048 MB.
- Log the repository, run ID, job ID, and run attempt before downloading.
- Stream the GitHub response directly into a boto3 managed S3 upload.
- Disable managed-transfer threads so the non-seekable HTTP response is consumed sequentially.
- Close the GitHub response after success or failure and propagate transfer failures to the SQS event source for retry and DLQ redrive.
- Preserve the bucket lifecycle rule that aborts incomplete multipart uploads after seven days as a fallback when Lambda is terminated before boto3 can abort the upload.

The job queue uses a batch size of one and moves messages to its DLQ after 10 failed receives, so a propagated archival failure does not acknowledge or delete the message.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `uv run pytest -q tests/lambdas/job_log_archiver_test.py tests/iac/terraform_contract_test.py` - 31 passed
- Python autopep8 hook - passed
- Python linter hook - passed
- Repository pre-commit hooks during commit - passed
