### PR TITLE
fix(observability): optimize stuck workflow audit

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/dashboard_forge_github_webhook_workflow_job_events.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/dashboard_forge_github_webhook_workflow_job_events.tf
@@ -221,7 +221,7 @@ locals {
         options = {
           enableSmartSources = true
           query              = <<-EOT
-            index="${var.splunk_conf.index}" ((forgecicd_log_type=webhook github.status=*) OR ("Successfully dispatched job for"))
+            index="${var.splunk_conf.index}" ((sourcetype="aws:cloudwatchlogs" source="*:/aws/lambda/*-webhook*" forgecicd_log_type=webhook github.status=*) OR (sourcetype="aws:cloudwatchlogs" source="*:/aws/lambda/*-dispatch-to-runner*" "Successfully dispatched job for"))
             | rex field=message "to the queue\(s\) (?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+)"
             | rex field=queued_urls_raw max_match=0 "(?<queued_url>https?://[^,\s]+)"
             | spath path=github.workflowJobId output=github_workflow_job_id
@@ -275,7 +275,7 @@ locals {
             | where total_events = queued_count
             | where has_dispatch = 1
             | eval stuck_since=strftime(first_seen, "%Y-%m-%dT%H:%M:%S%Z"), stuck_minutes=round((now() - first_seen) / 60, 1)
-            | where stuck_minutes > 15 AND stuck_minutes <= 1440
+            | where stuck_minutes > 15 AND stuck_minutes <= 10080
             | mvexpand queued_url
             | sort - stuck_minutes
             | table workflowJobId job_name repository workflow_name head_branch head_sha labels workflow_job_url run_id run_attempt run_url created_at started_at stuck_since stuck_minutes queued_url github_delivery forgecicd_tenant aws_region
@@ -292,7 +292,7 @@ locals {
         options = {
           enableSmartSources = true
           query              = <<-EOT
-            index="${var.splunk_conf.index}" ((forgecicd_log_type=webhook github.status=*) OR ("Received event contains runner labels" "Job ID:"))
+            index="${var.splunk_conf.index}" ((sourcetype="aws:cloudwatchlogs" source="*:/aws/lambda/*-webhook*" forgecicd_log_type=webhook github.status=*) OR (sourcetype="aws:cloudwatchlogs" source="*:/aws/lambda/*-dispatch-to-runner*" "Received event contains runner labels" "Job ID:"))
             | rex field=message "Received event contains runner labels '(?<runner_labels>[^']+)' from '(?<warning_repo>[^']+)'.*Job ID:\s(?<warning_workflowJobId>\d+)"
             | spath path=github.workflowJobId output=github_workflow_job_id
             | spath path=github.workflowJobUrl output=workflow_job_url
@@ -345,7 +345,7 @@ locals {
             | where total_events = queued_count
             | where has_runner_label_warning = 1
             | eval stuck_since=strftime(first_seen, "%Y-%m-%dT%H:%M:%S%Z"), stuck_minutes=round((now() - first_seen) / 60, 1)
-            | where stuck_minutes > 15 AND stuck_minutes <= 1440
+            | where stuck_minutes > 15 AND stuck_minutes <= 10080
             | eval labels=coalesce(mvjoin(runner_labels, ", "), mvjoin(github_labels, ", "))
             | sort - stuck_minutes
             | table workflowJobId job_name repository warning_repo workflow_name head_branch head_sha labels workflow_job_url run_id run_attempt run_url created_at started_at stuck_since stuck_minutes github_deliveries forgecicd_tenant

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/splunk_alert.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/splunk_alert.tf
@@ -2,7 +2,7 @@ locals {
   splunk_webhook_url = "${aws_apigatewayv2_api.splunk.api_endpoint}/splunk/${random_password.webhook_token.result}"
 
   stuck_workflow_job_search = <<-EOT
-    index="${var.splunk_conf.index}" ((forgecicd_log_type=webhook github.status=*) OR ("Successfully dispatched job for"))
+    index="${var.splunk_conf.index}" ((sourcetype="aws:cloudwatchlogs" source="*:/aws/lambda/*-webhook*" forgecicd_log_type=webhook github.status=*) OR (sourcetype="aws:cloudwatchlogs" source="*:/aws/lambda/*-dispatch-to-runner*" "Successfully dispatched job for"))
     | rex field=message "to the queue\(s\) (?<queued_url>https?://\S+)\s-\sJob ID:\s(?<dispatch_workflowJobId>\d+)"
     | rex field=queued_urls_raw max_match=0 "(?<queued_url>https?://[^,\s]+)"
     | spath path=github.workflowJobId output=github_workflow_job_id

--- a/tests/iac/stuck_workflow_search_test.py
+++ b/tests/iac/stuck_workflow_search_test.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALERT = REPO_ROOT.joinpath(
+    'modules',
+    'integrations',
+    'splunk_stuck_workflow_job_dispatcher',
+    'splunk_alert.tf',
+)
+DASHBOARD = REPO_ROOT.joinpath(
+    'modules',
+    'integrations',
+    'splunk_cloud_conf_shared',
+    'dashboard_forge_github_webhook_workflow_job_events.tf',
+)
+
+
+def test_redelivery_alert_scopes_webhook_and_dispatch_sources() -> None:
+    source = ALERT.read_text(encoding='utf-8')
+
+    assert 'sourcetype="aws:cloudwatchlogs"' in source
+    assert 'source="*:/aws/lambda/*-webhook*"' in source
+    assert 'source="*:/aws/lambda/*-dispatch-to-runner*"' in source
+    assert 'stuck_minutes <= 1440' in source
+
+
+def test_dashboard_supports_source_scoped_seven_day_audit() -> None:
+    source = DASHBOARD.read_text(encoding='utf-8')
+
+    assert source.count('source="*:/aws/lambda/*-webhook*"') >= 2
+    assert source.count('source="*:/aws/lambda/*-dispatch-to-runner*"') >= 2
+    assert source.count('stuck_minutes <= 10080') == 2


### PR DESCRIPTION
## Description

Make stuck-workflow searches efficient and usable for seven-day audits.

- Constrain webhook and dispatch branches by indexed CloudWatch sourcetype and source.
- Keep the automated redelivery alert limited to jobs at most 24 hours old.
- Extend both dashboard diagnostic searches to a seven-day individual-job window.
- Add offline contracts for source scope and retention limits.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `uv run --locked --only-group lambda-tests pytest -q tests/iac/stuck_workflow_search_test.py tests/iac/terraform_contract_test.py` (14 passed)
- All repository hooks passed except local `tofu-validate`, which could not hydrate the repository's existing pinned Lambda module commit.
- Offline IaC contracts passed; CI will validate the module on Linux.
