### PR TITLE
fix(observability): align OTel host coverage

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -1463,18 +1463,23 @@ EOF
 }
 
 resource "signalfx_single_value_chart" "chart_hosts_with_agent_installed" {
-  name        = "# Hosts with agent installed"
-  description = "Splunk OTel connector installed"
+  name        = "OTel host coverage (%)"
+  description = "Current Forge EC2 hosts reporting OTel memory metrics divided by hosts reporting AWS CPU metrics."
 
-  program_text = "A = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('aws_tag_TenantName', '*'), rollup='average').sum(by=['AWSUniqueId']).count().publish(label='A')"
+  program_text = <<-EOF
+active = data('^aws.ec2.cpu.utilization', filter=filter('aws_tag_TenantName', '*'), extrapolation='last_value', maxExtrapolations=2).sum(by=['AWSUniqueId']).count()
+otel = data('system.memory.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('aws_tag_TenantName', '*') and filter('state', 'used'), extrapolation='last_value', maxExtrapolations=2).sum(by=['AWSUniqueId']).count()
+A = (otel / active).scale(100).publish(label='A')
+EOF
 
   color_by         = "Dimension"
-  max_precision    = 4
+  max_precision    = 1
   refresh_interval = 60
 
   viz_options {
-    display_name = "Hosts with agent installed"
+    display_name = "OTel host coverage"
     label        = "A"
+    value_suffix = "%"
   }
 }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -24,8 +24,10 @@ run "runner_ec2_dashboard_contract" {
       signalfx_single_value_chart.chart_active_hosts.name == "# Active hosts"
       && strcontains(signalfx_single_value_chart.chart_active_hosts.program_text, "^aws.ec2.cpu.utilization")
       && strcontains(signalfx_single_value_chart.chart_active_hosts.program_text, "filter('aws_tag_TenantName', '*')")
+      && signalfx_single_value_chart.chart_hosts_with_agent_installed.name == "OTel host coverage (%)"
       && strcontains(signalfx_single_value_chart.chart_hosts_with_agent_installed.program_text, "filter('cloud.platform', 'aws_ec2')")
       && strcontains(signalfx_single_value_chart.chart_hosts_with_agent_installed.program_text, "filter('aws_tag_TenantName', '*')")
+      && strcontains(signalfx_single_value_chart.chart_hosts_with_agent_installed.program_text, "(otel / active).scale(100)")
       && !strcontains(signalfx_single_value_chart.chart_hosts_with_agent_installed.program_text, "aws_eks")
       && signalfx_list_chart.chart_active_hosts_missing_agent.name == "Active hosts missing Splunk OTel agent"
       && strcontains(signalfx_list_chart.chart_active_hosts_missing_agent.program_text, "filter=filter('aws_tag_TenantName', '*') and not filter('host.id', '*')")


### PR DESCRIPTION
## Description

Make EC2 runner OTel coverage comparable instead of showing two counts with different metric semantics.

The existing dashboard compared current AWS CPU hosts with a raw count of OTel memory streams. The updated chart calculates a percentage from:

- active Forge EC2 instances reporting AWS CPU metrics
- the same Forge EC2 population reporting OTel `system.memory.usage`

Both sides use `AWSUniqueId`, the tenant tag, and the same short extrapolation window. This makes a 12-host/1-agent observation explicit as coverage and avoids interpreting historical or differently grouped streams as installed agents.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Testing

- updated the runner EC2 dashboard behavior contract
- repository pre-commit hooks, including Terraform validation, passed
