### PR TITLE
fix(integrations): preserve Splunk permissions during destroy

### DIFF
--- a/modules/integrations/splunk_o11y_aws_integration_common/signalfx.tf
+++ b/modules/integrations/splunk_o11y_aws_integration_common/signalfx.tf
@@ -14,7 +14,12 @@ resource "signalfx_aws_integration" "integration" {
   use_metric_streams_sync   = true
   enable_check_large_volume = true
 
-  depends_on = [time_sleep.wait_30_seconds]
+  # Splunk needs these policies while disabling metric streams during destroy.
+  depends_on = [
+    time_sleep.wait_30_seconds,
+    aws_iam_role_policy.splunk_integration,
+    aws_iam_role_policy.splunk_managed_policy,
+  ]
 }
 
 # Force a delay between secret creation and seeding. We only need a few

--- a/modules/integrations/splunk_o11y_aws_integration_common/tests/integrations_splunk_o11y_aws_integration_common_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_aws_integration_common/tests/integrations_splunk_o11y_aws_integration_common_source_inventory.tftest.hcl
@@ -14,6 +14,7 @@ run "integrations_splunk_o11y_aws_integration_common_contract" {
       "resource \"signalfx_aws_external_integration\" \"integration\"",
       "resource \"signalfx_aws_integration\" \"integration\"",
       "resource \"time_sleep\" \"wait_30_seconds\"",
+      "depends_on = [\n    time_sleep.wait_30_seconds,\n    aws_iam_role_policy.splunk_integration,\n    aws_iam_role_policy.splunk_managed_policy,\n  ]",
       "data \"aws_caller_identity\" \"current\"",
       "data \"aws_iam_policy_document\" \"splunk_integration\"",
       "data \"aws_iam_policy_document\" \"splunk_managed_policy\"",


### PR DESCRIPTION
## Description

Ensure the Splunk Observability AWS integration is destroyed before its IAM policies. Splunk needs the CloudWatch metric-stream and `iam:PassRole` permissions while it disables metric streams; Terraform previously treated the policies as independent resources and could remove them first, leaving the integration in `CANCELLATION_FAILED`.

Add the two IAM policies to the integration's explicit dependencies and pin the ordering contract in the module source-inventory test.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu test` in `modules/integrations/splunk_o11y_aws_integration_common` (3 passed, 0 failed)
- `pre-commit run --files modules/integrations/splunk_o11y_aws_integration_common/signalfx.tf modules/integrations/splunk_o11y_aws_integration_common/tests/integrations_splunk_o11y_aws_integration_common_source_inventory.tftest.hcl`
- `git diff --check`
