### PR TITLE
fix(observability): extend service-limit chart window

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/README.md
@@ -15,6 +15,6 @@ supported AWS service used by Forge:
 - CloudFormation;
 - Route 53.
 
-Each chart reports the one-day average limit usage percentage by Trusted Advisor
+Each chart reports the seven-day average limit usage percentage by Trusted Advisor
 region and service limit. Services without `ServiceLimitUsage` telemetry are not
 represented.

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/main.tf
@@ -74,9 +74,9 @@ resource "signalfx_list_chart" "service_limit" {
   for_each = local.forge_services
 
   name        = "${each.value.display_name} service-limit usage"
-  description = "One-day average AWS Trusted Advisor service-limit usage for ${each.value.display_name}, by region and limit."
+  description = "Seven-day average AWS Trusted Advisor service-limit usage for ${each.value.display_name}, by region and limit."
 
-  program_text = "A = data('ServiceLimitUsage', filter=(${local.aws_service_limit_filter}) and filter('ServiceName', '${each.value.service_name}'), rollup='average').mean(over='1d').scale(100).max(by=['Region', 'ServiceLimit']).publish(label='A')"
+  program_text = "A = data('ServiceLimitUsage', filter=(${local.aws_service_limit_filter}) and filter('ServiceName', '${each.value.service_name}'), rollup='average').mean(over='7d').scale(100).max(by=['Region', 'ServiceLimit']).publish(label='A')"
   sort_by      = "-value"
 
   color_by                = "Scale"

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_behavior.tftest.hcl
@@ -51,7 +51,7 @@ run "creates_aws_service_limits_dashboard" {
       && strcontains(chart.program_text, "filter('namespace', 'AWS/TrustedAdvisor')")
       && strcontains(chart.program_text, "filter('stat', 'upper')")
       && strcontains(chart.program_text, "data('ServiceLimitUsage'")
-      && strcontains(chart.program_text, ".mean(over='1d').scale(100)")
+      && strcontains(chart.program_text, ".mean(over='7d').scale(100)")
       && strcontains(chart.program_text, ".max(by=['Region', 'ServiceLimit'])")
       && chart.color_by == "Scale"
       && anytrue([for scale in chart.color_scale : scale.gte == 80 && scale.lt == 100])

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_service_limits/tests/aws_service_limits_dashboard_source_inventory.tftest.hcl
@@ -16,7 +16,7 @@ run "aws_service_limits_dashboard_source_inventory" {
       "service_name = \"EC2\"",
       "service_name = \"VPC\"",
       "service_name = \"IAM\"",
-      ".mean(over='1d').scale(100)",
+      ".mean(over='7d').scale(100)",
       "__forge_aws_account_scope_not_configured__",
       "__forge_aws_region_scope_not_configured__",
     ]


### PR DESCRIPTION
## Description

Extend the AWS Trusted Advisor service-limit chart moving average from one day to seven days.

The `ServiceLimitUsage` metric is emitted infrequently. The one-day window expired between samples, leaving all service-limit list charts empty even though recent telemetry existed. A seven-day window restores values while retaining a bounded freshness period.

This change also updates the chart descriptions, dashboard documentation, and the behavior/source-inventory contracts.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- Validated the seven-day SignalFlow program against the production metric; all configured service families returned current list values.
- `tofu test -filter=tests/aws_service_limits_dashboard_behavior.tftest.hcl -filter=tests/aws_service_limits_dashboard_source_inventory.tftest.hcl` — 2 passed, 0 failed.
- `tofu fmt -check -recursive .`
- `git diff --check`
- Repository pre-commit hooks passed during commit.
