### PR TITLE
docs(platform): honor release version path

### DIFF
--- a/examples/deployments/platform/terragrunt/_global_settings/tenant.hcl
+++ b/examples/deployments/platform/terragrunt/_global_settings/tenant.hcl
@@ -28,7 +28,8 @@ locals {
   # ─────────────────────────────────────────────────────────────────────────────
   config = read_terragrunt_config("runner_settings.hcl")
 
-  release_version_file = "${get_repo_root()}/release_versions.yml"
+  release_version_env  = get_env("RELEASE_VERSION_PATH", "")
+  release_version_file = length(trimspace(local.release_version_env)) > 0 ? local.release_version_env : "${get_repo_root()}/release_versions.yml"
   release_version      = yamldecode(file(local.release_version_file))
   forge_module_ref     = local.release_version.spec.iac.modules.forge_runners.ref
 


### PR DESCRIPTION
## Description

Honor `RELEASE_VERSION_PATH` when the platform tenant configuration resolves the Forge module reference, while retaining `${get_repo_root()}/release_versions.yml` as the fallback.

The examples workflow already supplies the deployment-specific release file, but the shared platform `tenant.hcl` ignored it and attempted to read `forge/release_versions.yml`. That missing file stopped Terragrunt evaluation before apply. This change aligns the shared tenant configuration with the existing deployment-unit contract.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `pre-commit run terragrunt-hcl-fmt --files examples/deployments/platform/terragrunt/_global_settings/tenant.hcl`
- Full commit hook suite
- `terragrunt render --json` with the deployment `RELEASE_VERSION_PATH`; verified `inputs.tags.ForgeModuleRef` matches `spec.iac.modules.forge_runners.ref` from the supplied release file
- `git diff --check`
