### PR TITLE
fix(trust): reduce validation frequency

### DIFF
--- a/modules/platform/forge_runners/forge_trust_validator/README.md
+++ b/modules/platform/forge_runners/forge_trust_validator/README.md
@@ -15,6 +15,7 @@ Most runner AWS-auth failures happen at the ownership boundary between Forge and
 
 ## Operational Notes
 
+- Scheduled validation runs twice daily. Invoke the preparer Lambda explicitly after tenant IAM trust changes when immediate validation is required.
 - The delay is intentional because IAM trust changes are eventually consistent.
 - Cleanup is load-bearing: temporary trust must be removed even when validation fails.
 - A green `AssumeRole` check is not enough if `sts:TagSession` is missing.

--- a/modules/platform/forge_runners/forge_trust_validator/main.tf
+++ b/modules/platform/forge_runners/forge_trust_validator/main.tf
@@ -174,8 +174,8 @@ resource "aws_cloudwatch_log_group" "forge_trust_validator_lambda" {
 
 resource "aws_cloudwatch_event_rule" "forge_trust_preparer_lambda" {
   name                = local.forge_trust_preparer_function_name
-  description         = "Trigger Forge trust validation preparation every 10 minutes"
-  schedule_expression = "cron(*/10 * * * ? *)"
+  description         = "Trigger Forge trust validation preparation twice daily"
+  schedule_expression = "rate(12 hours)"
 
   tags     = var.tags
   tags_all = var.tags

--- a/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_source_inventory.tftest.hcl
+++ b/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_source_inventory.tftest.hcl
@@ -16,6 +16,8 @@ run "platform_forge_runners_forge_trust_validator_contract" {
       "resource \"aws_cloudwatch_log_group\" \"forge_trust_preparer_lambda\"",
       "resource \"aws_cloudwatch_log_group\" \"forge_trust_validator_lambda\"",
       "resource \"aws_cloudwatch_event_rule\" \"forge_trust_preparer_lambda\"",
+      "description         = \"Trigger Forge trust validation preparation twice daily\"",
+      "schedule_expression = \"rate(12 hours)\"",
       "resource \"aws_cloudwatch_event_target\" \"forge_trust_preparer_lambda\"",
       "resource \"aws_lambda_event_source_mapping\" \"forge_trust_validator_lambda\"",
       "resource \"aws_lambda_permission\" \"forge_trust_preparer_lambda\"",

--- a/tests/iac/terraform_contract_test.py
+++ b/tests/iac/terraform_contract_test.py
@@ -485,7 +485,7 @@ def test_forge_trust_validator_keeps_delayed_validation_contract() -> None:
         [
             'message_retention_seconds  = 86400',
             'visibility_timeout_seconds = 960',
-            'schedule_expression = "cron(*/10 * * * ? *)"',
+            'schedule_expression = "rate(12 hours)"',
             'event_source_arn = aws_sqs_queue.forge_trust_validator.arn',
             'batch_size       = 1',
             'actions = [\n      "iam:GetRole",',


### PR DESCRIPTION
## Description

Reduce scheduled Forge trust validation from every 10 minutes to twice daily using `rate(12 hours)`.

This lowers repeated IAM/STS validation from 144 runs to 2 runs per day while retaining an explicit path to invoke the preparer Lambda after tenant IAM trust changes when immediate validation is required. The source contract now pins the intended schedule.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu test` in `modules/platform/forge_runners/forge_trust_validator` — 2 passed
- Repository pre-commit hooks for the changed files — passed
