### PR TITLE
feat(webhook): enable API Gateway access logs

### DIFF
--- a/examples/deployments/integrations/terragrunt/environments/prod/splunk_cloud_data_manager/config.yml
+++ b/examples/deployments/integrations/terragrunt/environments/prod/splunk_cloud_data_manager/config.yml
@@ -10,6 +10,9 @@ cloudwatch_log_groups_config:
   enabled: true
   name: forge-cwl-prod
   datasource:
+    cwl-api-gateway:
+      enabled: true
+      index: forge-prod-index
     cwl-eks:
       enabled: true
       index: forge-prod-index

--- a/examples/templates/integrations/splunk_cloud_data_manager/config.yml
+++ b/examples/templates/integrations/splunk_cloud_data_manager/config.yml
@@ -10,6 +10,9 @@ cloudwatch_log_groups_config:
   enabled: <CWL_ENABLED>                    # true or false
   name: <CWL_GROUP_NAME>                    # e.g., forge-cwl-prod
   datasource:
+    cwl-api-gateway:
+      enabled: <CWL_API_GATEWAY_ENABLED>     # true or false
+      index: <CWL_API_GATEWAY_INDEX>         # e.g., forge-prod-index
     cwl-eks:
       enabled: <CWL_EKS_ENABLED>            # true or false
       index: <CWL_EKS_INDEX>                # e.g., forge-prod-index

--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -2,7 +2,37 @@ locals {
   # Templatized userdata (cloud-init) file.
   user_data_prefix               = "${path.module}/template_files"
   userdata_template_post_install = "${local.user_data_prefix}/post_install.tftpl"
+  webhook_api_gateway_access_log_format = jsonencode({
+    apiId                   = "$context.apiId"
+    domainName              = "$context.domainName"
+    errorMessage            = "$context.error.message"
+    errorResponseType       = "$context.error.responseType"
+    httpMethod              = "$context.httpMethod"
+    integrationErrorMessage = "$context.integrationErrorMessage"
+    integrationLatency      = "$context.integrationLatency"
+    integrationStatus       = "$context.integrationStatus"
+    path                    = "$context.path"
+    protocol                = "$context.protocol"
+    requestId               = "$context.requestId"
+    requestTime             = "$context.requestTime"
+    requestTimeEpoch        = "$context.requestTimeEpoch"
+    responseLatency         = "$context.responseLatency"
+    responseLength          = "$context.responseLength"
+    routeKey                = "$context.routeKey"
+    sourceIp                = "$context.identity.sourceIp"
+    stage                   = "$context.stage"
+    status                  = "$context.status"
+    userAgent               = "$context.identity.userAgent"
+  })
+}
 
+resource "aws_cloudwatch_log_group" "webhook_api_gateway_access" {
+  #checkov:skip=CKV_AWS_158:KMS encryption for webhook access logs is deferred until the runner webhook path is tested with customer-managed keys.
+  #checkov:skip=CKV_AWS_338:Webhook API access logs intentionally retain at most three days to limit request attribution data and ingestion cost.
+  name              = "/aws/apigateway/${var.runner_configs.prefix}-github-action-webhook"
+  retention_in_days = 3
+  tags              = var.tenant_configs.tags
+  tags_all          = var.tenant_configs.tags
 }
 
 # Enable AWS-managed encryption key.
@@ -121,7 +151,11 @@ module "runners" {
   # Retention period for the logs in days.
   logging_retention_in_days = var.runner_configs.logging_retention_in_days
 
-  webhook_lambda_zip                = "${data.external.download_lambdas.result.path}/webhook.zip"
+  webhook_lambda_zip = "${data.external.download_lambdas.result.path}/webhook.zip"
+  webhook_lambda_apigateway_access_log_settings = {
+    destination_arn = aws_cloudwatch_log_group.webhook_api_gateway_access.arn
+    format          = local.webhook_api_gateway_access_log_format
+  }
   runner_binaries_syncer_lambda_zip = "${data.external.download_lambdas.result.path}/runner-binaries-syncer.zip"
   runners_lambda_zip                = "${data.external.download_lambdas.result.path}/runners.zip"
 

--- a/modules/platform/ec2_deployment/tests/platform_ec2_deployment_source_inventory.tftest.hcl
+++ b/modules/platform/ec2_deployment/tests/platform_ec2_deployment_source_inventory.tftest.hcl
@@ -11,6 +11,7 @@ run "platform_ec2_deployment_contract" {
       "module \"ec2_update_runner_ssm_ami\"",
       "module \"ec2_update_runner_tags\"",
       "module \"runners\"",
+      "resource \"aws_cloudwatch_log_group\" \"webhook_api_gateway_access\"",
       "resource \"aws_kms_key\" \"github\"",
       "resource \"aws_kms_alias\" \"github\"",
       "resource \"aws_ssm_parameter\" \"hook_job_started\"",

--- a/modules/platform/forge_runners/github_webhook_relay/source/main.tf
+++ b/modules/platform/forge_runners/github_webhook_relay/source/main.tf
@@ -72,6 +72,7 @@ resource "aws_apigatewayv2_stage" "default" {
 
 resource "aws_cloudwatch_log_group" "api_gateway_access" {
   #checkov:skip=CKV_AWS_158:KMS encryption for webhook relay log groups is deferred until the relay logging path is tested with customer-managed keys.
+  #checkov:skip=CKV_AWS_338:Webhook API access logs intentionally retain at most three days to limit request attribution data and ingestion cost.
   name              = "/aws/apigateway/${local.api_name}"
   retention_in_days = 3
   tags              = var.tags

--- a/modules/platform/forge_runners/github_webhook_relay/source/main.tf
+++ b/modules/platform/forge_runners/github_webhook_relay/source/main.tf
@@ -36,12 +36,46 @@ resource "aws_apigatewayv2_route" "post_hook" {
 }
 
 resource "aws_apigatewayv2_stage" "default" {
-  #checkov:skip=CKV_AWS_76:API Gateway access logging is deferred until the webhook relay log delivery path is tested end-to-end.
   api_id      = aws_apigatewayv2_api.webhook.id
   name        = "$default"
   auto_deploy = true
-  tags        = var.tags
-  tags_all    = var.tags
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_gateway_access.arn
+    format = jsonencode({
+      apiId                   = "$context.apiId"
+      domainName              = "$context.domainName"
+      errorMessage            = "$context.error.message"
+      errorResponseType       = "$context.error.responseType"
+      httpMethod              = "$context.httpMethod"
+      integrationErrorMessage = "$context.integrationErrorMessage"
+      integrationLatency      = "$context.integrationLatency"
+      integrationStatus       = "$context.integrationStatus"
+      path                    = "$context.path"
+      protocol                = "$context.protocol"
+      requestId               = "$context.requestId"
+      requestTime             = "$context.requestTime"
+      requestTimeEpoch        = "$context.requestTimeEpoch"
+      responseLatency         = "$context.responseLatency"
+      responseLength          = "$context.responseLength"
+      routeKey                = "$context.routeKey"
+      sourceIp                = "$context.identity.sourceIp"
+      stage                   = "$context.stage"
+      status                  = "$context.status"
+      userAgent               = "$context.identity.userAgent"
+    })
+  }
+
+  tags     = var.tags
+  tags_all = var.tags
+}
+
+resource "aws_cloudwatch_log_group" "api_gateway_access" {
+  #checkov:skip=CKV_AWS_158:KMS encryption for webhook relay log groups is deferred until the relay logging path is tested with customer-managed keys.
+  name              = "/aws/apigateway/${local.api_name}"
+  retention_in_days = 3
+  tags              = var.tags
+  tags_all          = var.tags
 }
 
 resource "aws_lambda_permission" "apigw_invoke" {

--- a/modules/platform/forge_runners/github_webhook_relay/source/tests/platform_forge_runners_github_webhook_relay_source_inventory.tftest.hcl
+++ b/modules/platform/forge_runners/github_webhook_relay/source/tests/platform_forge_runners_github_webhook_relay_source_inventory.tftest.hcl
@@ -14,6 +14,7 @@ run "platform_forge_runners_github_webhook_relay_source_contract" {
       "resource \"aws_apigatewayv2_integration\" \"lambda\"",
       "resource \"aws_apigatewayv2_route\" \"post_hook\"",
       "resource \"aws_apigatewayv2_stage\" \"default\"",
+      "resource \"aws_cloudwatch_log_group\" \"api_gateway_access\"",
       "resource \"aws_lambda_permission\" \"apigw_invoke\"",
       "resource \"aws_cloudwatch_event_bus\" \"source\"",
       "resource \"aws_cloudwatch_log_delivery_source\" \"info_logs\"",

--- a/tests/iac/terraform_contract_test.py
+++ b/tests/iac/terraform_contract_test.py
@@ -309,6 +309,7 @@ def test_webhook_relay_api_gateway_access_logs_are_short_lived() -> None:
     )
     assert 'name              = "/aws/apigateway/${local.api_name}"' in log_group
     assert 'retention_in_days = 3' in log_group
+    assert 'CKV_AWS_338' in log_group
     assert 'CKV_AWS_76' not in stage
 
 

--- a/tests/iac/terraform_contract_test.py
+++ b/tests/iac/terraform_contract_test.py
@@ -276,6 +276,42 @@ def test_job_log_bucket_security_controls_are_preserved() -> None:
     assert 'Principal = "*"' not in read_policy
 
 
+def test_webhook_relay_api_gateway_access_logs_are_short_lived() -> None:
+    relay_tf = read_repo_file(
+        'modules/platform/forge_runners/github_webhook_relay/source/main.tf'
+    )
+    stage = hcl_block(
+        relay_tf,
+        'resource',
+        'aws_apigatewayv2_stage',
+        'default',
+    )
+    log_group = hcl_block(
+        relay_tf,
+        'resource',
+        'aws_cloudwatch_log_group',
+        'api_gateway_access',
+    )
+
+    assert_contains_all(
+        stage,
+        [
+            'access_log_settings {',
+            'destination_arn = aws_cloudwatch_log_group.api_gateway_access.arn',
+            'format = jsonencode({',
+            'requestId               = "$context.requestId"',
+            'sourceIp                = "$context.identity.sourceIp"',
+            'userAgent               = "$context.identity.userAgent"',
+            'routeKey                = "$context.routeKey"',
+            'status                  = "$context.status"',
+            'integrationErrorMessage = "$context.integrationErrorMessage"',
+        ],
+    )
+    assert 'name              = "/aws/apigateway/${local.api_name}"' in log_group
+    assert 'retention_in_days = 3' in log_group
+    assert 'CKV_AWS_76' not in stage
+
+
 def test_splunk_stuck_dispatcher_worker_contract_is_offline_and_scoped() -> None:
     lambda_tf = read_repo_file(
         'modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf'

--- a/tests/iac/terraform_contract_test.py
+++ b/tests/iac/terraform_contract_test.py
@@ -313,6 +313,46 @@ def test_webhook_relay_api_gateway_access_logs_are_short_lived() -> None:
     assert 'CKV_AWS_76' not in stage
 
 
+def test_runner_webhook_enables_upstream_api_gateway_access_logs() -> None:
+    deployment_tf = read_repo_file(
+        'modules/platform/ec2_deployment/main.tf'
+    )
+    runner_module = hcl_block(deployment_tf, 'module', 'runners')
+    log_group = hcl_block(
+        deployment_tf,
+        'resource',
+        'aws_cloudwatch_log_group',
+        'webhook_api_gateway_access',
+    )
+
+    assert_contains_all(
+        deployment_tf,
+        [
+            'webhook_api_gateway_access_log_format = jsonencode({',
+            'requestId               = "$context.requestId"',
+            'sourceIp                = "$context.identity.sourceIp"',
+            'userAgent               = "$context.identity.userAgent"',
+            'routeKey                = "$context.routeKey"',
+            'status                  = "$context.status"',
+            'integrationErrorMessage = "$context.integrationErrorMessage"',
+        ],
+    )
+    assert_contains_all(
+        runner_module,
+        [
+            'webhook_lambda_apigateway_access_log_settings = {',
+            'destination_arn = aws_cloudwatch_log_group.webhook_api_gateway_access.arn',
+            'format          = local.webhook_api_gateway_access_log_format',
+        ],
+    )
+    assert (
+        'name              = '
+        '"/aws/apigateway/${var.runner_configs.prefix}-github-action-webhook"'
+    ) in log_group
+    assert 'retention_in_days = 3' in log_group
+    assert 'CKV_AWS_338' in log_group
+
+
 def test_splunk_stuck_dispatcher_worker_contract_is_offline_and_scoped() -> None:
     lambda_tf = read_repo_file(
         'modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf'


### PR DESCRIPTION
## Description

Enable JSON access logging for both Forge GitHub webhook HTTP APIs so unsigned requests can be attributed without logging webhook headers or bodies.

- Capture request ID, source IP, user agent, route, status, latency, response size, and integration errors.
- Configure the custom cross-account webhook relay stage directly.
- Pass `webhook_lambda_apigateway_access_log_settings` into the pinned `terraform-aws-github-runner` v7.10.0 multi-runner module.
- Store each API's access logs in a dedicated `/aws/apigateway/<webhook-api-name>` log group.
- Retain the CloudWatch log group for three days.
- Remove the API Gateway access-logging Checkov exception.
- Enable the API Gateway dataset in the Splunk Data Manager deployment example and template.

The production Splunk configuration is updated separately to send the native `cwl-api-gateway` dataset to `srea-forge-prod-index`.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `uv run pytest -q tests/iac/terraform_contract_test.py` - 14 passed
- `tofu test -test-directory=tests` in the webhook relay source module - 2 passed
- `tofu test -test-directory=tests` in the EC2 deployment module - 2 passed
- Repository pre-commit hooks - passed
