### PR TITLE
fix(forge-runners): retry GitHub global lock requests

### DIFF
--- a/modules/platform/forge_runners/github_global_lock/lambda/github_clean_global_lock.py
+++ b/modules/platform/forge_runners/github_global_lock/lambda/github_clean_global_lock.py
@@ -16,6 +16,8 @@ import boto3  # noqa: E402
 import jwt  # noqa: E402
 import requests  # noqa: E402
 from botocore.config import Config  # noqa: E402
+from requests.adapters import HTTPAdapter  # noqa: E402
+from urllib3.util.retry import Retry  # noqa: E402
 
 # Configure logging
 LOG = logging.getLogger()
@@ -28,6 +30,23 @@ SSM_CLIENT_CONFIG = Config(
     connect_timeout=5,
     read_timeout=10,
     retries={'mode': 'standard', 'total_max_attempts': 4},
+)
+
+GITHUB_REQUEST_TIMEOUT = (5, 10)
+GITHUB_RETRY_CONFIG = Retry(
+    total=3,
+    connect=3,
+    read=3,
+    status=3,
+    backoff_factor=0.5,
+    status_forcelist=(429, 500, 502, 503, 504),
+    allowed_methods=frozenset({'GET', 'POST'}),
+    respect_retry_after_header=True,
+)
+GITHUB_SESSION = requests.Session()
+GITHUB_SESSION.mount(
+    'https://',
+    HTTPAdapter(max_retries=GITHUB_RETRY_CONFIG),
 )
 
 SSM = boto3.client('ssm', config=SSM_CLIENT_CONFIG)
@@ -52,7 +71,11 @@ def get_installation_access_token(jwt_token: str, installation_id: str) -> str:
         'Accept': 'application/vnd.github+json',
     }
     url = f'https://api.github.com/app/installations/{installation_id}/access_tokens'
-    response = requests.post(url, headers=headers)
+    response = GITHUB_SESSION.post(
+        url,
+        headers=headers,
+        timeout=GITHUB_REQUEST_TIMEOUT,
+    )
     response.raise_for_status()
     return response.json()['token']
 
@@ -96,8 +119,17 @@ def scan_and_process_dynamodb(access_token: str):
             if not owner or not repo or not run_id:
                 continue
 
-            status = get_workflow_status(
-                access_token, owner, repo, run_id, workflow_run_attempt)
+            try:
+                status = get_workflow_status(
+                    access_token, owner, repo, run_id, workflow_run_attempt)
+            except requests.RequestException as error:
+                LOG.warning(
+                    'Skipping lock %s after GitHub workflow lookup failed: %s',
+                    lock_id,
+                    error,
+                )
+                continue
+
             if status == 'completed':
                 print(f'Deleting completed workflow: {workflow_run_url}')
                 table.delete_item(
@@ -113,7 +145,11 @@ def get_workflow_status(access_token: str, owner: str, repo: str, run_id: str, a
     headers = {'Authorization': f'token {access_token}',
                'Accept': 'application/vnd.github.v3+json'}
 
-    response = requests.get(url, headers=headers)
+    response = GITHUB_SESSION.get(
+        url,
+        headers=headers,
+        timeout=GITHUB_REQUEST_TIMEOUT,
+    )
     if response.status_code == 200:
         return response.json().get('status')  # "completed" or other statuses
     return None

--- a/tests/lambdas/github_clean_global_lock_test.py
+++ b/tests/lambdas/github_clean_global_lock_test.py
@@ -6,6 +6,7 @@ import base64
 import json
 
 import boto3
+import requests
 from conftest import AWS_REGION, requires_aws
 from support import load_handler_module
 
@@ -96,7 +97,7 @@ def test_get_workflow_status_returns_none_on_non_200(monkeypatch, aws):
         def json(self):
             return {'status': 'completed'}
 
-    monkeypatch.setattr(mod.requests, 'get', lambda *_args,
+    monkeypatch.setattr(mod.GITHUB_SESSION, 'get', lambda *_args,
                         **_kwargs: _Response())
 
     assert mod.get_workflow_status(
@@ -106,6 +107,52 @@ def test_get_workflow_status_returns_none_on_non_200(monkeypatch, aws):
         '100',
         '1',
     ) is None
+
+
+def test_github_requests_retry_transient_failures(monkeypatch, aws):
+    mod = _load_lock_lambda(monkeypatch)
+
+    retries = mod.GITHUB_SESSION.get_adapter('https://').max_retries
+
+    assert retries.total == 3
+    assert retries.connect == 3
+    assert retries.read == 3
+    assert retries.status == 3
+    assert retries.allowed_methods == frozenset({'GET', 'POST'})
+    assert set(retries.status_forcelist) == {429, 500, 502, 503, 504}
+
+
+def test_scan_continues_after_github_connection_error(monkeypatch, aws):
+    table = _create_lock_table()
+    mod = _load_lock_lambda(monkeypatch)
+    for lock_id, run_id in (
+        ('lock-connection-error', '100'),
+        ('lock-complete', '101'),
+    ):
+        table.put_item(Item={
+            'lock_id': lock_id,
+            'workflow_run_url': (
+                f'https://github.com/acme/app/actions/runs/{run_id}'
+            ),
+            'workflow_run_attempt': '1',
+        })
+
+    def _status(_token, _owner, _repo, run_id, _attempt):
+        if run_id == '100':
+            raise requests.ConnectionError(
+                'Remote end closed connection without response'
+            )
+        return 'completed'
+
+    monkeypatch.setattr(mod, 'get_workflow_status', _status)
+
+    mod.scan_and_process_dynamodb('installation-token')
+
+    remaining = {
+        item['lock_id']
+        for item in table.scan()['Items']
+    }
+    assert remaining == {'lock-connection-error'}
 
 
 def test_lambda_handler_loads_ssm_secrets_and_runs_cleanup(monkeypatch, ssm):


### PR DESCRIPTION
## Description

Adds bounded connection, read, and transient-status retries with explicit
timeouts to the GitHub API calls made by the global-lock cleanup Lambda.

A dropped GitHub connection previously escaped to the outer handler and failed
the entire scheduled cleanup. After retries are exhausted, a failed workflow
lookup now leaves that lock for the next scheduled run while allowing the
remaining locks to be processed. Installation-token failures still fail the
invocation because cleanup cannot proceed without authentication.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `uv run --project .. --locked --only-group lambda-tests pytest -q lambdas/github_clean_global_lock_test.py` - 7 passed
- Full Lambda unit suite - 235 passed
- Repository pre-commit suite - passed
