### PR TITLE
fix(opencost): use exporter cluster dimension

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/main.tf
@@ -11,8 +11,12 @@ locals {
     for var_def in local.opencost_cluster_variables : var_def.values_suggested
   ]))
   opencost_cluster_filter = length(local.opencost_cluster_names) > 0 ? join(" or ", [
-    for cluster_name in local.opencost_cluster_names : "filter('k8s.cluster.name', '${cluster_name}')"
-  ]) : "filter('k8s.cluster.name', '__forge_cluster_scope_not_configured__')"
+    # OpenCost emits the Helm defaultClusterId value as cluster_id. The
+    # Kubernetes dashboard variable supplies the same cluster names, but its
+    # k8s.cluster.name property is not guaranteed to be attached to Prometheus
+    # metrics by the collector.
+    for cluster_name in local.opencost_cluster_names : "filter('cluster_id', '${cluster_name}')"
+  ]) : "filter('cluster_id', '__forge_cluster_scope_not_configured__')"
 }
 
 resource "signalfx_list_chart" "tenant_hourly_compute_cost" {
@@ -254,7 +258,7 @@ resource "signalfx_dashboard" "opencost" {
   }
 
   variable {
-    property               = "k8s.cluster.name"
+    property               = "cluster_id"
     alias                  = "Forge Cluster"
     description            = ""
     values                 = local.opencost_cluster_variable == null ? [] : local.opencost_cluster_variable.values

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/tests/opencost_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/opencost/tests/opencost_dashboard_behavior.tftest.hcl
@@ -23,8 +23,7 @@ run "opencost_dashboard_contract" {
     condition = (
       signalfx_list_chart.tenant_hourly_compute_cost.name == "Tenant hourly compute cost"
       && strcontains(signalfx_list_chart.tenant_hourly_compute_cost.program_text, "filter('namespace', 'tenant-a') or filter('namespace', 'tenant-b')")
-      && strcontains(signalfx_list_chart.tenant_hourly_compute_cost.program_text, "filter('k8s.cluster.name', 'forge-euw1-dev') or filter('k8s.cluster.name', 'forge-use1-prod')")
-      && !strcontains(signalfx_list_chart.tenant_hourly_compute_cost.program_text, "cluster_id")
+      && strcontains(signalfx_list_chart.tenant_hourly_compute_cost.program_text, "filter('cluster_id', 'forge-euw1-dev') or filter('cluster_id', 'forge-use1-prod')")
       && strcontains(signalfx_list_chart.tenant_hourly_compute_cost.program_text, "node_cpu_hourly_cost")
       && signalfx_time_chart.tenant_cpu_cost.name == "Tenant CPU cost"
       && strcontains(signalfx_time_chart.tenant_memory_cost.program_text, "node_ram_hourly_cost")
@@ -40,7 +39,7 @@ run "opencost_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.opencost.name == "Forge Billing and Cost - OpenCost"
       && signalfx_dashboard.opencost.dashboard_group == "forge-dashboard-group"
-      && signalfx_dashboard.opencost.variable[1].property == "k8s.cluster.name"
+      && signalfx_dashboard.opencost.variable[1].property == "cluster_id"
       && length(signalfx_dashboard.opencost.chart) == 6
     )
     error_message = "OpenCost dashboard must keep its name, group input, and chart count."


### PR DESCRIPTION
## Description

Use OpenCost's native `cluster_id` label for cluster filtering in the cost dashboard.

The OpenCost Helm release sets `opencost.exporter.defaultClusterId`, which the exporter emits as `cluster_id`. The dashboard had recently changed its filter and dashboard variable to `k8s.cluster.name`; that resource dimension is not guaranteed to be attached to Prometheus metrics and can filter every OpenCost series out.

The dashboard still derives the allowed cluster names from the shared Kubernetes variable definitions, but applies those values to the exporter label.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Testing

- updated the OpenCost dashboard behavior contract
- module interface and source-inventory tests passed
- repository pre-commit hooks, including Terraform validation, passed
- local behavior-plan execution was blocked by the downloaded SignalFx provider failing its macOS plugin handshake; clean CI will rerun it
