### PR TITLE
fix(observability): exclude read-only filesystems from disk panels

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
@@ -238,11 +238,11 @@ resource "signalfx_list_chart" "top_tenants_sqs_dlq_backlog" {
 
 resource "signalfx_list_chart" "top_tenants_ec2_disk" {
   name        = "Top 10 tenants: EC2 disk utilization"
-  description = "Highest current filesystem utilization on a Forge EC2 runner host per tenant."
+  description = "Highest current writable filesystem utilization on a Forge EC2 runner host per tenant."
 
   program_text = <<-EOF
-used = data('system.filesystem.usage', filter=(${local.ec2_tenant_filter}) and filter('cloud.platform', 'aws_ec2') and filter('state', 'used'), rollup='latest').sum(by=['aws_tag_TenantName', 'host.id'])
-free = data('system.filesystem.usage', filter=(${local.ec2_tenant_filter}) and filter('cloud.platform', 'aws_ec2') and filter('state', 'free'), rollup='latest').sum(by=['aws_tag_TenantName', 'host.id'])
+used = data('system.filesystem.usage', filter=(${local.ec2_tenant_filter}) and filter('cloud.platform', 'aws_ec2') and filter('state', 'used') and filter('type', 'ext4', 'xfs') and filter('mode', 'rw'), rollup='latest').sum(by=['aws_tag_TenantName', 'host.id'])
+free = data('system.filesystem.usage', filter=(${local.ec2_tenant_filter}) and filter('cloud.platform', 'aws_ec2') and filter('state', 'free') and filter('type', 'ext4', 'xfs') and filter('mode', 'rw'), rollup='latest').sum(by=['aws_tag_TenantName', 'host.id'])
 A = ((used / (used + free)) * 100).max(by=['aws_tag_TenantName']).top(count=10).publish(label='A')
 EOF
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -51,6 +51,8 @@ run "forge_impact_dashboard_contract" {
       && strcontains(signalfx_list_chart.top_tenants_sqs_backlog.program_text, "ApproximateNumberOfMessagesVisible")
       && strcontains(signalfx_list_chart.top_tenants_sqs_dlq_backlog.program_text, "*dead-letter*")
       && strcontains(signalfx_list_chart.top_tenants_ec2_disk.program_text, "system.filesystem.usage")
+      && strcontains(signalfx_list_chart.top_tenants_ec2_disk.program_text, "filter('type', 'ext4', 'xfs')")
+      && strcontains(signalfx_list_chart.top_tenants_ec2_disk.program_text, "filter('mode', 'rw')")
       && strcontains(signalfx_list_chart.top_tenants_ec2_status_failures.program_text, "StatusCheckFailed")
       && strcontains(signalfx_list_chart.top_tenants_k8s_restarts.program_text, "k8s.container.restarts")
       && strcontains(signalfx_list_chart.top_tenants_ebs_queue_length.program_text, "VolumeQueueLength")

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/job_right_sizing.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/job_right_sizing.tf
@@ -381,8 +381,8 @@ resource "signalfx_list_chart" "job_runs_high_peak_filesystem" {
 
   program_text = <<-EOF
 filesystem_identity = ${replace(local.ec2_runner_job_identity, "]", ", 'mountpoint', 'device']")}
-used = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used') and filter('aws_tag_TenantName', '*') and filter('aws_tag_ghr_job_url', '*')).sum(by=filesystem_identity)
-free = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'free') and filter('aws_tag_TenantName', '*') and filter('aws_tag_ghr_job_url', '*')).sum(by=filesystem_identity)
+used = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used') and filter('type', 'ext4', 'xfs') and filter('mode', 'rw') and filter('aws_tag_TenantName', '*') and filter('aws_tag_ghr_job_url', '*')).sum(by=filesystem_identity)
+free = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'free') and filter('type', 'ext4', 'xfs') and filter('mode', 'rw') and filter('aws_tag_TenantName', '*') and filter('aws_tag_ghr_job_url', '*')).sum(by=filesystem_identity)
 jobs = ((used / (used + free)) * 100).max(over='24h')
 A = jobs.above(80, inclusive=True).top(count=20).publish(label='A')
 EOF

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/main.tf
@@ -295,11 +295,11 @@ resource "signalfx_list_chart" "chart_top_instances_by_cpu_utilization" {
 
 resource "signalfx_time_chart" "chart_disk_utilization" {
   name        = "Disk utilization (%)"
-  description = "Percentile distribution across active hosts with agent installed"
+  description = "Writable filesystem utilization percentile distribution across active hosts with agent installed"
 
   program_text = <<-EOF
-B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used')).publish(label='B', enable=False)
-C = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'free')).publish(label='C', enable=False)
+B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used') and filter('type', 'ext4', 'xfs') and filter('mode', 'rw')).publish(label='B', enable=False)
+C = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'free') and filter('type', 'ext4', 'xfs') and filter('mode', 'rw')).publish(label='C', enable=False)
 D = ((B/(B+C))*100).mean(by=['AWSUniqueId']).publish(label='D', enable=False)
 E = (D).min().publish(label='E')
 F = (D).percentile(pct=10).publish(label='F')
@@ -1342,11 +1342,11 @@ EOF
 
 resource "signalfx_list_chart" "chart_disk_summary_utilization" {
   name        = "Disk summary utilization (%)"
-  description = "Percent of disk space utilized on all volumes on active hosts with agent installed. Tenant | Instance id | Host"
+  description = "Percent of disk space utilized on writable volumes on active hosts with agent installed. Tenant | Instance id | Host"
 
   program_text = <<-EOF
-A = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used')).sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.name', 'host.id', 'AWSUniqueId', 'mountpoint', 'device']).publish(label='A', enable=False)
-B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'free')).sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.name', 'host.id', 'AWSUniqueId', 'mountpoint', 'device']).publish(label='B', enable=False)
+A = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'used') and filter('type', 'ext4', 'xfs') and filter('mode', 'rw')).sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.name', 'host.id', 'AWSUniqueId', 'mountpoint', 'device']).publish(label='A', enable=False)
+B = data('system.filesystem.usage', filter=filter('cloud.platform', 'aws_ec2') and filter('state', 'free') and filter('type', 'ext4', 'xfs') and filter('mode', 'rw')).sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.name', 'host.id', 'AWSUniqueId', 'mountpoint', 'device']).publish(label='B', enable=False)
 C = ((A/(A+B))*100).publish(label='C')
 EOF
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_ec2/tests/runner_ec2_dashboard_behavior.tftest.hcl
@@ -47,11 +47,15 @@ run "runner_ec2_dashboard_contract" {
       && !strcontains(signalfx_time_chart.chart_cpu_utilization.program_text, "autodetect_id=")
       && strcontains(signalfx_time_chart.chart_disk_utilization.program_text, "alerts(detector_id='forge-runner-disk-detector')")
       && !strcontains(signalfx_time_chart.chart_disk_utilization.program_text, "autodetect_id=")
+      && strcontains(signalfx_time_chart.chart_disk_utilization.program_text, "filter('type', 'ext4', 'xfs')")
+      && strcontains(signalfx_time_chart.chart_disk_utilization.program_text, "filter('mode', 'rw')")
       && strcontains(signalfx_time_chart.chart_memory_utilization.program_text, "alerts(detector_id='forge-runner-memory-detector')")
       && !strcontains(signalfx_time_chart.chart_memory_utilization.program_text, "autodetect_id=")
       && signalfx_list_chart.chart_top_instances_by_cpu_utilization.sort_by == "-value"
       && signalfx_list_chart.chart_top_instances_by_cpu_utilization.time_range == 3600
-      && signalfx_list_chart.chart_disk_summary_utilization.description == "Percent of disk space utilized on all volumes on active hosts with agent installed. Tenant | Instance id | Host"
+      && signalfx_list_chart.chart_disk_summary_utilization.description == "Percent of disk space utilized on writable volumes on active hosts with agent installed. Tenant | Instance id | Host"
+      && strcontains(signalfx_list_chart.chart_disk_summary_utilization.program_text, "filter('type', 'ext4', 'xfs')")
+      && strcontains(signalfx_list_chart.chart_disk_summary_utilization.program_text, "filter('mode', 'rw')")
       && strcontains(signalfx_list_chart.chart_disk_summary_utilization.program_text, ".sum(by=['aws_tag_TenantName', 'aws_instance_id', 'host.name', 'host.id', 'AWSUniqueId', 'mountpoint', 'device'])")
       && contains([for field in signalfx_list_chart.chart_disk_summary_utilization.legend_options_fields : field.property if field.enabled], "aws_tag_TenantName")
       && contains([for field in signalfx_list_chart.chart_disk_summary_utilization.legend_options_fields : field.property if field.enabled], "aws_instance_id")
@@ -89,6 +93,8 @@ run "runner_ec2_dashboard_contract" {
       && strcontains(signalfx_list_chart.runner_classes_by_mean_peak_cpu.program_text, "aws_tag_ghr_runner_labels")
       && strcontains(signalfx_list_chart.runner_classes_by_mean_peak_memory.program_text, "aws_instance_type")
       && strcontains(signalfx_list_chart.job_runs_high_peak_filesystem.program_text, "system.filesystem.usage")
+      && strcontains(signalfx_list_chart.job_runs_high_peak_filesystem.program_text, "filter('type', 'ext4', 'xfs')")
+      && strcontains(signalfx_list_chart.job_runs_high_peak_filesystem.program_text, "filter('mode', 'rw')")
       && strcontains(signalfx_list_chart.job_runs_high_peak_filesystem.program_text, ".above(80, inclusive=True).top(count=20)")
       && length(signalfx_list_chart.job_runs_high_peak_filesystem.color_scale) == 3
       && one([for scale in signalfx_list_chart.job_runs_high_peak_filesystem.color_scale : scale.lt if scale.color == "blue"]) == 80


### PR DESCRIPTION
## Description

Restrict Forge EC2 disk-capacity dashboard panels to writable `ext4` and `xfs` filesystems.

Read-only Snap loop devices use `squashfs` and report 100% utilization by design, which caused false disk-capacity alerts and obscured actual EBS root-volume usage. The affected Forge impact, EC2 overview, and job right-sizing panels now require both:

- `type` in `ext4`, `xfs`
- `mode` equal to `rw`

Dashboard behavior tests cover the new filters.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `tofu fmt -check`
- `tofu test` in `dashboards/forge_impact` (4 passed)
- `tofu test` in `dashboards/runner_ec2` (4 passed)
- Repository pre-commit hooks
