### PR TITLE
fix(logs): distribute Kinesis partition keys

### DIFF
--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs.py
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import os
@@ -264,7 +265,7 @@ def ship_lines_to_kinesis(
     metadata_fields: dict[str, Any] | None = None,
 ) -> int:
     """Batch lines into PutRecords requests respecting count & size limits."""
-    buffer: list[tuple[bytes, int]] = []  # (data_bytes, length)
+    buffer: list[tuple[bytes, int, str]] = []
     total_shipped = 0
     current_bytes = 0
 
@@ -272,8 +273,10 @@ def ship_lines_to_kinesis(
         nonlocal buffer, total_shipped, current_bytes
         if not buffer:
             return
-        records = [{'Data': b, 'PartitionKey': str(
-            i)} for i, (b, _l) in enumerate(buffer)]
+        records = [
+            {'Data': data, 'PartitionKey': partition_key}
+            for data, _length, partition_key in buffer
+        ]
         attempt = 0
         failures: list[dict[str, Any]] = []
         while attempt < 4:
@@ -324,7 +327,7 @@ def ship_lines_to_kinesis(
         current_bytes = 0
 
     last_ts: float | None = None
-    for line in lines:
+    for line_number, line in enumerate(lines):
         if not line:
             continue
         ts = extract_ts(line, last_ts)
@@ -337,8 +340,18 @@ def ship_lines_to_kinesis(
             continue
         if len(buffer) >= MAX_RECORDS_BATCH or (current_bytes + payload_len) >= MAX_BATCH_BYTES:
             flush()
-        buffer.append((payload, payload_len))
+        buffer.append((
+            payload,
+            payload_len,
+            partition_key_for_line(bucket, key, line_number),
+        ))
         current_bytes += payload_len
 
     flush()
     return total_shipped
+
+
+def partition_key_for_line(bucket: str, key: str, line_number: int) -> str:
+    """Return a stable, high-cardinality Kinesis partition key."""
+    identity = f'{bucket}\0{key}\0{line_number}'.encode()
+    return hashlib.sha256(identity).hexdigest()

--- a/tests/lambdas/splunk_s3_runner_logs_test.py
+++ b/tests/lambdas/splunk_s3_runner_logs_test.py
@@ -187,6 +187,49 @@ def test_ship_lines_retries_only_failed_kinesis_records(monkeypatch, aws):
     assert len(calls) == 2
     assert len(calls[0]['Records']) == 2
     assert len(calls[1]['Records']) == 1
+    assert calls[0]['Records'][1]['PartitionKey'] == (
+        calls[1]['Records'][0]['PartitionKey']
+    )
+
+
+def test_ship_lines_uses_unique_partition_keys_across_batches(
+    monkeypatch, aws
+):
+    mod = _load_splunk(monkeypatch)
+    calls = []
+
+    class _Kinesis:
+        def put_records(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                'FailedRecordCount': 0,
+                'Records': [{} for _record in kwargs['Records']],
+            }
+
+    monkeypatch.setattr(mod, 'kinesis_client', _Kinesis())
+    monkeypatch.setattr(mod, 'MAX_RECORDS_BATCH', 2)
+
+    shipped = mod.ship_lines_to_kinesis(
+        [
+            '2026-07-03T22:26:04.000Z one',
+            'continued two',
+            'continued three',
+            'continued four',
+        ],
+        'forge-gh-logs',
+        'acme/app/99/1/4242.log',
+        {},
+    )
+
+    partition_keys = [
+        record['PartitionKey']
+        for call in calls
+        for record in call['Records']
+    ]
+
+    assert shipped == 4
+    assert len(calls) == 2
+    assert len(partition_keys) == len(set(partition_keys))
 
 
 def test_ship_lines_raises_when_kinesis_retries_are_exhausted(


### PR DESCRIPTION
## Description

Distribute runner-log Kinesis records with stable SHA-256 partition keys derived from the S3 bucket, object key, and object-wide line index.

Previously every batch and Lambda invocation reused the numeric partition keys `0..n`. Concurrent writes therefore repeatedly targeted the same shard mappings and produced `ProvisionedThroughputExceededException` failures even though the stream uses on-demand capacity. Failed-record retries continue to reuse the original partition key.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `uv run --group lambda-tests pytest tests/lambdas/splunk_s3_runner_logs_test.py` — 12 passed
- Full repository pre-commit hook suite — passed
