### PR TITLE
chore(billing): upload Lambda packages directly

### DIFF
--- a/modules/integrations/splunk_aws_billing/billing_per_resource.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource.tf
@@ -48,12 +48,6 @@ module "cur_per_resource" {
 
   tags = local.all_security_tags
 
-  store_on_s3         = true
-  s3_object_tags_only = true
-  s3_object_tags      = var.default_tags
-  s3_bucket           = aws_s3_bucket.aws_billing_report.id
-  s3_prefix           = "lambda/billing_per_resource"
-
   depends_on = [aws_cloudwatch_log_group.cur_per_resource]
 }
 

--- a/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_resource_process.tf
@@ -48,12 +48,6 @@ module "cur_per_resource_process" {
 
   tags = local.all_security_tags
 
-  store_on_s3         = true
-  s3_object_tags_only = true
-  s3_object_tags      = var.default_tags
-  s3_bucket           = aws_s3_bucket.aws_billing_report.id
-  s3_prefix           = "lambda/billing_per_resource_process"
-
   depends_on = [aws_cloudwatch_log_group.cur_per_resource_process]
 }
 

--- a/modules/integrations/splunk_aws_billing/billing_per_service.tf
+++ b/modules/integrations/splunk_aws_billing/billing_per_service.tf
@@ -49,12 +49,6 @@ module "cur_per_service" {
 
   tags = local.all_security_tags
 
-  store_on_s3         = true
-  s3_object_tags_only = true
-  s3_object_tags      = var.default_tags
-  s3_bucket           = aws_s3_bucket.aws_billing_report.id
-  s3_prefix           = "lambda/billing_per_service"
-
   depends_on = [aws_cloudwatch_log_group.cur_per_service]
 }
 


### PR DESCRIPTION
## Description

Upload the three Splunk AWS billing Lambda deployment packages directly through `aws_lambda_function.filename` instead of first storing them under the billing-report S3 bucket.

The handlers are small now that pandas and requests are supplied by Lambda layers. The billing-report bucket remains in place for CUR exports, notifications, and runtime data access.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: __________

## Testing

- `tofu test -test-directory=tests` (2 passed, 0 failed)
- `terraform fmt -check` on the three changed files
- Commit hooks, including Terraform/OpenTofu formatting, validation, linting, and security checks