### PR TITLE
fix(webhook): handle invalid signatures

### DIFF
--- a/modules/platform/forge_runners/github_webhook_relay/source/lambda/validate_signature.py
+++ b/modules/platform/forge_runners/github_webhook_relay/source/lambda/validate_signature.py
@@ -25,9 +25,20 @@ def lambda_handler(event, _):
         signature = headers.get('x-hub-signature-256', '')
         body = event['body']
         gh_event = headers.get('x-github-event', 'unknown')
+        delivery_id = headers.get('x-github-delivery', 'unknown')
+        user_agent = headers.get('user-agent', 'unknown')
+        source_ip = (
+            event.get('requestContext', {})
+            .get('http', {})
+            .get('sourceIp', 'unknown')
+        )
         LOG.info(
-            'Received GitHub webhook event=%s body_bytes=%d signature_present=%s',
+            'Received GitHub webhook event=%s delivery_id=%s source_ip=%s '
+            'user_agent=%s body_bytes=%d signature_present=%s',
             gh_event,
+            delivery_id,
+            source_ip,
+            user_agent,
             len(body.encode()),
             bool(signature),
         )
@@ -36,9 +47,19 @@ def lambda_handler(event, _):
                           hashlib.sha256).hexdigest()
         expected_signature = f"sha256={digest}"
         if not hmac.compare_digest(signature, expected_signature):
-            LOG.warning('Signature mismatch for GitHub webhook event=%s',
-                        gh_event)
-            raise ValueError('Invalid signature')
+            LOG.warning(
+                'Signature mismatch for GitHub webhook event=%s '
+                'delivery_id=%s source_ip=%s user_agent=%s',
+                gh_event,
+                delivery_id,
+                source_ip,
+                user_agent,
+            )
+            return {
+                'statusCode': 401,
+                'headers': {'content-type': 'application/json'},
+                'body': json.dumps({'message': 'Invalid signature'}),
+            }
 
         payload = json.loads(body)
         action = payload.get('action', 'none')

--- a/tests/lambdas/webhook_signature_test.py
+++ b/tests/lambdas/webhook_signature_test.py
@@ -11,7 +11,7 @@ These tests encode the intended security behavior and must pass.
 
 Handler contract used here:
   * accept  -> returns {"statusCode": 200, ...}
-  * reject  -> raises (ValueError("Invalid signature"))
+  * reject  -> returns {"statusCode": 401, ...}
 The secret is read at module load from the environment; the loader re-imports
 the module after each test sets env, so per-test secret config is honoured.
 """
@@ -58,13 +58,13 @@ def test_valid_signature_is_accepted(monkeypatch, event_bus, webhook_secret):
 
 def test_missing_signature_is_rejected(monkeypatch, event_bus, webhook_secret):
     event = make_apigw_v2_event(webhook_body(), signature_256=None)
-    with pytest.raises(Exception):
-        _invoke(
-            monkeypatch,
-            event_bus['name'],
-            secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
-            event=event,
-        )
+    resp = _invoke(
+        monkeypatch,
+        event_bus['name'],
+        secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
+        event=event,
+    )
+    assert resp['statusCode'] == 401
 
 
 def test_tampered_body_is_rejected(monkeypatch, event_bus, webhook_secret):
@@ -72,25 +72,23 @@ def test_tampered_body_is_rejected(monkeypatch, event_bus, webhook_secret):
     sig = sign_sha256(webhook_secret, body)
     tampered = body.replace(b'acme/app', b'attacker/app')
     event = make_apigw_v2_event(tampered, sig)
-    with pytest.raises(Exception):
-        _invoke(
-            monkeypatch,
-            event_bus['name'],
-            secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
-            event=event,
-        )
+    assert _invoke(
+        monkeypatch,
+        event_bus['name'],
+        secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
+        event=event,
+    )['statusCode'] == 401
 
 
 def test_wrong_secret_is_rejected(monkeypatch, event_bus, webhook_secret):
     body = webhook_body()
     event = make_apigw_v2_event(body, sign_sha256(b'the-wrong-secret', body))
-    with pytest.raises(Exception):
-        _invoke(
-            monkeypatch,
-            event_bus['name'],
-            secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
-            event=event,
-        )
+    assert _invoke(
+        monkeypatch,
+        event_bus['name'],
+        secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
+        event=event,
+    )['statusCode'] == 401
 
 
 def test_legacy_sha1_only_is_rejected(monkeypatch, event_bus, webhook_secret):
@@ -98,13 +96,12 @@ def test_legacy_sha1_only_is_rejected(monkeypatch, event_bus, webhook_secret):
     event = make_apigw_v2_event(body, signature_256=None)
     event['headers']['X-Hub-Signature'] = sign_sha1_legacy(
         webhook_secret, body)
-    with pytest.raises(Exception):
-        _invoke(
-            monkeypatch,
-            event_bus['name'],
-            secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
-            event=event,
-        )
+    assert _invoke(
+        monkeypatch,
+        event_bus['name'],
+        secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
+        event=event,
+    )['statusCode'] == 401
 
 
 # --------------------------------------------------------------------------- #
@@ -116,13 +113,12 @@ def test_forged_request_rejected_when_deploytime_secret_set(
     # Configure the secret the way the deployment does, and send an UNSIGNED
     # request. A correct handler rejects it.
     event = make_apigw_v2_event(webhook_body(), signature_256=None)
-    with pytest.raises(Exception):
-        _invoke(
-            monkeypatch,
-            event_bus['name'],
-            secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
-            event=event,
-        )
+    assert _invoke(
+        monkeypatch,
+        event_bus['name'],
+        secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
+        event=event,
+    )['statusCode'] == 401
 
 
 # --------------------------------------------------------------------------- #
@@ -137,13 +133,12 @@ def test_malformed_signature_is_rejected(
     raw_digest = sign_sha256(webhook_secret, body).split('=', 1)[1]
     # Valid digest but wrong/garbage scheme prefix: endswith() accepts it today.
     event = make_apigw_v2_event(body, f"{prefix}{raw_digest}")
-    with pytest.raises(Exception):
-        _invoke(
-            monkeypatch,
-            event_bus['name'],
-            secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
-            event=event,
-        )
+    assert _invoke(
+        monkeypatch,
+        event_bus['name'],
+        secret_env={'WEBHOOK_SECRET': webhook_secret.decode()},
+        event=event,
+    )['statusCode'] == 401
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/tests/validate_signature_exec_test.py
+++ b/tests/smoke/tests/validate_signature_exec_test.py
@@ -168,13 +168,15 @@ def test_real_validate_signature_rejects_missing_signature(client):
     lam = _deploy_validate_signature(client)
 
     resp, payload = _invoke(lam, _signed_event(signature=''))
-    assert resp.get('FunctionError') == 'Unhandled'
-    assert payload.get('errorMessage') == 'Invalid signature'
+    assert 'FunctionError' not in resp
+    assert payload.get('statusCode') == 401
+    assert json.loads(payload.get('body')) == {'message': 'Invalid signature'}
 
 
 def test_real_validate_signature_rejects_wrong_signature(client):
     lam = _deploy_validate_signature(client)
 
     resp, payload = _invoke(lam, _signed_event(signature='sha256=bad'))
-    assert resp.get('FunctionError') == 'Unhandled'
-    assert payload.get('errorMessage') == 'Invalid signature'
+    assert 'FunctionError' not in resp
+    assert payload.get('statusCode') == 401
+    assert json.loads(payload.get('body')) == {'message': 'Invalid signature'}


### PR DESCRIPTION
## Description

Return a handled HTTP 401 response when a GitHub webhook signature is missing or invalid instead of raising an unhandled Lambda exception.

The validation log now includes the GitHub delivery ID, source IP, user agent, event type, and signature presence without logging the signature or request body. This provides the evidence needed to distinguish unexpected traffic from GitHub delivery or secret-configuration problems.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Testing

- `uv run --project .. --locked --only-group lambda-tests pytest -q lambdas/webhook_signature_test.py`
- 11 tests passed
- updated MiniStack execution expectations for handled 401 responses
- repository pre-commit hooks passed
