### PR TITLE
feat(observability): add tenant and platform health detectors

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/README.md
@@ -40,7 +40,7 @@ It also creates:
 
 - Kubernetes detectors for missing telemetry, Splunk OTel collector health,
   pending tenant pods, and unhealthy platform pods.
-- One dependency detector per tenant in
+- One dependency and workload-health detector per tenant in
   `dashboard_variables.dependency_probes.tenant_names`. Each detector has rules
   for missing probe telemetry, unavailable SSM parameters, unavailable GitHub
   authentication or organization runner APIs, and a low GitHub API rate-limit

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
@@ -196,6 +196,7 @@ module "dashboard_forge_impact" {
   tenant_names      = var.dashboard_variables.forge_impact.tenant_names
   dynamic_variables = var.dashboard_variables.forge_impact.dynamic_variables
   dashboard_group   = signalfx_dashboard_group.forgecicd.id
+  detector_ids      = module.detector_dependency_probes.detector_ids
 }
 
 module "dashboard_runner_usage" {

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/README.md
@@ -52,7 +52,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_dashboard_group"></a> [dashboard\_group](#input\_dashboard\_group) | Splunk Observability dashboard group ID. | `string` | n/a | yes |
-| <a name="input_detector_ids"></a> [detector\_ids](#input\_detector\_ids) | Dependency detector IDs keyed by tenant for linking dashboard charts. | `map(string)` | n/a | yes |
+| <a name="input_detector_ids"></a> [detector\_ids](#input\_detector\_ids) | Tenant health detector IDs keyed by tenant for linking dashboard charts. | `map(string)` | n/a | yes |
 | <a name="input_dynamic_variables"></a> [dynamic\_variables](#input\_dynamic\_variables) | Additional dynamic variable definitions for the dashboard. | <pre>list(object({<br/>    property               = string<br/>    alias                  = string<br/>    description            = string<br/>    values                 = list(string)<br/>    value_required         = bool<br/>    values_suggested       = list(string)<br/>    restricted_suggestions = bool<br/>  }))</pre> | `[]` | no |
 | <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | Forge tenants available in the dashboard selector. | `list(string)` | n/a | yes |
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/main.tf
@@ -6,7 +6,7 @@ locals {
   metric_filter = "(${local.tenant_filter})"
   detector_alerts = join("\n", [
     for tenant_name, detector_id in var.detector_ids :
-    "alerts(detector_id='${detector_id}').publish(label='${tenant_name} dependency alerts')"
+    "alerts(detector_id='${detector_id}').publish(label='${tenant_name} health alerts')"
   ])
 }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface_contract.tftest.hcl
@@ -34,7 +34,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_dependency_probes_interface
       "description = \"Forge tenants available in the dashboard selector.\"",
       "type        = list(string)",
       "variable \"detector_ids\"",
-      "description = \"Dependency detector IDs keyed by tenant for linking dashboard charts.\"",
+      "description = \"Tenant health detector IDs keyed by tenant for linking dashboard charts.\"",
       "type        = map(string)",
     ]
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/variables.tf
@@ -23,6 +23,6 @@ variable "tenant_names" {
 }
 
 variable "detector_ids" {
-  description = "Dependency detector IDs keyed by tenant for linking dashboard charts."
+  description = "Tenant health detector IDs keyed by tenant for linking dashboard charts."
   type        = map(string)
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/README.md
@@ -78,6 +78,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_dashboard_group"></a> [dashboard\_group](#input\_dashboard\_group) | Dashboard group name for organizing dashboards. | `string` | n/a | yes |
+| <a name="input_detector_ids"></a> [detector\_ids](#input\_detector\_ids) | Tenant health detector IDs keyed by tenant for linking issue charts. | `map(string)` | n/a | yes |
 | <a name="input_dynamic_variables"></a> [dynamic\_variables](#input\_dynamic\_variables) | Additional dynamic variable definitions for the dashboard. | <pre>list(object({<br/>    property               = string<br/>    alias                  = string<br/>    description            = string<br/>    values                 = list(string)<br/>    value_required         = bool<br/>    values_suggested       = list(string)<br/>    restricted_suggestions = bool<br/>  }))</pre> | `[]` | no |
 | <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | Tenant namespaces that run Forge ARC runners. | `list(string)` | n/a | yes |
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/issues.tf
@@ -6,7 +6,10 @@ resource "signalfx_list_chart" "top_tenants_lambda_errors" {
   name        = "Top 10 tenants: Lambda errors"
   description = "Lambda errors over the selected window. Use the tenant property to continue investigation in the Lambdas dashboard."
 
-  program_text = "A = data('Errors', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+A = data('Errors', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')
+${local.tenant_health_alerts}
+EOF
 
   hide_missing_values     = true
   max_precision           = 0
@@ -31,7 +34,10 @@ resource "signalfx_list_chart" "top_tenants_lambda_throttles" {
   name        = "Top 10 tenants: Lambda throttles"
   description = "Lambda throttles over the selected window. Use the tenant property to continue investigation in the Lambdas dashboard."
 
-  program_text = "A = data('Throttles', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+A = data('Throttles', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')
+${local.tenant_health_alerts}
+EOF
 
   hide_missing_values     = true
   max_precision           = 0
@@ -140,7 +146,10 @@ resource "signalfx_list_chart" "top_tenants_k8s_pending_pods" {
   name        = "Top 10 tenants: K8S pending pods"
   description = "Current pending pod count by Forge tenant namespace."
 
-  program_text = "A = data('k8s.pod.phase', filter=(${local.k8s_tenant_namespace_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+A = data('k8s.pod.phase', filter=(${local.k8s_tenant_namespace_filter}), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).above(0).top(count=10).publish(label='A')
+${local.tenant_health_alerts}
+EOF
 
   hide_missing_values     = true
   max_precision           = 0
@@ -165,7 +174,10 @@ resource "signalfx_list_chart" "top_tenants_k8s_failed_pods" {
   name        = "Top 10 tenants: K8S failed or unknown pods"
   description = "Current failed or unknown pod count by Forge tenant namespace."
 
-  program_text = "A = data('k8s.pod.phase', filter=(${local.k8s_tenant_namespace_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+A = data('k8s.pod.phase', filter=(${local.k8s_tenant_namespace_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).count(by=['k8s.namespace.name']).above(0).top(count=10).publish(label='A')
+${local.tenant_health_alerts}
+EOF
 
   hide_missing_values     = true
   max_precision           = 0
@@ -190,7 +202,10 @@ resource "signalfx_list_chart" "top_tenants_sqs_backlog" {
   name        = "Top 10 tenants: SQS visible backlog"
   description = "Current visible SQS messages summed by Forge tenant."
 
-  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/SQS') and filter('QueueName', '*') and filter('stat', 'mean'), rollup='latest').sum(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+A = data('ApproximateNumberOfMessagesVisible', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/SQS') and filter('QueueName', '*') and filter('stat', 'mean'), rollup='latest').sum(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')
+${local.tenant_health_alerts}
+EOF
 
   hide_missing_values     = true
   max_precision           = 0
@@ -215,7 +230,10 @@ resource "signalfx_list_chart" "top_tenants_sqs_dlq_backlog" {
   name        = "Top 10 tenants: SQS dead-letter backlog"
   description = "Current visible messages in dead-letter queues summed by Forge tenant."
 
-  program_text = "A = data('ApproximateNumberOfMessagesVisible', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/SQS') and filter('QueueName', '*dead-letter*', '*dlq*', '*DLQ*') and filter('stat', 'mean'), rollup='latest').sum(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+A = data('ApproximateNumberOfMessagesVisible', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/SQS') and filter('QueueName', '*dead-letter*', '*dead_letter*', '*dlq*', '*DLQ*') and filter('stat', 'mean'), rollup='latest').sum(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')
+${local.tenant_health_alerts}
+EOF
 
   hide_missing_values     = true
   max_precision           = 0
@@ -284,7 +302,10 @@ resource "signalfx_list_chart" "top_tenants_ec2_status_failures" {
   name        = "Top 10 tenants: EC2 status check failures"
   description = "Highest instance or system status-check failure count on a Forge EC2 runner per tenant over the selected window."
 
-  program_text = "A = data('StatusCheckFailed', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'sum') and filter('aws_instance_id', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'aws_instance_id']).sum(over=${local.issue_window}).max(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+A = data('StatusCheckFailed', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EC2') and filter('stat', 'sum') and filter('aws_instance_id', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'aws_instance_id']).sum(over=${local.issue_window}).max(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')
+${local.tenant_health_alerts}
+EOF
 
   color_by                = "Scale"
   hide_missing_values     = true
@@ -319,7 +340,10 @@ resource "signalfx_list_chart" "top_tenants_k8s_restarts" {
   name        = "Top 10 tenants: K8S container restarts"
   description = "Positive container restart deltas in Forge tenant namespaces over the selected window."
 
-  program_text = "A = data('k8s.container.restarts', filter=(${local.k8s_tenant_namespace_filter}) and filter('k8s.container.name', '*'), rollup='latest').max(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.container.name']).delta().sum(by=['k8s.namespace.name']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+A = data('k8s.container.restarts', filter=(${local.k8s_tenant_namespace_filter}) and filter('k8s.container.name', '*'), rollup='latest').max(by=['k8s.namespace.name', 'k8s.pod.name', 'k8s.container.name']).delta().sum(by=['k8s.namespace.name']).sum(over=${local.issue_window}).above(0).top(count=10).publish(label='A')
+${local.tenant_health_alerts}
+EOF
 
   color_by                = "Scale"
   hide_missing_values     = true
@@ -378,7 +402,10 @@ resource "signalfx_list_chart" "top_tenants_ebs_iops_exceeded" {
   name        = "Top 10 tenants: EBS IOPS limit exceeded"
   description = "Highest EBS provisioned-IOPS exceeded count per Forge tenant over the selected window."
 
-  program_text = "A = data('VolumeIOPSExceededCheck', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EBS') and filter('stat', 'sum') and filter('VolumeId', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'VolumeId']).sum(over=${local.issue_window}).max(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')"
+  program_text = <<-EOF
+A = data('VolumeIOPSExceededCheck', filter=(${local.ec2_tenant_filter}) and filter('namespace', 'AWS/EBS') and filter('stat', 'sum') and filter('VolumeId', '*'), rollup='sum', extrapolation='zero').sum(by=['aws_tag_TenantName', 'VolumeId']).sum(over=${local.issue_window}).max(by=['aws_tag_TenantName']).above(0).top(count=10).publish(label='A')
+${local.tenant_health_alerts}
+EOF
 
   color_by                = "Scale"
   hide_missing_values     = true

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
@@ -26,6 +26,10 @@ locals {
     "(${local.configured_k8s_tenant_filter})",
     "(${local.configured_k8s_cluster_filter})",
   ])
+  tenant_health_alerts = join("\n", [
+    for tenant_name, detector_id in var.detector_ids :
+    "alerts(detector_id='${detector_id}').publish(label='${tenant_name} health alerts')"
+  ])
 }
 
 resource "terraform_data" "dashboard_parent" {

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -3,6 +3,10 @@ mock_provider "signalfx" {}
 variables {
   tenant_names    = ["tenant-b", "tenant-a"]
   dashboard_group = "forge-dashboard-group"
+  detector_ids = {
+    tenant-a = "tenant-a-health-detector"
+    tenant-b = "tenant-b-health-detector"
+  }
   dynamic_variables = [
     {
       property               = "aws_region"
@@ -57,6 +61,11 @@ run "forge_impact_dashboard_contract" {
       && strcontains(signalfx_list_chart.top_tenants_k8s_restarts.program_text, "k8s.container.restarts")
       && strcontains(signalfx_list_chart.top_tenants_ebs_queue_length.program_text, "VolumeQueueLength")
       && strcontains(signalfx_list_chart.top_tenants_ebs_iops_exceeded.program_text, "VolumeIOPSExceededCheck")
+      && strcontains(signalfx_list_chart.top_tenants_lambda_errors.program_text, "alerts(detector_id='tenant-a-health-detector')")
+      && strcontains(signalfx_list_chart.top_tenants_sqs_dlq_backlog.program_text, "tenant-b health alerts")
+      && strcontains(signalfx_list_chart.top_tenants_k8s_restarts.program_text, "alerts(detector_id='tenant-a-health-detector')")
+      && strcontains(signalfx_list_chart.top_tenants_ec2_status_failures.program_text, "alerts(detector_id='tenant-b-health-detector')")
+      && strcontains(signalfx_list_chart.top_tenants_ebs_iops_exceeded.program_text, "alerts(detector_id='tenant-a-health-detector')")
     )
     error_message = "Forge impact must rank affected tenants across live-backed Lambda, EC2, K8S, SQS, and EBS issue signals."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_contract.tftest.hcl
@@ -9,6 +9,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_cont
     module_path = "."
     expected_input_variables = [
       "dashboard_group",
+      "detector_ids",
       "dynamic_variables",
       "tenant_names",
     ]
@@ -17,6 +18,9 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_cont
       "variable \"dashboard_group\"",
       "description = \"Dashboard group name for organizing dashboards.\"",
       "type        = string",
+      "variable \"detector_ids\"",
+      "description = \"Tenant health detector IDs keyed by tenant for linking issue charts.\"",
+      "type        = map(string)",
       "variable \"dynamic_variables\"",
       "description = \"Additional dynamic variable definitions for the dashboard.\"",
       "type = list(object({",
@@ -62,9 +66,9 @@ run "integrations_splunk_o11y_conf_shared_dashboards_forge_impact_interface_cont
 
   assert {
     condition = (
-      output.expected_input_variable_count == 3
+      output.expected_input_variable_count == 4
       && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 18
+      && output.expected_interface_literal_count == 21
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/variables.tf
@@ -17,6 +17,11 @@ variable "dynamic_variables" {
   default = []
 }
 
+variable "detector_ids" {
+  description = "Tenant health detector IDs keyed by tenant for linking issue charts."
+  type        = map(string)
+}
+
 variable "tenant_names" {
   description = "Tenant namespaces that run Forge ARC runners."
   type        = list(string)

--- a/modules/integrations/splunk_o11y_conf_shared/detectors.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors.tf
@@ -17,6 +17,12 @@ module "detector_k8s" {
   k8s_platform_namespaces   = var.k8s_platform_namespaces
   team                      = var.team
   tenant_names              = var.dashboard_variables.runner_k8s.tenant_names
+  tenant_pods_pending_notifications = (
+    length(setsubtract(
+      toset(var.dashboard_variables.runner_k8s.tenant_names),
+      toset(var.dashboard_variables.dependency_probes.tenant_names),
+    )) == 0 ? [] : local.detector_notifications
+  )
 }
 
 module "detector_dependency_probes" {

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/README.md
@@ -1,7 +1,7 @@
-# Forge AWS Regional Platform Health Detector
+# Forge AWS Platform Health Detectors
 
-This detector applies the stable queued-build thresholds carried by the
-regional platform dashboard:
+The regional detector applies the stable queued-build thresholds carried by
+the regional platform dashboard:
 
 - Major when oldest queued-build age remains above 300 seconds for 10 minutes.
 - Warning when oldest age remains above 75 seconds and visible backlog remains
@@ -14,9 +14,10 @@ after oldest queued-build age remains below 60 seconds for 15 minutes. The DLQ
 rule evaluates the rolling five-minute send count and activates when that count
 is non-zero.
 
-Lambda throttle panels remain diagnostic-only because their observed warning
-baselines vary materially by AWS region. The five-minute throttle count must
-not page independently.
+Tenant-assigned Lambda throttle totals remain diagnostic-only at the regional
+level because their baselines vary materially by tenant and region. The
+control-plane detector only evaluates shared functions without a TenantName
+tag and requires sustained throttling before alerting.
 
 ## Ownership and configuration
 
@@ -36,8 +37,16 @@ Missing required values or a missing dynamic scope produce non-matching
 filters, so an incomplete configuration cannot create an organization-wide
 detector accidentally.
 
+The control-plane detector excludes tenant-tagged resources and monitors:
+
+- sustained errors and throttles in shared Forge Lambda functions;
+- sustained backlog and oldest-message age in shared SQS queues; and
+- visible messages in control-plane dead-letter queues, including
+  `dead-letter`, `dead_letter`, and `dlq` naming conventions.
+
 The charts that provide incident context are managed by the
 [AWS regional platform dashboard](../../dashboards/aws_regional_health/README.md).
+Use the Lambda and SQS control-plane dashboards for shared-resource incidents.
 Use the
 [dashboard runbook](../../../../../docs/operations/splunk-o11y-dashboard-runbook.md)
 for triage and recovery, and the
@@ -66,6 +75,7 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
+| [signalfx_detector.aws_control_plane_health](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
 | [signalfx_detector.aws_regional_platform_health](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) | resource |
 
 ## Inputs
@@ -81,5 +91,6 @@ No modules.
 
 | Name | Description |
 | ---- | ----------- |
+| <a name="output_control_plane_detector_id"></a> [control\_plane\_detector\_id](#output\_control\_plane\_detector\_id) | AWS control-plane detector ID for shared Lambda and SQS health. |
 | <a name="output_detector_id"></a> [detector\_id](#output\_detector\_id) | AWS regional platform detector ID for linking queue-health charts. |
 <!-- END_TF_DOCS -->

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/main.tf
@@ -15,8 +15,12 @@ locals {
   ]
   configured_scope_filter = length(local.configured_scope_filters) > 0 ? join(" and ", local.configured_scope_filters) : "filter('sf_metric', '__forge_dynamic_scope_not_configured__')"
 
-  aws_platform_filter = "(${local.configured_scope_filter})"
-  build_queue_filter  = "filter('QueueName', '*-queued-builds') and (not filter('QueueName', '*_dead_letter'))"
+  aws_platform_filter           = "(${local.configured_scope_filter})"
+  build_queue_filter            = "filter('QueueName', '*-queued-builds') and (not filter('QueueName', '*_dead_letter'))"
+  control_plane_filter          = "(${local.aws_platform_filter}) and (not filter('aws_tag_TenantName', '*'))"
+  control_plane_queue_filter    = "filter('namespace', 'AWS/SQS') and filter('QueueName', '*')"
+  control_plane_lambda_filter   = "filter('namespace', 'AWS/Lambda') and filter('aws_function_name', '*')"
+  dead_letter_queue_name_filter = "filter('QueueName', '*dead-letter*', '*dead_letter*', '*dlq*', '*DLQ*')"
 }
 
 resource "signalfx_detector" "aws_regional_platform_health" {
@@ -54,6 +58,63 @@ EOF
     description   = "At least one message sent to a queued-build dead-letter queue in five minutes"
     severity      = "Major"
     detect_label  = "Queued-build DLQ activity"
+    notifications = var.detector_notifications
+  }
+}
+
+resource "signalfx_detector" "aws_control_plane_health" {
+  name        = "${var.detector_name_prefix} AWS control-plane health"
+  description = "Monitors shared Forge Lambda errors and throttles plus control-plane SQS backlog and dead-letter queues. Tenant-tagged resources are intentionally excluded."
+  max_delay   = 120
+  tags        = local.detector_tags
+  teams       = [var.team]
+  time_range  = 3600
+
+  program_text = <<-EOF
+lambda_errors = data('Errors', filter=(${local.control_plane_filter}) and (${local.control_plane_lambda_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'aws_function_name'])
+lambda_throttles = data('Throttles', filter=(${local.control_plane_filter}) and (${local.control_plane_lambda_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'aws_function_name'])
+queue_oldest_age = data('ApproximateAgeOfOldestMessage', filter=(${local.control_plane_filter}) and (${local.control_plane_queue_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').max(by=['aws_region', 'QueueName'])
+queue_visible_messages = data('ApproximateNumberOfMessagesVisible', filter=(${local.control_plane_filter}) and (${local.control_plane_queue_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').max(by=['aws_region', 'QueueName'])
+dlq_visible_messages = data('ApproximateNumberOfMessagesVisible', filter=(${local.control_plane_filter}) and filter('namespace', 'AWS/SQS') and (${local.dead_letter_queue_name_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').max(by=['aws_region', 'QueueName'])
+detect(when(lambda_errors > 0, '10m')).publish('Control-plane Lambda errors')
+detect(when(lambda_throttles > 0, '5m')).publish('Control-plane Lambda throttles')
+detect(when(queue_oldest_age > 300, '10m'), off=when(queue_oldest_age < 60, '15m')).publish('Control-plane queue oldest age major')
+detect(when((queue_oldest_age > 75) and (queue_visible_messages > 10), '10m'), off=when(queue_oldest_age < 60, '15m')).publish('Control-plane queue backlog warning')
+detect(when(dlq_visible_messages > 0, '5m')).publish('Control-plane DLQ backlog')
+EOF
+
+  rule {
+    description   = "Shared Forge Lambda errors sustained for 10 minutes"
+    severity      = "Major"
+    detect_label  = "Control-plane Lambda errors"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Shared Forge Lambda throttles sustained for 5 minutes"
+    severity      = "Major"
+    detect_label  = "Control-plane Lambda throttles"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Control-plane queue oldest-message age above 300 seconds for 10 minutes"
+    severity      = "Major"
+    detect_label  = "Control-plane queue oldest age major"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Control-plane queue oldest-message age above 75 seconds and visible backlog above 10 for 10 minutes"
+    severity      = "Warning"
+    detect_label  = "Control-plane queue backlog warning"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Visible messages present in a control-plane dead-letter queue for 5 minutes"
+    severity      = "Major"
+    detect_label  = "Control-plane DLQ backlog"
     notifications = var.detector_notifications
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/outputs.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/outputs.tf
@@ -2,3 +2,8 @@ output "detector_id" {
   description = "AWS regional platform detector ID for linking queue-health charts."
   value       = signalfx_detector.aws_regional_platform_health.id
 }
+
+output "control_plane_detector_id" {
+  description = "AWS control-plane detector ID for shared Lambda and SQS health."
+  value       = signalfx_detector.aws_control_plane_health.id
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_behavior.tftest.hcl
@@ -86,4 +86,26 @@ run "creates_regional_platform_detector" {
     ])
     error_message = "Every regional platform detector rule must use the configured notification routing."
   }
+
+  assert {
+    condition = (
+      signalfx_detector.aws_control_plane_health.name == "Forge Prod AWS control-plane health"
+      && signalfx_detector.aws_control_plane_health.teams == toset(["forge-team"])
+      && length(signalfx_detector.aws_control_plane_health.rule) == 5
+      && strcontains(signalfx_detector.aws_control_plane_health.program_text, "not filter('aws_tag_TenantName', '*')")
+      && strcontains(signalfx_detector.aws_control_plane_health.program_text, "lambda_errors > 0, '10m'")
+      && strcontains(signalfx_detector.aws_control_plane_health.program_text, "lambda_throttles > 0, '5m'")
+      && strcontains(signalfx_detector.aws_control_plane_health.program_text, "filter('QueueName', '*dead-letter*', '*dead_letter*', '*dlq*', '*DLQ*')")
+      && strcontains(signalfx_detector.aws_control_plane_health.program_text, "dlq_visible_messages > 0, '5m'")
+    )
+    error_message = "The control-plane detector must exclude tenant resources and cover sustained Lambda, queue, and DLQ failures."
+  }
+
+  assert {
+    condition = alltrue([
+      for rule in signalfx_detector.aws_control_plane_health.rule :
+      toset(rule.notifications) == toset(["Email,forge@example.com"])
+    ])
+    error_message = "Every control-plane detector rule must use the configured notification routing."
+  }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_interface_contract.tftest.hcl
@@ -14,6 +14,7 @@ run "aws_regional_health_detector_interface_contract" {
       "team",
     ]
     expected_output_values = [
+      "control_plane_detector_id",
       "detector_id",
     ]
     expected_interface_literals = [
@@ -30,6 +31,8 @@ run "aws_regional_health_detector_interface_contract" {
       "restricted_suggestions = bool",
       "output \"detector_id\"",
       "description = \"AWS regional platform detector ID for linking queue-health charts.\"",
+      "output \"control_plane_detector_id\"",
+      "description = \"AWS control-plane detector ID for shared Lambda and SQS health.\"",
     ]
   }
 
@@ -51,8 +54,8 @@ run "aws_regional_health_detector_interface_contract" {
   assert {
     condition = (
       output.expected_input_variable_count == 4
-      && output.expected_output_value_count == 1
-      && output.expected_interface_literal_count == 13
+      && output.expected_output_value_count == 2
+      && output.expected_interface_literal_count == 15
     )
     error_message = "Interface contract counts must remain pinned."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_source_inventory.tftest.hcl
@@ -9,9 +9,13 @@ run "aws_regional_health_detector_source_inventory" {
     module_path = "."
     expected_literals = [
       "resource \"signalfx_detector\" \"aws_regional_platform_health\"",
+      "resource \"signalfx_detector\" \"aws_control_plane_health\"",
       "ApproximateAgeOfOldestMessage",
       "ApproximateNumberOfMessagesVisible",
       "NumberOfMessagesSent",
+      "Control-plane Lambda errors",
+      "Control-plane Lambda throttles",
+      "Control-plane DLQ backlog",
       "Build queue oldest age major",
       "Build queue backlog warning",
       "Queued-build DLQ activity",
@@ -27,7 +31,7 @@ run "aws_regional_health_detector_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 10
+    condition     = output.expected_literal_count == 14
     error_message = "Regional AWS detector source inventory count must remain pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/README.md
@@ -1,15 +1,21 @@
-# Tenant dependency-probe detectors
+# Tenant health detectors
 
-Creates one Splunk Observability detector per Forge tenant. Each detector has
-rules for:
+Creates one Splunk Observability detector per Forge tenant. Each detector keeps
+the four dependency rules and adds actionable workload-health rules for:
 
 - missing probe telemetry;
 - unavailable regional SSM GitHub App parameters;
 - failed GitHub App authentication or organization runner API access; and
-- low GitHub REST API rate-limit budget.
+- low GitHub REST API rate-limit budget;
+- Lambda error rate and sustained throttling;
+- delayed or stuck build queues and DLQ backlog;
+- pending or failed Kubernetes pods and repeated container restarts;
+- EC2 status-check failures; and
+- EBS provisioned-IOPS exceeded checks.
 
-The detector keeps `AWSRegion` in the output MTS so a tenant
-incident identifies the affected Forge deployment region.
+AWS alerts retain region and resource dimensions, while Kubernetes alerts retain
+cluster context. Existing aggregate EC2 memory/disk detectors remain responsible
+for those notifications to avoid duplicate tenant incidents.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -39,15 +45,15 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_detector_config"></a> [detector\_config](#input\_detector\_config) | Thresholds and durations for tenant dependency detectors. | <pre>object({<br/>    failure_duration                   = string<br/>    no_data_duration                   = string<br/>    no_data_fill_duration              = string<br/>    rate_limit_duration                = string<br/>    rate_limit_remaining_pct_threshold = number<br/>  })</pre> | n/a | yes |
+| <a name="input_detector_config"></a> [detector\_config](#input\_detector\_config) | Thresholds and durations for the dependency rules in tenant health detectors. | <pre>object({<br/>    failure_duration                   = string<br/>    no_data_duration                   = string<br/>    no_data_fill_duration              = string<br/>    rate_limit_duration                = string<br/>    rate_limit_remaining_pct_threshold = number<br/>  })</pre> | n/a | yes |
 | <a name="input_detector_name_prefix"></a> [detector\_name\_prefix](#input\_detector\_name\_prefix) | Prefix to use for Splunk Observability detector names. | `string` | n/a | yes |
 | <a name="input_detector_notifications"></a> [detector\_notifications](#input\_detector\_notifications) | Detector notification destinations. | `list(string)` | n/a | yes |
 | <a name="input_team"></a> [team](#input\_team) | Splunk Observability team ID. | `string` | n/a | yes |
-| <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | Forge tenants that require independent dependency detectors. | `list(string)` | n/a | yes |
+| <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | Forge tenants that require independent health detectors. | `list(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 | ---- | ----------- |
-| <a name="output_detector_ids"></a> [detector\_ids](#output\_detector\_ids) | Dependency detector IDs keyed by tenant for linking dashboard charts. |
+| <a name="output_detector_ids"></a> [detector\_ids](#output\_detector\_ids) | Tenant health detector IDs keyed by tenant for linking dashboard charts. |
 <!-- END_TF_DOCS -->

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/main.tf
@@ -1,12 +1,14 @@
 locals {
-  detector_tags = ["forgecicd", "dependency-probe", "github", "terraform"]
+  detector_tags                 = ["forgecicd", "tenant-health", "dependency-probe", "terraform"]
+  build_queue_filter            = "filter('QueueName', '*-queued-builds') and (not filter('QueueName', '*dead-letter*', '*dead_letter*', '*dlq*', '*DLQ*'))"
+  dead_letter_queue_name_filter = "filter('QueueName', '*dead-letter*', '*dead_letter*', '*dlq*', '*DLQ*')"
 }
 
 resource "signalfx_detector" "tenant_dependency_health" {
   for_each = toset(var.tenant_names)
 
-  name        = "${var.detector_name_prefix} tenant ${each.value} dependency health"
-  description = "Monitors ${each.value} GitHub App authentication, organization runner API availability and rate-limit budget, regional SSM credential access, and probe telemetry."
+  name        = "${var.detector_name_prefix} tenant ${each.value} health"
+  description = "Monitors ${each.value} dependencies, Lambda failures, build queues, Kubernetes workloads, EC2 status checks, and EBS IOPS limits."
   max_delay   = 120
   tags        = local.detector_tags
   teams       = [var.team]
@@ -17,10 +19,32 @@ tenant_cycle = data('forge.dependency.probe_executed', filter=filter('TenantName
 ssm_availability = data('forge.dependency.availability', filter=filter('TenantName', '${each.value}') and filter('Provider', 'AWS') and filter('CheckName', 'SSMCredentials'), rollup='min').min(by=['AWSRegion']).fill(value=0, duration='${var.detector_config.no_data_fill_duration}')
 github_availability = data('forge.dependency.availability', filter=filter('TenantName', '${each.value}') and filter('Provider', 'GitHub'), rollup='min').min(by=['AWSRegion']).fill(value=0, duration='${var.detector_config.no_data_fill_duration}')
 github_rate_limit_remaining_pct = data('forge.dependency.rate_limit_remaining_pct', filter=filter('TenantName', '${each.value}') and filter('Provider', 'GitHub') and filter('CheckName', 'OrgRunnersApi'), rollup='min').min(by=['AWSRegion']).fill(value=100, duration='${var.detector_config.no_data_fill_duration}')
+lambda_errors = data('Errors', filter=filter('aws_tag_TenantName', '${each.value}') and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(over='10m').sum(by=['aws_region', 'aws_function_name'])
+lambda_invocations = data('Invocations', filter=filter('aws_tag_TenantName', '${each.value}') and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(over='10m').sum(by=['aws_region', 'aws_function_name'])
+lambda_error_rate = (lambda_errors / lambda_invocations) * 100
+lambda_throttles = data('Throttles', filter=filter('aws_tag_TenantName', '${each.value}') and filter('namespace', 'AWS/Lambda') and filter('stat', 'sum') and filter('aws_function_version', '*'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'aws_function_name'])
+build_queue_oldest_age = data('ApproximateAgeOfOldestMessage', filter=filter('aws_tag_TenantName', '${each.value}') and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter}), rollup='latest').max(over='5m').max(by=['aws_region', 'QueueName'])
+build_queue_visible_messages = data('ApproximateNumberOfMessagesVisible', filter=filter('aws_tag_TenantName', '${each.value}') and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.build_queue_filter}), rollup='latest').max(over='5m').max(by=['aws_region', 'QueueName'])
+dlq_visible_messages = data('ApproximateNumberOfMessagesVisible', filter=filter('aws_tag_TenantName', '${each.value}') and filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and (${local.dead_letter_queue_name_filter}), rollup='latest').max(over='5m').max(by=['aws_region', 'QueueName'])
+pending_pods = data('k8s.pod.phase', filter=filter('k8s.namespace.name', '${each.value}'), rollup='latest').between(0, 1.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name']).fill(value=0, duration='10m')
+failed_or_unknown_pods = data('k8s.pod.phase', filter=filter('k8s.namespace.name', '${each.value}'), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name']).fill(value=0, duration='10m')
+container_restarts = data('k8s.container.restarts', filter=filter('k8s.namespace.name', '${each.value}') and filter('k8s.container.name', '*'), rollup='latest').max(by=['k8s.cluster.name', 'k8s.pod.name', 'k8s.container.name']).delta().sum(over='15m').sum(by=['k8s.cluster.name']).fill(value=0, duration='15m')
+ec2_status_failures = data('StatusCheckFailed', filter=filter('aws_tag_TenantName', '${each.value}') and filter('namespace', 'AWS/EC2') and filter('stat', 'upper') and filter('aws_instance_id', '*'), rollup='max', extrapolation='zero').max(over='5m').max(by=['aws_region', 'aws_instance_id'])
+ebs_iops_exceeded = data('VolumeIOPSExceededCheck', filter=filter('aws_tag_TenantName', '${each.value}') and filter('namespace', 'AWS/EBS') and filter('stat', 'upper') and filter('VolumeId', '*'), rollup='latest', extrapolation='zero').max(over='5m').max(by=['aws_region', 'VolumeId'])
 detect(when(tenant_cycle < 1, '${var.detector_config.no_data_duration}')).publish('Tenant dependency probe has no data')
 detect(when(ssm_availability < 1, '${var.detector_config.failure_duration}')).publish('Tenant GitHub App SSM credentials unavailable')
 detect(when(github_availability < 1, '${var.detector_config.failure_duration}')).publish('Tenant GitHub API unavailable')
 detect(when(github_rate_limit_remaining_pct < ${var.detector_config.rate_limit_remaining_pct_threshold}, '${var.detector_config.rate_limit_duration}')).publish('Tenant GitHub API rate-limit budget low')
+detect(when((lambda_errors >= 3) and (lambda_error_rate >= 5), '10m')).publish('Tenant Lambda error rate high')
+detect(when(lambda_throttles > 0, '5m')).publish('Tenant Lambda throttling')
+detect(when((build_queue_oldest_age > 75) and (build_queue_visible_messages > 10), '10m'), off=when(build_queue_oldest_age < 60, '15m')).publish('Tenant build queue delayed')
+detect(when(build_queue_oldest_age > 300, '10m'), off=when(build_queue_oldest_age < 60, '15m')).publish('Tenant build queue stuck')
+detect(when(dlq_visible_messages > 0, '5m')).publish('Tenant DLQ backlog')
+detect(when(pending_pods > 0, '10m')).publish('Tenant Kubernetes pod pending')
+detect(when(failed_or_unknown_pods > 0, '10m')).publish('Tenant Kubernetes pod failed or unknown')
+detect(when(container_restarts > 3)).publish('Tenant Kubernetes container restarting')
+detect(when(ec2_status_failures > 0, '5m')).publish('Tenant EC2 status check failure')
+detect(when(ebs_iops_exceeded > 0, '5m')).publish('Tenant EBS IOPS limit exceeded')
 EOF
 
   rule {
@@ -48,6 +72,76 @@ EOF
     description   = "GitHub API rate-limit budget below ${var.detector_config.rate_limit_remaining_pct_threshold}% for ${var.detector_config.rate_limit_duration}"
     severity      = "Warning"
     detect_label  = "Tenant GitHub API rate-limit budget low"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "At least 3 Lambda errors and at least 5 percent error rate for 10 minutes, grouped by function"
+    severity      = "Major"
+    detect_label  = "Tenant Lambda error rate high"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Lambda throttling sustained for 5 minutes, grouped by function"
+    severity      = "Major"
+    detect_label  = "Tenant Lambda throttling"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Build queue oldest-message age above 75 seconds and visible backlog above 10 for 10 minutes"
+    severity      = "Warning"
+    detect_label  = "Tenant build queue delayed"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Build queue oldest-message age above 300 seconds for 10 minutes"
+    severity      = "Major"
+    detect_label  = "Tenant build queue stuck"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Visible messages present in a dead-letter queue for 5 minutes"
+    severity      = "Major"
+    detect_label  = "Tenant DLQ backlog"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Kubernetes pod pending for 10 minutes, grouped by cluster"
+    severity      = "Warning"
+    detect_label  = "Tenant Kubernetes pod pending"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Kubernetes pod failed or unknown for 10 minutes, grouped by cluster"
+    severity      = "Major"
+    detect_label  = "Tenant Kubernetes pod failed or unknown"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "More than 3 Kubernetes container restarts in 15 minutes, grouped by cluster"
+    severity      = "Warning"
+    detect_label  = "Tenant Kubernetes container restarting"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "EC2 instance status-check failure sustained for 5 minutes"
+    severity      = "Major"
+    detect_label  = "Tenant EC2 status check failure"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "EBS provisioned-IOPS exceeded check sustained for 5 minutes"
+    severity      = "Warning"
+    detect_label  = "Tenant EBS IOPS limit exceeded"
     notifications = var.detector_notifications
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/outputs.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/outputs.tf
@@ -1,5 +1,5 @@
 output "detector_ids" {
-  description = "Dependency detector IDs keyed by tenant for linking dashboard charts."
+  description = "Tenant health detector IDs keyed by tenant for linking dashboard charts."
   value = {
     for tenant_name, detector in signalfx_detector.tenant_dependency_health :
     tenant_name => detector.id

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_behavior.tftest.hcl
@@ -21,18 +21,18 @@ run "creates_one_dependency_detector_per_tenant" {
 
   assert {
     condition = (
-      signalfx_detector.tenant_dependency_health["tenant-a"].name == "Forge Prod tenant tenant-a dependency health"
-      && signalfx_detector.tenant_dependency_health["tenant-b"].name == "Forge Prod tenant tenant-b dependency health"
+      signalfx_detector.tenant_dependency_health["tenant-a"].name == "Forge Prod tenant tenant-a health"
+      && signalfx_detector.tenant_dependency_health["tenant-b"].name == "Forge Prod tenant tenant-b health"
     )
     error_message = "Dependency probes must create a distinct detector for every configured tenant."
   }
 
   assert {
     condition = (
-      length(signalfx_detector.tenant_dependency_health["tenant-a"].rule) == 4
-      && length(signalfx_detector.tenant_dependency_health["tenant-b"].rule) == 4
+      length(signalfx_detector.tenant_dependency_health["tenant-a"].rule) == 14
+      && length(signalfx_detector.tenant_dependency_health["tenant-b"].rule) == 14
     )
-    error_message = "Every tenant detector must keep no-data, SSM, GitHub availability, and rate-limit rules."
+    error_message = "Every tenant detector must keep four dependency rules plus ten actionable workload-health rules."
   }
 
   assert {
@@ -40,8 +40,13 @@ run "creates_one_dependency_detector_per_tenant" {
       strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "forge.dependency.probe_executed")
       && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "forge.dependency.availability")
       && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "forge.dependency.rate_limit_remaining_pct")
-      && !strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "filter('namespace'")
+      && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "filter('aws_tag_TenantName', 'tenant-a')")
+      && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "lambda_error_rate >= 5")
+      && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "filter('QueueName', '*dead-letter*', '*dead_letter*', '*dlq*', '*DLQ*')")
+      && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "filter('k8s.namespace.name', 'tenant-a')")
+      && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "StatusCheckFailed")
+      && strcontains(signalfx_detector.tenant_dependency_health["tenant-a"].program_text, "VolumeIOPSExceededCheck")
     )
-    error_message = "Tenant detectors must consume direct Splunk metrics without a CloudWatch namespace filter."
+    error_message = "Tenant detectors must combine direct dependency telemetry with tenant-scoped AWS and Kubernetes health signals."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_interface_contract.tftest.hcl
@@ -29,7 +29,7 @@ run "dependency_probes_interface_contract" {
       "rate_limit_duration                = string",
       "rate_limit_remaining_pct_threshold = number",
       "output \"detector_ids\"",
-      "description = \"Dependency detector IDs keyed by tenant for linking dashboard charts.\"",
+      "description = \"Tenant health detector IDs keyed by tenant for linking dashboard charts.\"",
     ]
   }
 

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/tests/dependency_probes_source_inventory.tftest.hcl
@@ -19,6 +19,16 @@ run "dependency_probes_source_inventory" {
       "Tenant GitHub App SSM credentials unavailable",
       "Tenant GitHub API unavailable",
       "Tenant GitHub API rate-limit budget low",
+      "Tenant Lambda error rate high",
+      "Tenant Lambda throttling",
+      "Tenant build queue delayed",
+      "Tenant build queue stuck",
+      "Tenant DLQ backlog",
+      "Tenant Kubernetes pod pending",
+      "Tenant Kubernetes pod failed or unknown",
+      "Tenant Kubernetes container restarting",
+      "Tenant EC2 status check failure",
+      "Tenant EBS IOPS limit exceeded",
     ]
   }
 
@@ -28,7 +38,7 @@ run "dependency_probes_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 11
+    condition     = output.expected_literal_count == 21
     error_message = "Detector source inventory count must remain pinned."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/dependency_probes/variables.tf
@@ -14,12 +14,12 @@ variable "team" {
 }
 
 variable "tenant_names" {
-  description = "Forge tenants that require independent dependency detectors."
+  description = "Forge tenants that require independent health detectors."
   type        = list(string)
 }
 
 variable "detector_config" {
-  description = "Thresholds and durations for tenant dependency detectors."
+  description = "Thresholds and durations for the dependency rules in tenant health detectors."
   type = object({
     failure_duration                   = string
     no_data_duration                   = string

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
@@ -32,7 +32,7 @@ A small platform team cannot watch every tenant manually. These detectors conver
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.30.3 |
+| <a name="provider_signalfx"></a> [signalfx](#provider\_signalfx) | 9.33.0 |
 
 ## Modules
 

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/README.md
@@ -59,6 +59,7 @@ No modules.
 | <a name="input_k8s_platform_namespaces"></a> [k8s\_platform\_namespaces](#input\_k8s\_platform\_namespaces) | Namespaces that contain platform pods required for runner scheduling and networking. | `list(string)` | n/a | yes |
 | <a name="input_team"></a> [team](#input\_team) | Team ID. | `string` | n/a | yes |
 | <a name="input_tenant_names"></a> [tenant\_names](#input\_tenant\_names) | List of Forge tenant namespaces. | `list(string)` | n/a | yes |
+| <a name="input_tenant_pods_pending_notifications"></a> [tenant\_pods\_pending\_notifications](#input\_tenant\_pods\_pending\_notifications) | Optional notification override for the legacy aggregate tenant pending-pod detector. | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/main.tf
@@ -108,7 +108,7 @@ EOF
     description   = "Tenant pod pending for ${var.k8s_detector_config.pending_pods_duration}"
     severity      = "Warning"
     detect_label  = "Tenant pod pending"
-    notifications = var.detector_notifications
+    notifications = var.tenant_pods_pending_notifications == null ? var.detector_notifications : var.tenant_pods_pending_notifications
   }
 }
 

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/main.tf
@@ -114,7 +114,7 @@ EOF
 
 resource "signalfx_detector" "k8s_platform_pods_unhealthy" {
   name        = "${var.detector_name_prefix} K8S platform pods unhealthy"
-  description = "Detects sustained failed or unknown pods in Forge platform namespaces, grouped by cluster and namespace. Restore the affected scheduling or networking component and verify runner capacity."
+  description = "Detects sustained failed or unknown pods and repeated container restarts in Forge platform namespaces, grouped by cluster and namespace."
   max_delay   = 120
   tags        = local.detector_tags
   teams       = [var.team]
@@ -122,13 +122,22 @@ resource "signalfx_detector" "k8s_platform_pods_unhealthy" {
 
   program_text = <<-EOF
 platform_failed_pods = data('k8s.pod.phase', filter=(${local.k8s_platform_filter}), rollup='latest').between(3.5, 5.5, low_inclusive=True, high_inclusive=True).sum(by=['k8s.cluster.name', 'k8s.namespace.name']).fill(value=0, duration='${var.k8s_detector_config.platform_pods_duration}')
+platform_container_restarts = data('k8s.container.restarts', filter=(${local.k8s_platform_filter}) and filter('k8s.container.name', '*'), rollup='latest').max(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name', 'k8s.container.name']).delta().sum(over='${var.k8s_detector_config.container_restarts_duration}').sum(by=['k8s.cluster.name', 'k8s.namespace.name']).fill(value=0, duration='${var.k8s_detector_config.container_restarts_duration}')
 detect(when(platform_failed_pods > ${var.k8s_detector_config.platform_unhealthy_threshold}, '${var.k8s_detector_config.platform_pods_duration}')).publish('Platform pod failed or unknown')
+detect(when(platform_container_restarts > ${var.k8s_detector_config.container_restarts_threshold})).publish('Platform container restarting')
 EOF
 
   rule {
     description   = "Platform pod failed or unknown for ${var.k8s_detector_config.platform_pods_duration}"
     severity      = "Major"
     detect_label  = "Platform pod failed or unknown"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Platform container restarts above ${var.k8s_detector_config.container_restarts_threshold} for ${var.k8s_detector_config.container_restarts_duration}"
+    severity      = "Warning"
+    detect_label  = "Platform container restarting"
     notifications = var.detector_notifications
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract.tftest.hcl
@@ -16,6 +16,7 @@ run "integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract" {
       "k8s_platform_namespaces",
       "team",
       "tenant_names",
+      "tenant_pods_pending_notifications",
     ]
     expected_output_values = [
       "detector_ids",
@@ -68,6 +69,8 @@ run "integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract" {
       "description = \"Team ID.\"",
       "variable \"tenant_names\"",
       "description = \"List of Forge tenant namespaces.\"",
+      "variable \"tenant_pods_pending_notifications\"",
+      "description = \"Optional notification override for the legacy aggregate tenant pending-pod detector.\"",
       "output \"detector_ids\"",
       "description = \"Kubernetes detector IDs for linking the matching dashboard charts.\"",
     ]
@@ -100,9 +103,9 @@ run "integrations_splunk_o11y_conf_shared_detectors_k8s_interface_contract" {
 
   assert {
     condition = (
-      output.expected_input_variable_count == 8
+      output.expected_input_variable_count == 9
       && output.expected_output_value_count == 1
-      && output.expected_interface_literal_count == 49
+      && output.expected_interface_literal_count == 51
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/k8s_detector_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/k8s_detector_behavior.tftest.hcl
@@ -83,9 +83,13 @@ run "k8s_detector_scope_and_threshold_contract" {
       && strcontains(signalfx_detector.k8s_tenant_pods_pending.program_text, ".fill(value=0, duration='10m')")
       && strcontains(signalfx_detector.k8s_platform_pods_unhealthy.program_text, "filter('k8s.namespace.name', 'kube-system') or filter('k8s.namespace.name', 'karpenter')")
       && !strcontains(signalfx_detector.k8s_platform_pods_unhealthy.program_text, "Platform pod pending")
-      && length(signalfx_detector.k8s_platform_pods_unhealthy.rule) == 1
-      && one(signalfx_detector.k8s_platform_pods_unhealthy.rule).severity == "Major"
+      && strcontains(signalfx_detector.k8s_platform_pods_unhealthy.program_text, "platform_container_restarts")
+      && strcontains(signalfx_detector.k8s_platform_pods_unhealthy.program_text, ".delta().sum(over='10m')")
+      && strcontains(signalfx_detector.k8s_platform_pods_unhealthy.program_text, "platform_container_restarts > 3")
+      && length(signalfx_detector.k8s_platform_pods_unhealthy.rule) == 2
+      && length([for rule in signalfx_detector.k8s_platform_pods_unhealthy.rule : rule if rule.severity == "Major"]) == 1
+      && length([for rule in signalfx_detector.k8s_platform_pods_unhealthy.rule : rule if rule.severity == "Warning"]) == 1
     )
-    error_message = "K8s workload detectors must aggregate tenant pending pods by tenant and retain only the actionable platform failed-or-unknown rule."
+    error_message = "K8s workload detectors must aggregate tenant pending pods by tenant and cover actionable platform pod failures and restart pressure."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/k8s_detector_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/tests/k8s_detector_behavior.tftest.hcl
@@ -93,3 +93,16 @@ run "k8s_detector_scope_and_threshold_contract" {
     error_message = "K8s workload detectors must aggregate tenant pending pods by tenant and cover actionable platform pod failures and restart pressure."
   }
 }
+
+run "allows_tenant_health_to_own_pending_pod_notifications" {
+  command = plan
+
+  variables {
+    tenant_pods_pending_notifications = []
+  }
+
+  assert {
+    condition     = length(one(signalfx_detector.k8s_tenant_pods_pending.rule).notifications) == 0
+    error_message = "The aggregate pending-pod detector must support suppressing notifications when tenant health detectors own the same signal."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/k8s/variables.tf
@@ -66,3 +66,9 @@ variable "tenant_names" {
   description = "List of Forge tenant namespaces."
   type        = list(string)
 }
+
+variable "tenant_pods_pending_notifications" {
+  description = "Optional notification override for the legacy aggregate tenant pending-pod detector."
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
## Description

Adds tenant-level and platform-level Forge health detectors:

- extends each tenant dependency detector into a single tenant health detector while preserving the four GitHub, SSM, rate-limit, and telemetry rules;
- adds tenant-scoped Lambda error-rate and throttle alerts, delayed and stuck build-queue alerts, DLQ backlog detection, Kubernetes pending/failed/restart alerts, EC2 status-check failures, and EBS IOPS exceeded checks;
- recognizes `dead-letter`, `dead_letter`, `dlq`, and `DLQ` queue naming conventions, including job-log dead-letter queues;
- links tenant health alert streams to the matching Forge Tenant Impact and dependency charts;
- suppresses the legacy aggregate pending-pod notification when all Kubernetes tenants are covered by the per-tenant health detectors;
- creates a shared AWS control-plane detector for platform Lambda and SQS health while excluding tenant-tagged resources;
- extends Kubernetes platform health with container restart pressure in platform namespaces;
- keeps existing EC2 CPU, memory, and disk detectors separate to avoid duplicate notifications, while network, EBS queue length, and Lambda duration remain dashboard diagnostics.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu test` in `detectors/dependency_probes`: 3 passed
- `tofu test` in `detectors/k8s`: 4 passed
- `tofu test` in `dashboards/dependency_probes`: 3 passed
- `tofu test` in `dashboards/forge_impact`: 4 passed
- `tofu test` in the shared integration module: 3 passed
- live SignalFlow execution against `csdevops` for all ten new tenant workload conditions
- commit hooks, including Terraform/OpenTofu formatting and validation, security checks, and linters