### PR TITLE
fix(lambdas): configure retries for SSM clients

### DIFF
--- a/modules/integrations/splunk_dependency_monitor/lambda/handler.py
+++ b/modules/integrations/splunk_dependency_monitor/lambda/handler.py
@@ -18,6 +18,7 @@ from urllib.parse import quote
 
 import boto3
 import common
+from botocore.config import Config
 
 LOG = logging.getLogger()
 LOG.setLevel(
@@ -29,6 +30,11 @@ GITHUB_API_VERSION = os.environ.get('GITHUB_API_VERSION', '2022-11-28')
 GITHUB_TIMEOUT_SECONDS = int(os.environ.get('GITHUB_TIMEOUT_SECONDS', '10'))
 TENANT_PARAMETER_ROOT = '/forge/'
 TENANT_PARAMETER_SUFFIX = '/github_ghes_org'
+SSM_CLIENT_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=10,
+    retries={'mode': 'standard', 'total_max_attempts': 4},
+)
 
 queued_datapoints: list[dict[str, Any]] = []
 queued_events: list[dict[str, Any]] = []
@@ -63,7 +69,10 @@ def aws_client(service_name: str) -> Any:
     """Create an AWS client pinned to the Lambda deployment region."""
     if not AWS_REGION:
         raise ValueError('AWS_REGION is missing from the Lambda environment')
-    return boto3.client(service_name, region_name=AWS_REGION)
+    client_kwargs: dict[str, Any] = {'region_name': AWS_REGION}
+    if service_name == 'ssm':
+        client_kwargs['config'] = SSM_CLIENT_CONFIG
+    return boto3.client(service_name, **client_kwargs)
 
 
 def _normalize_parameter_value(value: str) -> str:

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda/worker.py
@@ -9,11 +9,18 @@ from typing import Any, Dict, Iterable, List, Tuple
 
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 LOG = logging.getLogger()
 LOG.setLevel(getattr(logging, os.environ.get(
     'LOG_LEVEL', 'INFO').upper(), logging.INFO))
+
+SSM_CLIENT_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=10,
+    retries={'mode': 'standard', 'total_max_attempts': 4},
+)
 
 dynamodb = boto3.client('dynamodb')
 deserializer = TypeDeserializer()
@@ -119,7 +126,7 @@ def load_tenant_configs() -> List[Dict[str, Any]]:
         raise ValueError(
             'Tenant config SSM parameter count must be at least 1')
 
-    ssm_client = boto3.client('ssm')
+    ssm_client = boto3.client('ssm', config=SSM_CLIENT_CONFIG)
     chunks = []
     for index in range(parameter_count):
         parameter_name = f"{parameter_prefix}/{index}"
@@ -201,7 +208,11 @@ def load_github_app_credentials(payload: Dict[str, Any]) -> Dict[str, Any]:
     aws_region = payload['aws_region']
     tenant_config = resolve_tenant_config(payload)
     deployment_prefix = tenant_config['deployment_prefix']
-    ssm_client = boto3.client('ssm', region_name=aws_region)
+    ssm_client = boto3.client(
+        'ssm',
+        region_name=aws_region,
+        config=SSM_CLIENT_CONFIG,
+    )
     parameter_base = f"/forge/{deployment_prefix}"
 
     raw_key = get_parameter(ssm_client, f"{parameter_base}/github_app_key")

--- a/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/lambda/ec2_update_runner_ssm_ami.py
+++ b/modules/platform/ec2_deployment/ec2_update_runner_ssm_ami/lambda/ec2_update_runner_ssm_ami.py
@@ -3,12 +3,19 @@ import logging
 import os
 
 import boto3
+from botocore.config import Config
 
 LOG = logging.getLogger()
 level_str = os.environ.get('LOG_LEVEL', 'INFO').upper()
 LOG.setLevel(getattr(logging, level_str, logging.INFO))
 
-ssm = boto3.client('ssm')
+SSM_CLIENT_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=10,
+    retries={'mode': 'standard', 'total_max_attempts': 4},
+)
+
+ssm = boto3.client('ssm', config=SSM_CLIENT_CONFIG)
 ec2 = boto3.client('ec2')
 
 

--- a/modules/platform/ec2_deployment/ec2_update_runner_tags/lambda/ec2_update_runner_tags.py
+++ b/modules/platform/ec2_deployment/ec2_update_runner_tags/lambda/ec2_update_runner_tags.py
@@ -3,13 +3,20 @@ import logging
 import os
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 LOG = logging.getLogger()
 level_str = os.environ.get('LOG_LEVEL', 'INFO').upper()
 LOG.setLevel(getattr(logging, level_str, logging.INFO))
 
-ssm = boto3.client('ssm')
+SSM_CLIENT_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=10,
+    retries={'mode': 'standard', 'total_max_attempts': 4},
+)
+
+ssm = boto3.client('ssm', config=SSM_CLIENT_CONFIG)
 ec2 = boto3.client('ec2')
 
 

--- a/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
+++ b/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
@@ -12,13 +12,20 @@ import boto3
 import jwt
 import requests
 from boto3.s3.transfer import TransferConfig
+from botocore.config import Config
 from requests.exceptions import RequestException
 
 LOG = logging.getLogger()
 level_str = os.environ.get('LOG_LEVEL', 'INFO').upper()
 LOG.setLevel(getattr(logging, level_str, logging.INFO))
 
-SSM = boto3.client('ssm')
+SSM_CLIENT_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=10,
+    retries={'mode': 'standard', 'total_max_attempts': 4},
+)
+
+SSM = boto3.client('ssm', config=SSM_CLIENT_CONFIG)
 S3 = boto3.client('s3')
 S3_TRANSFER_CONFIG = TransferConfig(use_threads=False)
 

--- a/modules/platform/forge_runners/github_app_runner_group/lambda/github_app_runner_group.py
+++ b/modules/platform/forge_runners/github_app_runner_group/lambda/github_app_runner_group.py
@@ -14,13 +14,20 @@ if package_dir not in sys.path:
 import boto3  # noqa: E402
 import jwt  # noqa: E402
 import requests  # noqa: E402
+from botocore.config import Config  # noqa: E402
 
 # Configure logging
 LOG = logging.getLogger()
 level_str = os.environ.get('LOG_LEVEL', 'INFO').upper()
 LOG.setLevel(getattr(logging, level_str, logging.INFO))
 
-SSM = boto3.client('ssm')
+SSM_CLIENT_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=10,
+    retries={'mode': 'standard', 'total_max_attempts': 4},
+)
+
+SSM = boto3.client('ssm', config=SSM_CLIENT_CONFIG)
 
 
 def generate_jwt(app_id: str, private_key: str) -> str:

--- a/modules/platform/forge_runners/github_global_lock/lambda/github_clean_global_lock.py
+++ b/modules/platform/forge_runners/github_global_lock/lambda/github_clean_global_lock.py
@@ -15,6 +15,7 @@ if package_dir not in sys.path:
 import boto3  # noqa: E402
 import jwt  # noqa: E402
 import requests  # noqa: E402
+from botocore.config import Config  # noqa: E402
 
 # Configure logging
 LOG = logging.getLogger()
@@ -23,7 +24,13 @@ LOG.setLevel(getattr(logging, level_str, logging.INFO))
 
 DYNAMODB_TABLE = os.getenv('DYNAMODB_TABLE')
 
-SSM = boto3.client('ssm')
+SSM_CLIENT_CONFIG = Config(
+    connect_timeout=5,
+    read_timeout=10,
+    retries={'mode': 'standard', 'total_max_attempts': 4},
+)
+
+SSM = boto3.client('ssm', config=SSM_CLIENT_CONFIG)
 dynamodb = boto3.resource('dynamodb')
 table = dynamodb.Table(DYNAMODB_TABLE)
 

--- a/tests/lambdas/splunk_dependency_monitor_test.py
+++ b/tests/lambdas/splunk_dependency_monitor_test.py
@@ -229,7 +229,7 @@ def test_lambda_handler_keeps_tenant_failures_independent(monkeypatch, aws):
     monkeypatch.setattr(
         handler.boto3,
         'client',
-        lambda _service, *, region_name: (
+        lambda _service, *, region_name, **_kwargs: (
             region_name == 'us-west-2' and object()
         ),
     )
@@ -414,7 +414,7 @@ def test_tenants_are_discovered_from_regional_ssm(monkeypatch, aws):
     monkeypatch.setattr(
         handler.boto3,
         'client',
-        lambda _service, *, region_name: (
+        lambda _service, *, region_name, **_kwargs: (
             FakeSsm() if region_name == 'us-west-2' else None
         ),
     )
@@ -484,7 +484,7 @@ def test_tenant_discovery_runs_on_every_invocation(
     monkeypatch.setattr(
         handler.boto3,
         'client',
-        lambda _service, *, region_name: (
+        lambda _service, *, region_name, **_kwargs: (
             FakeSsm() if region_name == 'us-west-2' else None
         ),
     )
@@ -891,7 +891,7 @@ def test_lambda_handler_clears_warm_invocation_state(monkeypatch, aws):
     monkeypatch.setattr(
         handler.boto3,
         'client',
-        lambda _service, *, region_name: object(),
+        lambda _service, *, region_name, **_kwargs: object(),
     )
     monkeypatch.setattr(
         handler.common,
@@ -923,6 +923,30 @@ def test_aws_client_requires_explicit_region(monkeypatch, aws):
         handler.aws_client('ssm')
 
 
+def test_ssm_client_uses_bounded_standard_retries(monkeypatch, aws):
+    handler = _load_handler(monkeypatch)
+    captured = {}
+
+    def fake_client(service_name, **kwargs):
+        captured['service_name'] = service_name
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(handler.boto3, 'client', fake_client)
+
+    handler.aws_client('ssm')
+
+    config = captured['config']
+    assert captured['service_name'] == 'ssm'
+    assert captured['region_name'] == 'us-west-2'
+    assert config.connect_timeout == 5
+    assert config.read_timeout == 10
+    assert config.retries == {
+        'mode': 'standard',
+        'total_max_attempts': 4,
+    }
+
+
 def test_discovery_rejects_unavailable_parameter(monkeypatch, aws):
     handler = _load_handler(monkeypatch)
     parameter_name = '/forge/tenant-a-usw2-sl/github_ghes_org'
@@ -944,7 +968,7 @@ def test_discovery_rejects_unavailable_parameter(monkeypatch, aws):
     monkeypatch.setattr(
         handler.boto3,
         'client',
-        lambda _service, *, region_name: FakeSsm(),
+        lambda _service, *, region_name, **_kwargs: FakeSsm(),
     )
 
     with pytest.raises(ValueError, match='unavailable'):

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -1,3 +1,4 @@
+import ast
 import re
 import tomllib
 from pathlib import Path
@@ -66,6 +67,35 @@ def dependency_group_names(group_name: str) -> set[str]:
         )[0].lower()
         for dependency in dependencies
     }
+
+
+def test_python_ssm_clients_use_explicit_retry_config() -> None:
+    missing_config = []
+
+    for path in sorted((REPO_ROOT / 'modules').rglob('*.py')):
+        tree = ast.parse(path.read_text(encoding='utf-8'))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            is_boto3_client = all((
+                isinstance(node.func.value, ast.Name),
+                getattr(node.func.value, 'id', None) == 'boto3',
+                node.func.attr == 'client',
+            ))
+            if not is_boto3_client:
+                continue
+            first_arg = node.args[0] if node.args else None
+            if not isinstance(first_arg, ast.Constant):
+                continue
+            if first_arg.value != 'ssm':
+                continue
+            if not any(keyword.arg == 'config' for keyword in node.keywords):
+                relative_path = path.relative_to(REPO_ROOT).as_posix()
+                missing_config.append(f'{relative_path}:{node.lineno}')
+
+    assert missing_config == []
 
 
 def test_each_module_has_specific_native_test_file() -> None:


### PR DESCRIPTION
## Description

Configure every production Python SSM client with bounded Botocore standard retries, a 5-second connection timeout, a 10-second read timeout, and four total attempts.

This makes transient SSM endpoint connectivity failures retry within the Lambda invocation before relying on the invocation source to retry the entire event. It also adds a repository guard requiring explicit retry configuration on future direct Python SSM clients.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- 91 affected Lambda and quality tests passed.
- All pre-commit formatting, lint, security, and validation hooks passed.
- `git diff --check` passed.
