### PR TITLE
fix(logs): fail runner-log delivery after retries

### DIFF
--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs.py
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs.py
@@ -275,6 +275,7 @@ def ship_lines_to_kinesis(
         records = [{'Data': b, 'PartitionKey': str(
             i)} for i, (b, _l) in enumerate(buffer)]
         attempt = 0
+        failures: list[dict[str, Any]] = []
         while attempt < 4:
             resp = kinesis_client.put_records(
                 StreamName=KINESIS_STREAM_NAME, Records=records)
@@ -283,6 +284,11 @@ def ship_lines_to_kinesis(
                 total_shipped += len(buffer)
                 break
             # retry failed records
+            failures = [
+                result
+                for result in resp.get('Records', [])
+                if 'ErrorCode' in result
+            ]
             new_records = [
                 rec
                 for rec, result in zip(records, resp.get('Records', []))
@@ -300,7 +306,20 @@ def ship_lines_to_kinesis(
             time.sleep(backoff)
         else:
             LOG.error(
-                'kinesis_put_failed_after_retries remaining=%d', len(records))
+                'kinesis_put_failed_after_retries remaining=%d failures=%s',
+                len(records),
+                [
+                    {
+                        'error_code': failure.get('ErrorCode'),
+                        'error_message': failure.get('ErrorMessage'),
+                    }
+                    for failure in failures
+                ],
+            )
+            raise RuntimeError(
+                f'Kinesis rejected {len(records)} runner-log records '
+                'after 4 attempts'
+            )
         buffer = []
         current_bytes = 0
 

--- a/tests/lambdas/splunk_s3_runner_logs_test.py
+++ b/tests/lambdas/splunk_s3_runner_logs_test.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from conftest import requires_aws
 from support import load_handler_module
 
@@ -186,6 +187,42 @@ def test_ship_lines_retries_only_failed_kinesis_records(monkeypatch, aws):
     assert len(calls) == 2
     assert len(calls[0]['Records']) == 2
     assert len(calls[1]['Records']) == 1
+
+
+def test_ship_lines_raises_when_kinesis_retries_are_exhausted(
+    monkeypatch, aws, caplog
+):
+    mod = _load_splunk(monkeypatch)
+    calls = []
+
+    class _Kinesis:
+        def put_records(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                'FailedRecordCount': 1,
+                'Records': [{
+                    'ErrorCode': 'ProvisionedThroughputExceededException',
+                    'ErrorMessage': 'Rate exceeded for shard shardId-000',
+                }],
+            }
+
+    monkeypatch.setattr(mod, 'kinesis_client', _Kinesis())
+    monkeypatch.setattr(mod.time, 'sleep', lambda _seconds: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match='Kinesis rejected 1 runner-log records after 4 attempts',
+    ):
+        mod.ship_lines_to_kinesis(
+            ['2026-07-03T22:26:04.000Z one'],
+            'forge-gh-logs',
+            'acme/app/99/1/4242.log',
+            {},
+        )
+
+    assert len(calls) == 4
+    assert 'ProvisionedThroughputExceededException' in caplog.text
+    assert 'shardId-000' in caplog.text
 
 
 def test_ship_lines_skips_oversized_payload(monkeypatch, aws):


### PR DESCRIPTION
## Description

Stop silently discarding runner-log records when Kinesis `PutRecords` retries are exhausted.

The Lambda now:

- logs the final Kinesis error codes and messages
- raises after four failed attempts so the source SQS message is retried and can redrive to its DLQ
- continues retrying only the residual failed records within an invocation

This changes delivery from silent loss to at-least-once retry semantics. Reprocessing the S3 object can duplicate records that Kinesis accepted before the terminal failure.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Testing

- `uv run --project .. --locked --only-group lambda-tests pytest -q lambdas/splunk_s3_runner_logs_test.py`
- 11 tests passed
- repository pre-commit hooks passed
