### PR TITLE
perf(trust): validate tenant roles concurrently

### DIFF
--- a/modules/platform/forge_runners/forge_trust_validator/lambda/trust_validator.py
+++ b/modules/platform/forge_runners/forge_trust_validator/lambda/trust_validator.py
@@ -1,4 +1,6 @@
 import json
+import os
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List
 
 import boto3
@@ -6,6 +8,93 @@ from botocore.exceptions import ClientError
 from trust_common import (LOG, assume_role, build_session_policy_for_tenants,
                           build_sts_client_from_creds, cleanup_forge_roles,
                           get_lambda_caller_identity)
+
+
+def validate_tenant_role(
+    sts_as_forge: Any,
+    tenant_arn: str,
+    forge_role_arn: str,
+) -> Dict[str, Any]:
+    LOG.info(
+        'Attempting to assume Tenant role: %s from Forge role: %s',
+        tenant_arn,
+        forge_role_arn,
+    )
+    tenant_entry = {
+        'tenant_role_arn': tenant_arn,
+        'assume_role_success': False,
+        'assume_role_error': None,
+        'tag_session_success': False,
+        'tag_session_error': None,
+    }
+
+    try:
+        sts_as_forge.assume_role(
+            RoleArn=tenant_arn,
+            RoleSessionName='TenantValidation-Basic',
+        )
+        LOG.info(f'Basic AssumeRole successful for {tenant_arn}')
+        tenant_entry['assume_role_success'] = True
+    except ClientError as e:
+        LOG.error(f'Basic AssumeRole failed for {tenant_arn}: {e}')
+        tenant_entry['assume_role_error'] = str(e)
+    except Exception as e:
+        LOG.error(
+            'Unexpected error in Basic AssumeRole for %s: %s',
+            tenant_arn,
+            e,
+        )
+        tenant_entry['assume_role_error'] = f'Unexpected error: {e}'
+
+    if tenant_entry['assume_role_success']:
+        try:
+            tenant_resp = sts_as_forge.assume_role(
+                RoleArn=tenant_arn,
+                RoleSessionName='TenantValidation-Tags',
+                Tags=[
+                    {
+                        'Key': 'CreatedBy',
+                        'Value': 'ForgeTrustValidator',
+                    },
+                    {'Key': 'Validation', 'Value': 'True'},
+                ],
+            )
+
+            tenant_creds = tenant_resp['Credentials']
+            sts_as_tenant = boto3.client(
+                'sts',
+                aws_access_key_id=tenant_creds['AccessKeyId'],
+                aws_secret_access_key=tenant_creds['SecretAccessKey'],
+                aws_session_token=tenant_creds['SessionToken'],
+            )
+            identity = sts_as_tenant.get_caller_identity()
+            LOG.info(
+                'AssumeRole WITH Tags successful for %s. Identity: %s',
+                tenant_arn,
+                identity['Arn'],
+            )
+
+            tenant_entry['tag_session_success'] = True
+        except ClientError as e:
+            LOG.error(
+                'AssumeRole WITH Tags failed for %s: %s',
+                tenant_arn,
+                e,
+            )
+            tenant_entry['tag_session_error'] = str(e)
+        except Exception as e:
+            LOG.error(
+                'Unexpected error in AssumeRole WITH Tags for %s: %s',
+                tenant_arn,
+                e,
+            )
+            tenant_entry['tag_session_error'] = f'Unexpected error: {e}'
+    else:
+        tenant_entry['tag_session_error'] = (
+            'Skipped because basic AssumeRole failed'
+        )
+
+    return tenant_entry
 
 
 def validate_prepared_forge_role_against_tenants(
@@ -37,89 +126,26 @@ def validate_prepared_forge_role_against_tenants(
         forge_creds = forge_assume_resp['Credentials']
         sts_as_forge = build_sts_client_from_creds(forge_creds)
 
-        for tenant_arn in tenant_role_arns:
-            LOG.info(
-                'Attempting to assume Tenant role: %s from Forge role: %s',
-                tenant_arn,
-                forge_role_arn,
-            )
-            tenant_entry = {
-                'tenant_role_arn': tenant_arn,
-                'assume_role_success': False,
-                'assume_role_error': None,
-                'tag_session_success': False,
-                'tag_session_error': None,
-            }
-
-            try:
-                sts_as_forge.assume_role(
-                    RoleArn=tenant_arn,
-                    RoleSessionName='TenantValidation-Basic',
-                )
-                LOG.info(f'Basic AssumeRole successful for {tenant_arn}')
-                tenant_entry['assume_role_success'] = True
-            except ClientError as e:
-                LOG.error(f'Basic AssumeRole failed for {tenant_arn}: {e}')
-                tenant_entry['assume_role_error'] = str(e)
-            except Exception as e:
-                LOG.error(
-                    'Unexpected error in Basic AssumeRole for %s: %s',
+        configured_workers = int(os.environ.get(
+            'VALIDATION_MAX_WORKERS',
+            '8',
+        ))
+        worker_count = max(1, min(configured_workers, len(tenant_role_arns)))
+        LOG.info(
+            'Validating %s tenant roles with %s workers for Forge role %s',
+            len(tenant_role_arns),
+            worker_count,
+            forge_role_arn,
+        )
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            result['tenant_results'] = list(executor.map(
+                lambda tenant_arn: validate_tenant_role(
+                    sts_as_forge,
                     tenant_arn,
-                    e,
-                )
-                tenant_entry['assume_role_error'] = f'Unexpected error: {e}'
-
-            if tenant_entry['assume_role_success']:
-                try:
-                    tenant_resp = sts_as_forge.assume_role(
-                        RoleArn=tenant_arn,
-                        RoleSessionName='TenantValidation-Tags',
-                        Tags=[
-                            {
-                                'Key': 'CreatedBy',
-                                'Value': 'ForgeTrustValidator',
-                            },
-                            {'Key': 'Validation', 'Value': 'True'},
-                        ],
-                    )
-
-                    tenant_creds = tenant_resp['Credentials']
-                    sts_as_tenant = boto3.client(
-                        'sts',
-                        aws_access_key_id=tenant_creds['AccessKeyId'],
-                        aws_secret_access_key=tenant_creds['SecretAccessKey'],
-                        aws_session_token=tenant_creds['SessionToken'],
-                    )
-                    identity = sts_as_tenant.get_caller_identity()
-                    LOG.info(
-                        'AssumeRole WITH Tags successful for %s. Identity: %s',
-                        tenant_arn,
-                        identity['Arn'],
-                    )
-
-                    tenant_entry['tag_session_success'] = True
-                except ClientError as e:
-                    LOG.error(
-                        'AssumeRole WITH Tags failed for %s: %s',
-                        tenant_arn,
-                        e,
-                    )
-                    tenant_entry['tag_session_error'] = str(e)
-                except Exception as e:
-                    LOG.error(
-                        'Unexpected error in AssumeRole WITH Tags for %s: %s',
-                        tenant_arn,
-                        e,
-                    )
-                    tenant_entry['tag_session_error'] = (
-                        f'Unexpected error: {e}'
-                    )
-            else:
-                tenant_entry['tag_session_error'] = (
-                    'Skipped because basic AssumeRole failed'
-                )
-
-            result['tenant_results'].append(tenant_entry)
+                    forge_role_arn,
+                ),
+                tenant_role_arns,
+            ))
 
     except ClientError as e:
         LOG.error(f'IAM/STS error for Forge role {forge_role_arn}: {e}')

--- a/modules/platform/forge_runners/forge_trust_validator/main.tf
+++ b/modules/platform/forge_runners/forge_trust_validator/main.tf
@@ -65,7 +65,8 @@ module "forge_trust_validator_lambda" {
   trigger_on_package_timestamp = false
 
   environment_variables = {
-    LOG_LEVEL = var.log_level
+    LOG_LEVEL              = var.log_level
+    VALIDATION_MAX_WORKERS = tostring(var.validation_max_workers)
   }
 
   function_tags = var.tags

--- a/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_interface_contract.tftest.hcl
+++ b/modules/platform/forge_runners/forge_trust_validator/tests/platform_forge_runners_forge_trust_validator_interface_contract.tftest.hcl
@@ -15,6 +15,7 @@ run "platform_forge_runners_forge_trust_validator_interface_contract" {
       "prefix",
       "tags",
       "tenant_iam_roles",
+      "validation_max_workers",
     ]
     expected_output_values = []
     expected_interface_literals = [
@@ -31,6 +32,12 @@ run "platform_forge_runners_forge_trust_validator_interface_contract" {
       "&& var.iam_propagation_delay_seconds <= 900",
       ")",
       "error_message = \"iam_propagation_delay_seconds must be between 0 and 900.\"",
+      "variable \"validation_max_workers\"",
+      "description = \"Maximum number of tenant trust relationships validated concurrently for each Forge role.\"",
+      "default     = 8",
+      "var.validation_max_workers >= 1",
+      "&& var.validation_max_workers <= 32",
+      "error_message = \"validation_max_workers must be between 1 and 32.\"",
       "variable \"log_level\"",
       "type        = string",
       "description = \"Log level for application logging (e.g., INFO, DEBUG, WARN, ERROR)\"",
@@ -77,9 +84,9 @@ run "platform_forge_runners_forge_trust_validator_interface_contract" {
 
   assert {
     condition = (
-      output.expected_input_variable_count == 7
+      output.expected_input_variable_count == 8
       && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 29
+      && output.expected_interface_literal_count == 35
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/platform/forge_runners/forge_trust_validator/variables.tf
+++ b/modules/platform/forge_runners/forge_trust_validator/variables.tf
@@ -35,6 +35,20 @@ variable "iam_propagation_delay_seconds" {
   }
 }
 
+variable "validation_max_workers" {
+  type        = number
+  description = "Maximum number of tenant trust relationships validated concurrently for each Forge role."
+  default     = 8
+
+  validation {
+    condition = (
+      var.validation_max_workers >= 1
+      && var.validation_max_workers <= 32
+    )
+    error_message = "validation_max_workers must be between 1 and 32."
+  }
+}
+
 variable "forge_iam_roles" {
   type        = map(string)
   description = "List of IAM role ARNs for Forge runners."

--- a/tests/iac/terraform_contract_test.py
+++ b/tests/iac/terraform_contract_test.py
@@ -462,7 +462,10 @@ def test_forge_trust_validator_keeps_delayed_validation_contract() -> None:
         'trust_preparer.py'
     )
     assert preparer_required <= environment_keys(preparer_module)
-    assert environment_keys(validator_module) == {'LOG_LEVEL'}
+    assert environment_keys(validator_module) == {
+        'LOG_LEVEL',
+        'VALIDATION_MAX_WORKERS',
+    }
 
     assert_contains_all(
         preparer_module,

--- a/tests/lambdas/trust_workflow_test.py
+++ b/tests/lambdas/trust_workflow_test.py
@@ -519,6 +519,69 @@ def test_validate_prepared_forge_role_records_tenant_failures(
     )
 
 
+def test_validate_prepared_forge_role_uses_bounded_tenant_workers(
+    monkeypatch, aws
+):
+    mod = load_handler_module('trust_validator')
+    forge_creds = {
+        'AccessKeyId': 'access',
+        'SecretAccessKey': 'secret',
+        'SessionToken': 'token',
+    }
+    executor_workers = []
+    mapped_roles = []
+
+    class _Executor:
+        def __init__(self, max_workers):
+            executor_workers.append(max_workers)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def map(self, operation, roles):
+            mapped_roles.extend(roles)
+            return [operation(role) for role in roles]
+
+    monkeypatch.setenv('VALIDATION_MAX_WORKERS', '2')
+    monkeypatch.setattr(
+        mod,
+        'assume_role',
+        lambda **_kwargs: {'Credentials': forge_creds},
+    )
+    monkeypatch.setattr(
+        mod,
+        'build_sts_client_from_creds',
+        lambda _creds: object(),
+    )
+    monkeypatch.setattr(mod, 'ThreadPoolExecutor', _Executor)
+    monkeypatch.setattr(
+        mod,
+        'validate_tenant_role',
+        lambda _client, tenant_arn, _forge_role_arn: {
+            'tenant_role_arn': tenant_arn,
+        },
+    )
+    tenant_roles = [
+        f'arn:aws:iam::111111111111:role/tenant-{index}'
+        for index in range(3)
+    ]
+
+    result = mod.validate_prepared_forge_role_against_tenants(
+        FORGE_ROLE,
+        tenant_roles,
+    )
+
+    assert executor_workers == [2]
+    assert mapped_roles == tenant_roles
+    assert result['tenant_results'] == [
+        {'tenant_role_arn': role}
+        for role in tenant_roles
+    ]
+
+
 def test_validate_handler_accepts_only_sqs_validation_events(monkeypatch, aws):
     mod = load_handler_module('trust_validator')
     monkeypatch.setattr(mod, 'get_lambda_caller_identity', lambda: {})


### PR DESCRIPTION
## Description

Reduce the duration of each trust-validation run by validating tenant roles concurrently for each prepared Forge role.

The validator now:

- uses a bounded thread pool, defaulting to eight workers
- preserves tenant result ordering and per-tenant AssumeRole/TagSession failure details
- keeps Forge-role preparation and cleanup semantics unchanged
- exposes `validation_max_workers` with a validated range of 1–32

This complements #531, which reduces the scheduled frequency. It does not include that schedule change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other: performance improvement

## Testing

- `uv run --project .. --locked --only-group lambda-tests pytest -q lambdas/trust_workflow_test.py`
- 20 tests passed
- `tofu fmt -check modules/platform/forge_runners/forge_trust_validator`
- repository hooks passed except local `tofu-validate`, which could not hydrate the pinned Lambda module commit in this partial clone; GitHub CI should run the clean validation
