### PR TITLE
fix(logs): checkpoint and split runner log ingestion

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/props_runner_logs.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_runner_logs.tf
@@ -70,6 +70,7 @@ resource "splunk_configs_conf" "forgecicd_runner_logs_logs" {
     "REPORT-forgecicd_runner_logs_tenant_fields_logs" = "forgecicd_runner_logs_tenant_fields_logs"
     "REPORT-forgecicd_runner_ec2"                     = "forgecicd_runner_ec2"
     "REPORT-forgecicd_runner_arc"                     = "forgecicd_runner_arc"
+    "TRUNCATE"                                        = "1000000"
   }
 
   acl {
@@ -112,7 +113,6 @@ resource "splunk_configs_conf" "forgecicd_runner_logs_logs" {
       variables["SEGMENTATION-standard"],
       variables["SHOULD_LINEMERGE"],
       variables["TRANSFORMS"],
-      variables["TRUNCATE"],
       variables["detect_trailing_nulls"],
       variables["disabled"],
       variables["maxDist"],

--- a/modules/integrations/splunk_cloud_conf_shared/tests/integrations_splunk_cloud_conf_shared_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/integrations_splunk_cloud_conf_shared_source_inventory.tftest.hcl
@@ -44,6 +44,7 @@ run "integrations_splunk_cloud_conf_shared_contract" {
       "resource \"splunk_configs_conf\" \"forgecicd_kube_container_log_hook\"",
       "resource \"splunk_configs_conf\" \"forgecicd_runner_logs_json\"",
       "resource \"splunk_configs_conf\" \"forgecicd_runner_logs_logs\"",
+      "\"TRUNCATE\"                                        = \"1000000\"",
       "resource \"splunk_configs_conf\" \"forgecicd_billing_cur_instance_id\"",
       "resource \"splunk_configs_conf\" \"forgecicd_billing_cur_volume_id\"",
       "resource \"splunk_configs_conf\" \"forgecicd_cloudwatchlogs_runner_tenant_fields\"",

--- a/modules/integrations/splunk_cloud_s3_runner_logs/README.md
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/README.md
@@ -16,7 +16,9 @@ Forge archives job logs and operational logs because runners are destroyed after
 ## Operational Notes
 
 - Splunk HEC endpoint and secret configuration must be correct before enabling delivery.
-- The SQS event source concurrency cap and DLQ receive threshold are configurable, defaulting to 40 concurrent invocations and 100 receives.
+- The SQS event source concurrency cap and DLQ receive threshold are configurable, defaulting to 40 concurrent invocations and 5 receives.
+- `.log` objects are processed in line-aligned 8 MiB chunks. Each successful chunk enqueues the next byte offset on the same SQS queue, preserving timestamp state across invocations.
+- Individual `.log` lines whose wrapped HEC event exceeds 1,000,000 bytes are split into UTF-8-safe records targeting at most 750 KiB. The records retain the original timestamp and include `forge_event_id`, `chunked`, `chunk_index`, `chunk_count`, and `original_line_bytes` HEC fields.
 - The scheduled redrive Lambda moves DLQ messages back to the runner-log event queue every ten minutes.
 - Use the backup bucket, DLQ, and redrive Lambda logs when logs are missing from Splunk.
 - The S3 event path should match the job-log archiver bucket layout.
@@ -91,8 +93,9 @@ Forge archives job logs and operational logs because runners are destroyed after
 | <a name="input_lambda_event_source_mapping_maximum_concurrency"></a> [lambda\_event\_source\_mapping\_maximum\_concurrency](#input\_lambda\_event\_source\_mapping\_maximum\_concurrency) | Maximum concurrent Lambda invocations for the runner-log SQS event source mapping. | `number` | `40` | no |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Log level for application logging (e.g., INFO, DEBUG, WARN, ERROR) | `string` | `"INFO"` | no |
 | <a name="input_logging_retention_in_days"></a> [logging\_retention\_in\_days](#input\_logging\_retention\_in\_days) | Log retention period in days | `number` | `3` | no |
+| <a name="input_runner_log_chunk_size_bytes"></a> [runner\_log\_chunk\_size\_bytes](#input\_runner\_log\_chunk\_size\_bytes) | Maximum bytes processed from a runner .log object before continuing from a line-aligned SQS checkpoint. | `number` | `8388608` | no |
 | <a name="input_splunk_hec_endpoint"></a> [splunk\_hec\_endpoint](#input\_splunk\_hec\_endpoint) | Full URL of Splunk HEC endpoint | `string` | n/a | yes |
-| <a name="input_sqs_redrive_max_receive_count"></a> [sqs\_redrive\_max\_receive\_count](#input\_sqs\_redrive\_max\_receive\_count) | Number of source-queue receives allowed before a runner-log message moves to the DLQ. | `number` | `100` | no |
+| <a name="input_sqs_redrive_max_receive_count"></a> [sqs\_redrive\_max\_receive\_count](#input\_sqs\_redrive\_max\_receive\_count) | Number of source-queue receives allowed before a runner-log message moves to the DLQ. | `number` | `5` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
@@ -1,5 +1,6 @@
 locals {
-  prefix_lambda = "splunk-s3-runner-logs"
+  prefix_lambda          = "splunk-s3-runner-logs"
+  lambda_timeout_seconds = 900
 }
 
 module "splunk_s3_runner_logs_lambda" {
@@ -11,7 +12,7 @@ module "splunk_s3_runner_logs_lambda" {
   handler       = "splunk_s3_runner_logs.lambda_handler"
   runtime       = "python3.12"
   memory_size   = 1024
-  timeout       = 900
+  timeout       = local.lambda_timeout_seconds
   architectures = ["x86_64"]
 
   source_path = [{
@@ -25,7 +26,9 @@ module "splunk_s3_runner_logs_lambda" {
 
   environment_variables = {
     KINESIS_STREAM_NAME = aws_kinesis_stream.splunk_s3_runner_logs.name
+    LOG_CHUNK_BYTES     = var.runner_log_chunk_size_bytes
     LOG_LEVEL           = var.log_level
+    SQS_QUEUE_URL       = aws_sqs_queue.log_events_queue.url
   }
 
   attach_policy_json = true
@@ -58,9 +61,9 @@ data "aws_iam_policy_document" "splunk_s3_runner_logs_lambda" {
   }
 
   statement {
-    sid       = "SQSPoll"
+    sid       = "SQSProcessAndCheckpoint"
     effect    = "Allow"
-    actions   = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"]
+    actions   = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes", "sqs:SendMessage"]
     resources = [aws_sqs_queue.log_events_queue.arn]
   }
 

--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs/splunk_s3_runner_logs.py
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs/splunk_s3_runner_logs.py
@@ -16,13 +16,20 @@ LOG.setLevel(getattr(logging, level_str, logging.INFO))
 
 s3_client = boto3.client('s3')
 kinesis_client = boto3.client('kinesis')
+sqs_client = boto3.client('sqs')
 sts_client = boto3.client('sts')
 
 SOURCETYPE = os.getenv('SOURCETYPE')
 INDEX = os.getenv('INDEX')
 KINESIS_STREAM_NAME = os.getenv('KINESIS_STREAM_NAME')
+SQS_QUEUE_URL = os.getenv('SQS_QUEUE_URL')
+LOG_CHUNK_BYTES = int(os.getenv('LOG_CHUNK_BYTES', str(8 * 1024 * 1024)))
 MAX_RECORDS_BATCH = 500
 MAX_BATCH_BYTES = 4000000
+MAX_KINESIS_RECORD_BYTES = 1000000
+LONG_LINE_RECORD_TARGET_BYTES = 750 * 1024
+CHECKPOINT_FIELD = 'forge_runner_log_checkpoint'
+CHECKPOINT_VERSION = 1
 
 # Safety clamps
 MAX_RECORDS_BATCH = min(MAX_RECORDS_BATCH, 500)
@@ -53,68 +60,276 @@ def lambda_handler(event, _context):
             LOG.warning('invalid_json_body_skip')
             continue
 
+        checkpoint = body_json.get(CHECKPOINT_FIELD)
+        if checkpoint is not None:
+            total_lines += process_log_checkpoint(checkpoint)
+            continue
+
         for s3_rec in body_json.get('Records', []):
             bucket = s3_rec.get('s3', {}).get('bucket', {}).get('name')
-            key = s3_rec.get('s3', {}).get('object', {}).get('key')
+            object_data = s3_rec.get('s3', {}).get('object', {})
+            key = object_data.get('key')
+            object_size = object_data.get('size')
             if not bucket or not key:
                 LOG.warning('missing_bucket_or_key')
                 continue
-            LOG.info('processing_object bucket=%s key=%s', bucket, key)
-            # Fetch object tags once per object
-            tags: dict[str, str] = {}
-            try:
-                tag_resp = s3_client.get_object_tagging(Bucket=bucket, Key=key)
-                tag_set = tag_resp.get('TagSet', [])
-                LOG.debug('Fetched %d tags for bucket=%s key=%s',
-                          len(tag_set), bucket, key)
-
-                for idx, t in enumerate(tag_set):
-                    k = t.get('Key')
-                    v = t.get('Value')
-                    LOG.debug(
-                        'Processing tag[%d]: Key=%s, Value=%s', idx, k, v)
-                    if k is not None and v is not None:
-                        tags[k] = v
-                    else:
-                        LOG.warning(
-                            'Skipped invalid tag[%d] bucket=%s key=%s tag=%s', idx, bucket, key, t)
-
-                LOG.debug('Final object_tags bucket=%s key=%s tag_count=%d tags=%s',
-                          bucket, key, len(tags), tags)
-            except Exception as tag_err:  # pragma: no cover
-                LOG.warning(
-                    'tag_fetch_failed bucket=%s key=%s err=%s', bucket, key, tag_err)
-
-            metadata_fields = load_metadata_fields(bucket, key, tags)
-
-            # Decide ingestion strategy based on file type.
-            if key.endswith('.json'):
-                # Treat entire JSON file as a single event line.
-                try:
-                    obj = s3_client.get_object(Bucket=bucket, Key=key)
-                    raw = obj['Body'].read()
-                    text = raw.decode('utf-8', errors='replace')
-                    shipped = ship_lines_to_kinesis(
-                        [text], bucket, key, tags, metadata_fields)
-                    LOG.info(
-                        'json_object_ingested bucket=%s key=%s size=%d', bucket, key, len(raw))
-                except Exception as json_err:  # pragma: no cover
-                    LOG.warning(
-                        'json_object_failed bucket=%s key=%s err=%s', bucket, key, json_err)
-                    continue
-            elif key.endswith('.log'):
-                # Line-by-line streaming for log files.
-                line_iter = stream_s3_object_lines(bucket, key)
-                shipped = ship_lines_to_kinesis(
-                    line_iter, bucket, key, tags, metadata_fields)
-            else:
-                LOG.info('unsupported_object_skip bucket=%s key=%s', bucket, key)
-                continue
-            total_lines += shipped
-            LOG.info('object_complete bucket=%s key=%s lines=%d',
-                     bucket, key, shipped)
+            total_lines += process_s3_object(
+                bucket,
+                key,
+                object_size=object_size,
+            )
 
     return {'statusCode': 200, 'body': json.dumps({'lines': total_lines})}
+
+
+def process_s3_object(
+    bucket: str,
+    key: str,
+    *,
+    object_size: int | None = None,
+    start_offset: int = 0,
+    last_timestamp: float | None = None,
+) -> int:
+    """Process a JSON object or one bounded, line-aligned log chunk."""
+    LOG.info(
+        'processing_object bucket=%s key=%s offset=%d',
+        bucket,
+        key,
+        start_offset,
+    )
+    tags = load_object_tags(bucket, key)
+    metadata_fields = load_metadata_fields(bucket, key, tags)
+
+    if key.endswith('.json'):
+        if start_offset != 0:
+            raise ValueError('JSON objects do not support checkpoint offsets')
+        try:
+            obj = s3_client.get_object(Bucket=bucket, Key=key)
+            raw = obj['Body'].read()
+            text = raw.decode('utf-8', errors='replace')
+            shipped = ship_lines_to_kinesis(
+                [text], bucket, key, tags, metadata_fields)
+            LOG.info(
+                'json_object_ingested bucket=%s key=%s size=%d',
+                bucket,
+                key,
+                len(raw),
+            )
+        except Exception as json_err:  # pragma: no cover
+            LOG.warning(
+                'json_object_failed bucket=%s key=%s err=%s',
+                bucket,
+                key,
+                json_err,
+            )
+            return 0
+        LOG.info('object_complete bucket=%s key=%s lines=%d',
+                 bucket, key, shipped)
+        return shipped
+
+    if not key.endswith('.log'):
+        LOG.info('unsupported_object_skip bucket=%s key=%s', bucket, key)
+        return 0
+
+    if object_size is None:
+        object_size = s3_client.head_object(
+            Bucket=bucket,
+            Key=key,
+        )['ContentLength']
+    object_size = int(object_size)
+    if start_offset < 0 or start_offset > object_size:
+        raise ValueError(
+            f'Invalid checkpoint offset {start_offset} for size {object_size}'
+        )
+    if start_offset == object_size:
+        LOG.info('object_complete bucket=%s key=%s lines=0', bucket, key)
+        return 0
+
+    lines, next_offset = read_s3_object_line_chunk(
+        bucket,
+        key,
+        start_offset,
+        LOG_CHUNK_BYTES,
+    )
+    shipped = ship_lines_to_kinesis(
+        lines,
+        bucket,
+        key,
+        tags,
+        metadata_fields,
+        line_number_start=start_offset,
+        initial_last_ts=last_timestamp,
+    )
+    last_timestamp = timestamp_after_lines(lines, last_timestamp)
+    LOG.info(
+        'object_chunk_complete bucket=%s key=%s offset=%d next_offset=%d '
+        'size=%d lines=%d',
+        bucket,
+        key,
+        start_offset,
+        next_offset,
+        object_size,
+        shipped,
+    )
+
+    if next_offset < object_size:
+        enqueue_log_checkpoint(
+            bucket,
+            key,
+            next_offset,
+            object_size,
+            last_timestamp,
+        )
+    else:
+        LOG.info('object_complete bucket=%s key=%s lines=%d',
+                 bucket, key, shipped)
+    return shipped
+
+
+def process_log_checkpoint(checkpoint: Any) -> int:
+    """Validate and process a continuation message from the runner-log queue."""
+    if not isinstance(checkpoint, dict):
+        raise ValueError('Runner-log checkpoint must be an object')
+    if checkpoint.get('version') != CHECKPOINT_VERSION:
+        raise ValueError('Unsupported runner-log checkpoint version')
+
+    bucket = checkpoint.get('bucket')
+    key = checkpoint.get('key')
+    offset = checkpoint.get('offset')
+    object_size = checkpoint.get('object_size')
+    last_timestamp = checkpoint.get('last_timestamp')
+    valid_bucket = isinstance(bucket, str) and bool(bucket)
+    valid_key = isinstance(key, str) and key.endswith('.log')
+    valid_offset = isinstance(offset, int) and not isinstance(offset, bool)
+    valid_size = (
+        isinstance(object_size, int) and not isinstance(object_size, bool)
+    )
+    timestamp_is_number = isinstance(last_timestamp, (int, float))
+    timestamp_is_boolean = isinstance(last_timestamp, bool)
+    valid_timestamp = last_timestamp is None or (
+        timestamp_is_number and not timestamp_is_boolean
+    )
+    if not all((
+        valid_bucket,
+        valid_key,
+        valid_offset,
+        valid_size,
+        valid_timestamp,
+    )):
+        raise ValueError('Invalid runner-log checkpoint')
+
+    return process_s3_object(
+        bucket,
+        key,
+        object_size=object_size,
+        start_offset=offset,
+        last_timestamp=last_timestamp,
+    )
+
+
+def enqueue_log_checkpoint(
+    bucket: str,
+    key: str,
+    offset: int,
+    object_size: int,
+    last_timestamp: float | None,
+) -> None:
+    """Enqueue the next byte offset after the current chunk is fully shipped."""
+    if not SQS_QUEUE_URL:
+        raise RuntimeError('SQS_QUEUE_URL is required for log checkpoints')
+    body = {
+        CHECKPOINT_FIELD: {
+            'version': CHECKPOINT_VERSION,
+            'bucket': bucket,
+            'key': key,
+            'offset': offset,
+            'object_size': object_size,
+            'last_timestamp': last_timestamp,
+        },
+    }
+    sqs_client.send_message(
+        QueueUrl=SQS_QUEUE_URL,
+        MessageBody=json.dumps(body, separators=(',', ':')),
+    )
+    LOG.info(
+        'object_checkpoint_enqueued bucket=%s key=%s offset=%d size=%d',
+        bucket,
+        key,
+        offset,
+        object_size,
+    )
+
+
+def load_object_tags(bucket: str, key: str) -> dict[str, str]:
+    """Fetch scalar S3 object tags used as Splunk event fields."""
+    tags: dict[str, str] = {}
+    try:
+        tag_resp = s3_client.get_object_tagging(Bucket=bucket, Key=key)
+        tag_set = tag_resp.get('TagSet', [])
+        LOG.debug('Fetched %d tags for bucket=%s key=%s',
+                  len(tag_set), bucket, key)
+
+        for idx, tag in enumerate(tag_set):
+            tag_key = tag.get('Key')
+            tag_value = tag.get('Value')
+            if tag_key is not None and tag_value is not None:
+                tags[tag_key] = tag_value
+            else:
+                LOG.warning(
+                    'Skipped invalid tag[%d] bucket=%s key=%s tag=%s',
+                    idx,
+                    bucket,
+                    key,
+                    tag,
+                )
+    except Exception as tag_err:  # pragma: no cover
+        LOG.warning(
+            'tag_fetch_failed bucket=%s key=%s err=%s',
+            bucket,
+            key,
+            tag_err,
+        )
+    return tags
+
+
+def read_s3_object_line_chunk(
+    bucket: str,
+    key: str,
+    start_offset: int,
+    max_bytes: int,
+) -> tuple[list[str], int]:
+    """Read at least max_bytes and stop only after a complete log line."""
+    if max_bytes < 1:
+        raise ValueError('max_bytes must be positive')
+
+    obj = s3_client.get_object(
+        Bucket=bucket,
+        Key=key,
+        Range=f'bytes={start_offset}-',
+    )
+    body = obj['Body']
+    buffer = b''
+    lines: list[str] = []
+    consumed = 0
+
+    try:
+        while True:
+            chunk = body.read(64 * 1024)
+            if not chunk:
+                if buffer:
+                    lines.append(buffer.decode('utf-8', errors='replace'))
+                    consumed += len(buffer)
+                return lines, start_offset + consumed
+
+            buffer += chunk
+            while b'\n' in buffer:
+                raw_line, buffer = buffer.split(b'\n', 1)
+                lines.append(raw_line.decode('utf-8', errors='replace'))
+                consumed += len(raw_line) + 1
+                if consumed >= max_bytes:
+                    return lines, start_offset + consumed
+    finally:
+        body.close()
 
 
 def stream_s3_object_lines(bucket: str, key: str) -> Iterable[str]:
@@ -226,6 +441,18 @@ def extract_ts(line: str, last_ts: str | float | None) -> float:
     return round(time.time(), 3)
 
 
+def timestamp_after_lines(
+    lines: Iterable[str],
+    initial_last_ts: float | None,
+) -> float | None:
+    """Return the timestamp state that must continue with the next chunk."""
+    last_ts = initial_last_ts
+    for line in lines:
+        if line:
+            last_ts = extract_ts(line, last_ts)
+    return last_ts
+
+
 def wrap_line(
     line: str,
     ts: float,
@@ -233,6 +460,7 @@ def wrap_line(
     key: str,
     tags: dict[str, str],
     metadata_fields: dict[str, Any] | None = None,
+    event_fields: dict[str, Any] | None = None,
 ) -> str:
     """
     Wrap a log line with metadata for Splunk/Kinesis ingestion.
@@ -242,6 +470,7 @@ def wrap_line(
         'AccountId': ACCOUNT_ID,
         **(metadata_fields or {}),
         **tags,
+        **(event_fields or {}),
     }
     event = {
         'event': line,
@@ -257,12 +486,101 @@ def wrap_line(
     return json.dumps(event) + '\n'
 
 
+def split_long_log_line(
+    line: str,
+    ts: float,
+    bucket: str,
+    key: str,
+    tags: dict[str, str],
+    metadata_fields: dict[str, Any] | None,
+    line_number: int,
+) -> list[bytes]:
+    """Split one oversized log line into UTF-8-safe HEC event payloads."""
+    event_id = partition_key_for_line(bucket, key, line_number)
+    original_line_bytes = len(line.encode('utf-8'))
+    placeholder_fields = {
+        'forge_event_id': event_id,
+        'chunked': 'true',
+        'chunk_index': 999999999,
+        'chunk_count': 999999999,
+        'original_line_bytes': original_line_bytes,
+    }
+    fragments: list[str] = []
+    start = 0
+
+    while start < len(line):
+        low = start + 1
+        high = len(line)
+        best_end = start
+        while low <= high:
+            candidate_end = (low + high) // 2
+            candidate = wrap_line(
+                line[start:candidate_end],
+                ts,
+                bucket,
+                key,
+                tags,
+                metadata_fields,
+                placeholder_fields,
+            ).encode('utf-8')
+            if len(candidate) <= LONG_LINE_RECORD_TARGET_BYTES:
+                best_end = candidate_end
+                low = candidate_end + 1
+            else:
+                high = candidate_end - 1
+
+        if best_end == start:
+            raise RuntimeError(
+                'Runner-log metadata exceeds the long-line record target'
+            )
+        fragments.append(line[start:best_end])
+        start = best_end
+
+    chunk_count = len(fragments)
+    payloads = []
+    for chunk_index, fragment in enumerate(fragments):
+        chunk_fields = {
+            'forge_event_id': event_id,
+            'chunked': 'true',
+            'chunk_index': chunk_index,
+            'chunk_count': chunk_count,
+            'original_line_bytes': original_line_bytes,
+        }
+        payload = wrap_line(
+            fragment,
+            ts,
+            bucket,
+            key,
+            tags,
+            metadata_fields,
+            chunk_fields,
+        ).encode('utf-8')
+        if len(payload) > MAX_KINESIS_RECORD_BYTES:
+            raise RuntimeError(
+                f'Long-line chunk exceeds Kinesis limit: {len(payload)} bytes'
+            )
+        payloads.append(payload)
+
+    LOG.info(
+        'long_line_split bucket=%s key=%s event_id=%s '
+        'original_bytes=%d chunks=%d',
+        bucket,
+        key,
+        event_id,
+        original_line_bytes,
+        chunk_count,
+    )
+    return payloads
+
+
 def ship_lines_to_kinesis(
     lines: Iterable[str],
     bucket: str,
     key: str,
     tags: dict[str, str],
     metadata_fields: dict[str, Any] | None = None,
+    line_number_start: int = 0,
+    initial_last_ts: float | None = None,
 ) -> int:
     """Batch lines into PutRecords requests respecting count & size limits."""
     buffer: list[tuple[bytes, int, str]] = []
@@ -326,32 +644,63 @@ def ship_lines_to_kinesis(
         buffer = []
         current_bytes = 0
 
-    last_ts: float | None = None
-    for line_number, line in enumerate(lines):
+    last_ts = initial_last_ts
+    for line_number, line in enumerate(lines, start=line_number_start):
         if not line:
             continue
         ts = extract_ts(line, last_ts)
         last_ts = ts
         payload = wrap_line(
             line, ts, bucket, key, tags, metadata_fields).encode('utf-8')
-        payload_len = len(payload)
-        if payload_len > 1000000:  # Guard insanely long lines
-            LOG.warning('line_too_large_skip size=%d', payload_len)
-            continue
-        if len(buffer) >= MAX_RECORDS_BATCH or (current_bytes + payload_len) >= MAX_BATCH_BYTES:
-            flush()
-        buffer.append((
-            payload,
-            payload_len,
-            partition_key_for_line(bucket, key, line_number),
-        ))
-        current_bytes += payload_len
+        if len(payload) > MAX_KINESIS_RECORD_BYTES:
+            if not key.endswith('.log'):
+                raise RuntimeError(
+                    'Oversized non-log runner event cannot be safely split'
+                )
+            payloads = split_long_log_line(
+                line,
+                ts,
+                bucket,
+                key,
+                tags,
+                metadata_fields,
+                line_number,
+            )
+        else:
+            payloads = [payload]
+
+        for chunk_index, chunk_payload in enumerate(payloads):
+            payload_len = len(chunk_payload)
+            batch_is_full = len(buffer) >= MAX_RECORDS_BATCH
+            batch_would_be_too_large = (
+                current_bytes + payload_len >= MAX_BATCH_BYTES
+            )
+            if batch_is_full or batch_would_be_too_large:
+                flush()
+            buffer.append((
+                chunk_payload,
+                payload_len,
+                partition_key_for_line(
+                    bucket,
+                    key,
+                    line_number,
+                    chunk_index if len(payloads) > 1 else None,
+                ),
+            ))
+            current_bytes += payload_len
 
     flush()
     return total_shipped
 
 
-def partition_key_for_line(bucket: str, key: str, line_number: int) -> str:
+def partition_key_for_line(
+    bucket: str,
+    key: str,
+    line_number: int,
+    chunk_index: int | None = None,
+) -> str:
     """Return a stable, high-cardinality Kinesis partition key."""
-    identity = f'{bucket}\0{key}\0{line_number}'.encode()
-    return hashlib.sha256(identity).hexdigest()
+    identity = f'{bucket}\0{key}\0{line_number}'
+    if chunk_index is not None:
+        identity = f'{identity}\0{chunk_index}'
+    return hashlib.sha256(identity.encode()).hexdigest()

--- a/modules/integrations/splunk_cloud_s3_runner_logs/sqs.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/sqs.tf
@@ -1,6 +1,6 @@
 resource "aws_sqs_queue" "log_events_queue" {
   name                       = "splunk-s3-runner-logs-events"
-  visibility_timeout_seconds = 900
+  visibility_timeout_seconds = local.lambda_timeout_seconds * 6
   message_retention_seconds  = 86400
   kms_master_key_id          = aws_kms_key.splunk_s3_runner_logs.arn
   redrive_policy = jsonencode({

--- a/modules/integrations/splunk_cloud_s3_runner_logs/tests/integrations_splunk_cloud_s3_runner_logs_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/tests/integrations_splunk_cloud_s3_runner_logs_interface_contract.tftest.hcl
@@ -14,6 +14,7 @@ run "integrations_splunk_cloud_s3_runner_logs_interface_contract" {
       "lambda_event_source_mapping_maximum_concurrency",
       "log_level",
       "logging_retention_in_days",
+      "runner_log_chunk_size_bytes",
       "splunk_hec_endpoint",
       "sqs_redrive_max_receive_count",
       "tags",
@@ -35,6 +36,9 @@ run "integrations_splunk_cloud_s3_runner_logs_interface_contract" {
       "description = \"Log retention period in days\"",
       "type        = number",
       "default     = 3",
+      "variable \"runner_log_chunk_size_bytes\"",
+      "description = \"Maximum bytes processed from a runner .log object before continuing from a line-aligned SQS checkpoint.\"",
+      "default     = 8388608",
       "variable \"lambda_event_source_mapping_maximum_concurrency\"",
       "description = \"Maximum concurrent Lambda invocations for the runner-log SQS event source mapping.\"",
       "default     = 40",
@@ -42,7 +46,7 @@ run "integrations_splunk_cloud_s3_runner_logs_interface_contract" {
       "description = \"Full URL of Splunk HEC endpoint\"",
       "variable \"sqs_redrive_max_receive_count\"",
       "description = \"Number of source-queue receives allowed before a runner-log message moves to the DLQ.\"",
-      "default     = 100",
+      "default     = 5",
       "variable \"tags\"",
     ]
   }
@@ -74,9 +78,9 @@ run "integrations_splunk_cloud_s3_runner_logs_interface_contract" {
 
   assert {
     condition = (
-      output.expected_input_variable_count == 9
+      output.expected_input_variable_count == 10
       && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 24
+      && output.expected_interface_literal_count == 27
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/integrations/splunk_cloud_s3_runner_logs/variables.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/variables.tf
@@ -30,6 +30,21 @@ variable "log_level" {
   default     = "INFO"
 }
 
+variable "runner_log_chunk_size_bytes" {
+  description = "Maximum bytes processed from a runner .log object before continuing from a line-aligned SQS checkpoint."
+  type        = number
+  default     = 8388608
+
+  validation {
+    condition = (
+      var.runner_log_chunk_size_bytes >= 1048576
+      && var.runner_log_chunk_size_bytes <= 268435456
+      && floor(var.runner_log_chunk_size_bytes) == var.runner_log_chunk_size_bytes
+    )
+    error_message = "runner_log_chunk_size_bytes must be an integer between 1 MiB and 256 MiB."
+  }
+}
+
 variable "lambda_event_source_mapping_maximum_concurrency" {
   description = "Maximum concurrent Lambda invocations for the runner-log SQS event source mapping."
   type        = number
@@ -48,7 +63,7 @@ variable "lambda_event_source_mapping_maximum_concurrency" {
 variable "sqs_redrive_max_receive_count" {
   description = "Number of source-queue receives allowed before a runner-log message moves to the DLQ."
   type        = number
-  default     = 100
+  default     = 5
 
   validation {
     condition = (

--- a/tests/iac/terraform_contract_test.py
+++ b/tests/iac/terraform_contract_test.py
@@ -522,6 +522,15 @@ def test_splunk_runner_logs_caps_parallel_sqs_scaling() -> None:
         in lambda_module
     )
     assert 'memory_size   = 1024' in lambda_module
+    assert 'lambda_timeout_seconds = 900' in lambda_tf
+    assert 'timeout       = local.lambda_timeout_seconds' in lambda_module
+    assert 'LOG_CHUNK_BYTES     = var.runner_log_chunk_size_bytes' in (
+        lambda_module
+    )
+    assert 'SQS_QUEUE_URL       = aws_sqs_queue.log_events_queue.url' in (
+        lambda_module
+    )
+    assert '"sqs:SendMessage"' in lambda_tf
     assert 'batch_size                         = 1' in event_source
     assert re.search(r'(?m)^\s*scaling_config\s*{', event_source)
     assert (
@@ -531,6 +540,10 @@ def test_splunk_runner_logs_caps_parallel_sqs_scaling() -> None:
     )
     assert (
         'maxReceiveCount     = var.sqs_redrive_max_receive_count'
+        in sqs_tf
+    )
+    assert (
+        'visibility_timeout_seconds = local.lambda_timeout_seconds * 6'
         in sqs_tf
     )
     assert 'reserved_concurrent_executions' not in lambda_module
@@ -556,6 +569,25 @@ def test_splunk_shared_extraction_classifies_runner_logs_redrive() -> None:
         '"FORMAT"     = "aws_region::$1 forgecicd_log_type::$2"'
         in transforms_tf
     )
+
+
+def test_splunk_runner_log_raw_chunks_are_not_truncated() -> None:
+    props_tf = read_repo_file(
+        'modules/integrations/splunk_cloud_conf_shared/'
+        'props_runner_logs.tf'
+    )
+    runner_logs_props = hcl_block(
+        props_tf,
+        'resource',
+        'splunk_configs_conf',
+        'forgecicd_runner_logs_logs',
+    )
+
+    assert re.search(
+        r'(?m)^\s*"TRUNCATE"\s*=\s*"1000000"$',
+        runner_logs_props,
+    )
+    assert 'variables["TRUNCATE"]' not in runner_logs_props
 
 
 def test_forge_subscription_ecr_cross_product_uses_region_provider_alias() -> None:

--- a/tests/lambdas/splunk_s3_runner_logs_test.py
+++ b/tests/lambdas/splunk_s3_runner_logs_test.py
@@ -13,6 +13,10 @@ FIXTURES_DIR = Path(__file__).with_name('fixtures')
 
 def _load_splunk(monkeypatch):
     monkeypatch.setenv('KINESIS_STREAM_NAME', 'splunk-runner-logs-test')
+    monkeypatch.setenv(
+        'SQS_QUEUE_URL',
+        'https://sqs.us-west-2.amazonaws.com/123456789012/runner-logs',
+    )
     return load_handler_module('splunk_s3_runner_logs')
 
 
@@ -268,26 +272,244 @@ def test_ship_lines_raises_when_kinesis_retries_are_exhausted(
     assert 'shardId-000' in caplog.text
 
 
-def test_ship_lines_skips_oversized_payload(monkeypatch, aws):
+def test_ship_lines_splits_oversized_log_line(monkeypatch, aws):
     mod = _load_splunk(monkeypatch)
-    calls = []
+    records = []
 
     class _Kinesis:
         def put_records(self, **kwargs):
-            calls.append(kwargs)
-            return {'FailedRecordCount': 0, 'Records': []}
+            records.extend(kwargs['Records'])
+            return {
+                'FailedRecordCount': 0,
+                'Records': [{} for _record in kwargs['Records']],
+            }
 
     monkeypatch.setattr(mod, 'kinesis_client', _Kinesis())
+    monkeypatch.setattr(mod, 'MAX_KINESIS_RECORD_BYTES', 1000)
+    monkeypatch.setattr(mod, 'LONG_LINE_RECORD_TARGET_BYTES', 800)
 
+    line = 'x' * 2000
     shipped = mod.ship_lines_to_kinesis(
-        ['x' * 1_000_000],
+        [line],
+        'forge-gh-logs',
+        'acme/app/99/1/4242.log',
+        {'chunked': 'overridden-by-internal-field'},
+    )
+
+    events = [json.loads(record['Data'].decode()) for record in records]
+    event_ids = {event['fields']['forge_event_id'] for event in events}
+    partition_keys = [record['PartitionKey'] for record in records]
+
+    assert shipped == len(records)
+    assert len(records) > 1
+    assert ''.join(event['event'] for event in events) == line
+    assert len(event_ids) == 1
+    assert partition_keys == [
+        mod.partition_key_for_line(
+            'forge-gh-logs',
+            'acme/app/99/1/4242.log',
+            0,
+            chunk_index,
+        )
+        for chunk_index in range(len(records))
+    ]
+    assert len(partition_keys) == len(set(partition_keys))
+    assert all(len(record['Data']) <= 800 for record in records)
+    assert [
+        event['fields']['chunk_index'] for event in events
+    ] == list(range(len(events)))
+    assert all(
+        all((
+            event['fields']['chunked'] == 'true',
+            event['fields']['chunk_count'] == len(events),
+            event['fields']['original_line_bytes'] == len(line.encode()),
+        ))
+        for event in events
+    )
+
+
+def test_ship_lines_splits_unicode_without_corrupting_raw_event(
+    monkeypatch, aws
+):
+    mod = _load_splunk(monkeypatch)
+    records = []
+
+    class _Kinesis:
+        def put_records(self, **kwargs):
+            records.extend(kwargs['Records'])
+            return {
+                'FailedRecordCount': 0,
+                'Records': [{} for _record in kwargs['Records']],
+            }
+
+    monkeypatch.setattr(mod, 'kinesis_client', _Kinesis())
+    monkeypatch.setattr(mod, 'MAX_KINESIS_RECORD_BYTES', 1000)
+    monkeypatch.setattr(mod, 'LONG_LINE_RECORD_TARGET_BYTES', 800)
+
+    line = '🙂\\"' * 500
+    shipped = mod.ship_lines_to_kinesis(
+        [line],
         'forge-gh-logs',
         'acme/app/99/1/4242.log',
         {},
     )
 
-    assert shipped == 0
-    assert calls == []
+    events = [json.loads(record['Data'].decode()) for record in records]
+
+    assert shipped == len(records)
+    assert len(records) > 1
+    assert ''.join(event['event'] for event in events) == line
+    assert all(len(record['Data']) <= 800 for record in records)
+    assert all(
+        event['fields']['original_line_bytes'] == len(line.encode('utf-8'))
+        for event in events
+    )
+
+
+def test_read_s3_object_line_chunk_preserves_line_boundaries(
+    monkeypatch, s3_kms
+):
+    mod = _load_splunk(monkeypatch)
+    bucket = s3_kms['buckets']['alpha']
+    key = 'acme/app/99/1/line-boundaries.log'
+    payload = b'one\ntwo-long\nthree'
+    s3_kms['s3'].put_object(Bucket=bucket, Key=key, Body=payload)
+
+    first_lines, first_offset = mod.read_s3_object_line_chunk(
+        bucket,
+        key,
+        0,
+        5,
+    )
+    second_lines, final_offset = mod.read_s3_object_line_chunk(
+        bucket,
+        key,
+        first_offset,
+        5,
+    )
+
+    assert first_lines == ['one', 'two-long']
+    assert first_offset == len(b'one\ntwo-long\n')
+    assert second_lines == ['three']
+    assert final_offset == len(payload)
+
+
+def test_lambda_handler_checkpoints_large_log_after_successful_chunk(
+    monkeypatch, s3_kms
+):
+    mod = _load_splunk(monkeypatch)
+    bucket = s3_kms['buckets']['alpha']
+    key = 'acme/app/99/1/checkpoint.log'
+    payload = (
+        b'2026-07-03T22:26:04.000Z one\n'
+        b'continued second\n'
+        b'continued third\n'
+    )
+    kinesis_events = []
+    kinesis_timestamps = []
+    checkpoint_messages = []
+
+    class _Kinesis:
+        def put_records(self, **kwargs):
+            for record in kwargs['Records']:
+                event = json.loads(record['Data'].decode())
+                kinesis_events.append(event['event'])
+                kinesis_timestamps.append(event['time'])
+            return {
+                'FailedRecordCount': 0,
+                'Records': [{} for _record in kwargs['Records']],
+            }
+
+    class _SQS:
+        def send_message(self, **kwargs):
+            checkpoint_messages.append(json.loads(kwargs['MessageBody']))
+            return {'MessageId': 'checkpoint-1'}
+
+    monkeypatch.setattr(mod, 'kinesis_client', _Kinesis())
+    monkeypatch.setattr(mod, 'sqs_client', _SQS())
+    monkeypatch.setattr(mod, 'LOG_CHUNK_BYTES', 10)
+    s3_kms['s3'].put_object(Bucket=bucket, Key=key, Body=payload)
+
+    initial_event = {
+        'Records': [{
+            'body': json.dumps({
+                'Records': [{
+                    's3': {
+                        'bucket': {'name': bucket},
+                        'object': {'key': key, 'size': len(payload)},
+                    },
+                }],
+            }),
+        }],
+    }
+
+    initial_result = mod.lambda_handler(initial_event, None)
+
+    assert json.loads(initial_result['body']) == {'lines': 1}
+    assert kinesis_events == ['2026-07-03T22:26:04.000Z one']
+    assert len(checkpoint_messages) == 1
+    checkpoint = checkpoint_messages.pop()
+    checkpoint_data = checkpoint[mod.CHECKPOINT_FIELD]
+    assert checkpoint_data == {
+        'version': 1,
+        'bucket': bucket,
+        'key': key,
+        'offset': len(b'2026-07-03T22:26:04.000Z one\n'),
+        'object_size': len(payload),
+        'last_timestamp': 1783117564.0,
+    }
+
+    continuation_lines = 0
+    while True:
+        continuation_result = mod.lambda_handler(
+            {'Records': [{'body': json.dumps(checkpoint)}]},
+            None,
+        )
+        continuation_lines += json.loads(continuation_result['body'])['lines']
+        if not checkpoint_messages:
+            break
+        checkpoint = checkpoint_messages.pop()
+
+    assert continuation_lines == 2
+    assert kinesis_events == [
+        '2026-07-03T22:26:04.000Z one',
+        'continued second',
+        'continued third',
+    ]
+    assert kinesis_timestamps == [1783117564.0] * 3
+    assert checkpoint_messages == []
+
+
+def test_process_s3_object_does_not_checkpoint_failed_chunk(
+    monkeypatch, s3_kms
+):
+    mod = _load_splunk(monkeypatch)
+    bucket = s3_kms['buckets']['alpha']
+    key = 'acme/app/99/1/failed-chunk.log'
+    payload = b'first line\nsecond line\n'
+    checkpoint_messages = []
+
+    class _SQS:
+        def send_message(self, **kwargs):
+            checkpoint_messages.append(kwargs)
+            return {'MessageId': 'unexpected'}
+
+    def _fail_shipping(*_args, **_kwargs):
+        raise RuntimeError('Kinesis unavailable')
+
+    monkeypatch.setattr(mod, 'sqs_client', _SQS())
+    monkeypatch.setattr(mod, 'ship_lines_to_kinesis', _fail_shipping)
+    monkeypatch.setattr(mod, 'LOG_CHUNK_BYTES', 5)
+    s3_kms['s3'].put_object(Bucket=bucket, Key=key, Body=payload)
+
+    with pytest.raises(RuntimeError, match='Kinesis unavailable'):
+        mod.process_s3_object(
+            bucket,
+            key,
+            object_size=len(payload),
+        )
+
+    assert checkpoint_messages == []
 
 
 def test_lambda_handler_streams_log_lines_with_sidecar_fields(


### PR DESCRIPTION
## Description

Fixes sustained runner-log queue age caused by Lambda invocations processing complete large S3 log objects and timing out before acknowledging their SQS messages.

- Process `.log` objects in line-aligned 8 MiB chunks and enqueue a continuation checkpoint only after successful Kinesis delivery.
- Split oversized individual log lines into UTF-8-safe HEC events targeting 750 KiB instead of silently dropping them.
- Add stable chunk metadata for search and reconstruction: `forge_event_id`, `chunked`, `chunk_index`, `chunk_count`, and `original_line_bytes`.
- Keep the Lambda timeout at 15 minutes, set SQS visibility to six times that timeout, and reduce the default DLQ receive threshold from 100 to 5.
- Set `TRUNCATE=1000000` only for `forgecicd:runner-logs:logs` so Splunk retains the bounded raw fragments. Small events and runner-log JSON events are unchanged.

Delivery remains at least once. If Kinesis accepts a chunk but its continuation message cannot be sent, the current chunk can be replayed; stable event and chunk identifiers allow deduplication.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `.venv/bin/pytest -q tests/lambdas/splunk_s3_runner_logs_test.py tests/iac/terraform_contract_test.py -k 'splunk_s3_runner_logs or splunk_runner_logs or splunk_runner_log_raw_chunks'` — 19 passed
- `tofu test` in `modules/integrations/splunk_cloud_s3_runner_logs` — 2 passed
- `tofu test` in `modules/integrations/splunk_cloud_conf_shared` — 4 passed
- `tofu validate` for both affected modules
- Pre-commit hooks, Python lint/compile, OpenTofu formatting, and diff checks passed
