### PR TITLE
fix(runner-groups): retry transient GitHub reads

### DIFF
--- a/modules/platform/forge_runners/github_app_runner_group/lambda/github_app_runner_group.py
+++ b/modules/platform/forge_runners/github_app_runner_group/lambda/github_app_runner_group.py
@@ -22,6 +22,75 @@ LOG.setLevel(getattr(logging, level_str, logging.INFO))
 
 SSM = boto3.client('ssm')
 
+GITHUB_REQUEST_TIMEOUT_SECONDS = 10
+GITHUB_GET_MAX_ATTEMPTS = 3
+GITHUB_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+GITHUB_MAX_RETRY_DELAY_SECONDS = 10
+
+
+def _retry_delay_seconds(response: Any, attempt: int) -> float:
+    """Return a bounded Retry-After or exponential-backoff delay."""
+    retry_after = response.headers.get('Retry-After')
+    if retry_after is not None:
+        try:
+            return min(
+                max(float(retry_after), 0),
+                GITHUB_MAX_RETRY_DELAY_SECONDS,
+            )
+        except (TypeError, ValueError):
+            pass
+
+    return min(2 ** (attempt - 1), GITHUB_MAX_RETRY_DELAY_SECONDS)
+
+
+def github_get(url: str, headers: Dict[str, str]) -> Any:
+    """GET GitHub API data with bounded retries for transient failures."""
+    for attempt in range(1, GITHUB_GET_MAX_ATTEMPTS + 1):
+        try:
+            response = requests.get(
+                url,
+                headers=headers,
+                timeout=GITHUB_REQUEST_TIMEOUT_SECONDS,
+            )
+        except (requests.ConnectionError, requests.Timeout) as error:
+            if attempt == GITHUB_GET_MAX_ATTEMPTS:
+                raise
+
+            delay = min(
+                2 ** (attempt - 1),
+                GITHUB_MAX_RETRY_DELAY_SECONDS,
+            )
+            LOG.warning(
+                'GitHub GET %s failed transiently on attempt %s/%s: %s. '
+                'Retrying in %s seconds.',
+                url,
+                attempt,
+                GITHUB_GET_MAX_ATTEMPTS,
+                error,
+                delay,
+            )
+            time.sleep(delay)
+            continue
+
+        retryable = response.status_code in GITHUB_RETRYABLE_STATUS_CODES
+        if not retryable or attempt == GITHUB_GET_MAX_ATTEMPTS:
+            response.raise_for_status()
+            return response
+
+        delay = _retry_delay_seconds(response, attempt)
+        LOG.warning(
+            'GitHub GET %s returned retryable status %s on attempt %s/%s. '
+            'Retrying in %s seconds.',
+            url,
+            response.status_code,
+            attempt,
+            GITHUB_GET_MAX_ATTEMPTS,
+            delay,
+        )
+        time.sleep(delay)
+
+    raise RuntimeError('GitHub GET retry loop exhausted unexpectedly')
+
 
 def generate_jwt(app_id: str, private_key: str) -> str:
     """Generate a JWT for GitHub App authentication."""
@@ -56,8 +125,7 @@ def list_repositories(access_token: str, github_api: str) -> List[Dict[str, Any]
     url = f'{github_api}/installation/repositories'
 
     while url:
-        response = requests.get(url, headers=headers)
-        response.raise_for_status()
+        response = github_get(url, headers)
         data = response.json()
 
         # Add repositories from the current page
@@ -73,8 +141,7 @@ def get_all_runner_groups(url: str, headers: Dict[str, str]) -> List[Dict[str, A
     """Fetch all runner groups, handling pagination."""
     runner_groups = []
     while url:
-        response = requests.get(url, headers=headers)
-        response.raise_for_status()
+        response = github_get(url, headers)
         data = response.json()
         runner_groups.extend(data.get('runner_groups', []))
 

--- a/tests/lambdas/github_app_runner_group_test.py
+++ b/tests/lambdas/github_app_runner_group_test.py
@@ -14,15 +14,25 @@ pytestmark = requires_aws
 
 
 class _Response:
-    def __init__(self, payload, *, links=None, headers=None):
+    def __init__(
+        self,
+        payload,
+        *,
+        links=None,
+        headers=None,
+        status_code=200,
+    ):
         self._payload = payload
         self.links = links or {}
         self.headers = headers or {}
+        self.status_code = status_code
 
     def json(self):
         return self._payload
 
     def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f'HTTP {self.status_code}')
         return None
 
 
@@ -30,8 +40,8 @@ def test_list_repositories_follows_github_pagination(monkeypatch, aws):
     mod = load_handler_module('github_app_runner_group')
     calls = []
 
-    def _get(url, headers):
-        calls.append((url, headers))
+    def _get(url, headers, timeout):
+        calls.append((url, headers, timeout))
         if len(calls) == 1:
             return _Response(
                 {'repositories': [{'id': 1, 'full_name': 'org/one'}]},
@@ -48,6 +58,7 @@ def test_list_repositories_follows_github_pagination(monkeypatch, aws):
     assert [repo['full_name'] for repo in repos] == ['org/one', 'org/two']
     assert calls[0][0] == 'https://api.github.test/installation/repositories'
     assert calls[1][0] == 'https://api.github.test/page/2'
+    assert calls[0][2] == mod.GITHUB_REQUEST_TIMEOUT_SECONDS
 
 
 def test_save_to_runner_group_creates_selected_group_and_adds_repos(
@@ -134,8 +145,8 @@ def test_get_all_runner_groups_follows_link_header_pagination(
     mod = load_handler_module('github_app_runner_group')
     calls = []
 
-    def _get(url, headers):
-        calls.append((url, headers))
+    def _get(url, headers, timeout):
+        calls.append((url, headers, timeout))
         if len(calls) == 1:
             return _Response(
                 {'runner_groups': [{'id': 1, 'name': 'small'}]},
@@ -159,6 +170,67 @@ def test_get_all_runner_groups_follows_link_header_pagination(
 
     assert [group['name'] for group in groups] == ['small', 'large']
     assert calls[1][0] == 'https://api.github.test/page/2'
+    assert calls[0][2] == mod.GITHUB_REQUEST_TIMEOUT_SECONDS
+
+
+def test_get_all_runner_groups_retries_transient_github_503(
+    monkeypatch, aws
+):
+    mod = load_handler_module('github_app_runner_group')
+    calls = []
+    sleeps = []
+
+    def _get(url, headers, timeout):
+        calls.append((url, headers, timeout))
+        if len(calls) == 1:
+            return _Response(
+                {},
+                headers={'Retry-After': '0'},
+                status_code=503,
+            )
+        return _Response(
+            {'runner_groups': [{'id': 1, 'name': 'small'}]},
+        )
+
+    monkeypatch.setattr(mod.requests, 'get', _get)
+    monkeypatch.setattr(mod.time, 'sleep', sleeps.append)
+
+    groups = mod.get_all_runner_groups(
+        'https://api.github.test/orgs/acme/actions/runner-groups',
+        {'Authorization': 'Bearer token'},
+    )
+
+    assert [group['name'] for group in groups] == ['small']
+    assert len(calls) == 2
+    assert sleeps == [0]
+
+
+def test_get_all_runner_groups_does_not_retry_permanent_github_404(
+    monkeypatch, aws
+):
+    mod = load_handler_module('github_app_runner_group')
+    calls = []
+
+    def _get(url, headers, timeout):
+        calls.append((url, headers, timeout))
+        return _Response({}, status_code=404)
+
+    monkeypatch.setattr(mod.requests, 'get', _get)
+    monkeypatch.setattr(
+        mod.time,
+        'sleep',
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError('permanent errors must not be retried')
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match='HTTP 404'):
+        mod.get_all_runner_groups(
+            'https://api.github.test/orgs/acme/actions/runner-groups',
+            {'Authorization': 'Bearer token'},
+        )
+
+    assert len(calls) == 1
 
 
 def test_lambda_handler_propagates_missing_secret_without_github_calls(


### PR DESCRIPTION
## Description

Retry transient GitHub API read failures while reconciling runner groups and selected repositories.

- retries `429`, `500`, `502`, `503`, and `504` responses up to three attempts
- retries connection and timeout failures
- honors `Retry-After` with a 10-second cap and otherwise uses bounded exponential backoff
- adds a 10-second request timeout
- leaves permanent failures such as `404` non-retryable

Only idempotent `GET` requests use this retry path, avoiding duplicate runner-group creation.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

- `python -m pytest -q tests/lambdas` — 227 passed
- repository pre-commit hooks passed during commit
