### PR TITLE
feat(observability): add runner log tuning health gates

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
@@ -83,7 +83,7 @@ resource "signalfx_single_value_chart" "lambda_duration_guardrail" {
 
 resource "signalfx_single_value_chart" "lambda_errors" {
   name         = "Runner-log Lambda errors/timeouts - sum(30m)"
-  description  = "Lambda Errors includes invocation timeouts. Use the manual Splunk validation runbook on this dashboard to distinguish timeout-only failures."
+  description  = "Lambda Errors includes invocation timeouts."
   program_text = "A = data('Errors', filter=(${local.aws_platform_filter}) and (${local.lambda_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='30m').sum().publish(label='A')"
   color_by     = "Dimension"
 
@@ -337,30 +337,6 @@ EOF
   }
 }
 
-resource "signalfx_text_chart" "tuning_validation" {
-  name        = "Runner-log tuning validation runbook"
-  description = "Manual acceptance checks that complement the live runner-log health panels."
-
-  markdown = <<-EOF
-## Manual tuning validation
-
-- **Duration:** maximum stays below 6 minutes where possible and below 8 minutes as the guardrail. The AWS metric exposes mean/max, not native p99.
-- **Timeouts:** the live Lambda errors/timeouts panel remains zero. Manually confirm timeout-only failures in Splunk with `REPORT RequestId Status: timeout`.
-- **Checkpoint replay:** manually run the following Splunk search; it must return no rows:
-
-```
-index="srea-forge-prod-index" source="*splunk-s3-runner-logs-lambda*" "processing_object" "offset="
-| rex "bucket=(?<bucket>\\S+) key=(?<key>\\S+).*offset=(?<offset>\\d+)"
-| where like(key, "%.log")
-| stats count AS attempts values(source) AS sources BY bucket key offset
-| where attempts > 1
-```
-
-- **Kinesis:** read and write throughput-exceeded panels remain zero.
-- **Queue recovery:** oldest-message age shows a sustained downward trend over the six-hour panel.
-EOF
-}
-
 resource "terraform_data" "dashboard_parent" {
   triggers_replace = var.dashboard_group
 }
@@ -510,12 +486,5 @@ resource "signalfx_dashboard" "runner_logs_ingestion" {
     column   = 0
     width    = 12
     height   = 1
-  }
-  chart {
-    chart_id = signalfx_text_chart.tuning_validation.id
-    row      = 6
-    column   = 0
-    width    = 12
-    height   = 2
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
@@ -53,13 +53,42 @@ resource "signalfx_single_value_chart" "oldest_message" {
   }
 }
 
+resource "signalfx_single_value_chart" "lambda_duration_guardrail" {
+  name                    = "Runner-log Lambda duration guardrail"
+  description             = "Maximum duration over 30 minutes. This is a conservative guardrail for the 6-8 minute target because the AWS integration does not expose a native p99 statistic."
+  program_text            = "A = data('Duration', filter=(${local.aws_platform_filter}) and (${local.lambda_filter}) and filter('stat', 'upper'), rollup='max').max(over='30m').max().publish(label='A')"
+  color_by                = "Scale"
+  secondary_visualization = "Sparkline"
+
+  color_scale {
+    color = "green"
+    lt    = 360000
+  }
+  color_scale {
+    color = "orange"
+    gte   = 360000
+    lt    = 480000
+  }
+  color_scale {
+    color = "red"
+    gte   = 480000
+  }
+
+  viz_options {
+    display_name = "Maximum duration"
+    label        = "A"
+    value_unit   = "Millisecond"
+  }
+}
+
 resource "signalfx_single_value_chart" "lambda_errors" {
-  name         = "Runner-log Lambda errors - sum(30m)"
+  name         = "Runner-log Lambda errors/timeouts - sum(30m)"
+  description  = "Lambda Errors includes invocation timeouts. Use the manual Splunk validation runbook on this dashboard to distinguish timeout-only failures."
   program_text = "A = data('Errors', filter=(${local.aws_platform_filter}) and (${local.lambda_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='30m').sum().publish(label='A')"
   color_by     = "Dimension"
 
   viz_options {
-    display_name = "Lambda errors"
+    display_name = "Lambda errors/timeouts"
     label        = "A"
   }
 }
@@ -154,14 +183,22 @@ resource "signalfx_time_chart" "lambda_concurrency" {
 
 resource "signalfx_time_chart" "lambda_duration" {
   name         = "Runner-log Lambda duration"
-  description  = "Average runner-log Lambda execution duration by AWS region."
-  program_text = "A = data('Duration', filter=(${local.aws_platform_filter}) and (${local.lambda_filter}) and filter('stat', 'mean'), rollup='average').mean(over='5m').mean(by=['aws_region', 'aws_function_name']).publish(label='A')"
+  description  = "Mean and maximum runner-log Lambda execution duration by AWS region. Keep maximum below 6 minutes where possible and below 8 minutes as the operational guardrail."
+  program_text = <<-EOF
+average = data('Duration', filter=(${local.aws_platform_filter}) and (${local.lambda_filter}) and filter('stat', 'mean'), rollup='average').mean(over='5m').mean(by=['aws_region', 'aws_function_name']).publish(label='A')
+maximum = data('Duration', filter=(${local.aws_platform_filter}) and (${local.lambda_filter}) and filter('stat', 'upper'), rollup='max').max(over='5m').max(by=['aws_region', 'aws_function_name']).publish(label='B')
+EOF
   plot_type    = "LineChart"
-  time_range   = 3600
+  time_range   = 21600
 
   viz_options {
     display_name = "Average duration"
     label        = "A"
+    value_unit   = "Millisecond"
+  }
+  viz_options {
+    display_name = "Maximum duration"
+    label        = "B"
     value_unit   = "Millisecond"
   }
 }
@@ -243,6 +280,20 @@ resource "signalfx_time_chart" "kinesis_iterator_age" {
   }
 }
 
+resource "signalfx_time_chart" "oldest_message_trend" {
+  name         = "Runner-log oldest message age - 6h trend"
+  description  = "Maximum source-queue message age by AWS region. After tuning, the sustained trend should decline rather than repeatedly reset and grow."
+  program_text = "A = data('ApproximateAgeOfOldestMessage', filter=(${local.aws_platform_filter}) and (${local.queue_filter}) and filter('stat', 'upper'), rollup='max').max(over='5m').max(by=['aws_region']).publish(label='A')"
+  plot_type    = "LineChart"
+  time_range   = 21600
+
+  viz_options {
+    display_name = "Oldest message age"
+    label        = "A"
+    value_unit   = "Second"
+  }
+}
+
 resource "signalfx_time_chart" "firehose_delivery" {
   name             = "Runner-log delivery to Splunk"
   description      = "Records delivered successfully to Splunk per five minutes."
@@ -284,6 +335,30 @@ EOF
     label        = "B"
     value_unit   = "Second"
   }
+}
+
+resource "signalfx_text_chart" "tuning_validation" {
+  name        = "Runner-log tuning validation runbook"
+  description = "Manual acceptance checks that complement the live runner-log health panels."
+
+  markdown = <<-EOF
+## Manual tuning validation
+
+- **Duration:** maximum stays below 6 minutes where possible and below 8 minutes as the guardrail. The AWS metric exposes mean/max, not native p99.
+- **Timeouts:** the live Lambda errors/timeouts panel remains zero. Manually confirm timeout-only failures in Splunk with `REPORT RequestId Status: timeout`.
+- **Checkpoint replay:** manually run the following Splunk search; it must return no rows:
+
+```
+index="srea-forge-prod-index" source="*splunk-s3-runner-logs-lambda*" "processing_object" "offset="
+| rex "bucket=(?<bucket>\\S+) key=(?<key>\\S+).*offset=(?<offset>\\d+)"
+| where like(key, "%.log")
+| stats count AS attempts values(source) AS sources BY bucket key offset
+| where attempts > 1
+```
+
+- **Kinesis:** read and write throughput-exceeded panels remain zero.
+- **Queue recovery:** oldest-message age shows a sustained downward trend over the six-hour panel.
+EOF
 }
 
 resource "terraform_data" "dashboard_parent" {
@@ -332,24 +407,31 @@ resource "signalfx_dashboard" "runner_logs_ingestion" {
     height   = 1
   }
   chart {
-    chart_id = signalfx_single_value_chart.lambda_errors.id
+    chart_id = signalfx_single_value_chart.lambda_duration_guardrail.id
     row      = 0
     column   = 4
     width    = 2
     height   = 1
   }
   chart {
-    chart_id = signalfx_single_value_chart.kinesis_throttles.id
+    chart_id = signalfx_single_value_chart.lambda_errors.id
     row      = 0
     column   = 6
-    width    = 3
+    width    = 2
+    height   = 1
+  }
+  chart {
+    chart_id = signalfx_single_value_chart.kinesis_throttles.id
+    row      = 0
+    column   = 8
+    width    = 2
     height   = 1
   }
   chart {
     chart_id = signalfx_single_value_chart.firehose_freshness.id
     row      = 0
-    column   = 9
-    width    = 3
+    column   = 10
+    width    = 2
     height   = 1
   }
   chart {
@@ -421,5 +503,19 @@ resource "signalfx_dashboard" "runner_logs_ingestion" {
     column   = 6
     width    = 6
     height   = 1
+  }
+  chart {
+    chart_id = signalfx_time_chart.oldest_message_trend.id
+    row      = 5
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+  chart {
+    chart_id = signalfx_text_chart.tuning_validation.id
+    row      = 6
+    column   = 0
+    width    = 12
+    height   = 2
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
@@ -9,6 +9,11 @@ mock_provider "signalfx" {
       id = "time-chart-id"
     }
   }
+  mock_resource "signalfx_text_chart" {
+    defaults = {
+      id = "text-chart-id"
+    }
+  }
   mock_resource "signalfx_dashboard" {}
 }
 
@@ -52,10 +57,10 @@ run "creates_runner_logs_ingestion_dashboard" {
     condition = (
       signalfx_dashboard.runner_logs_ingestion.name == "Forge Runner Logs Ingestion"
       && signalfx_dashboard.runner_logs_ingestion.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.runner_logs_ingestion.chart) == 15
+      && length(signalfx_dashboard.runner_logs_ingestion.chart) == 18
       && length(signalfx_dashboard.runner_logs_ingestion.variable) == 3
     )
-    error_message = "The runner-log ingestion dashboard must keep its name, parent group, fifteen panels, and dedicated variables."
+    error_message = "The runner-log ingestion dashboard must keep its name, parent group, eighteen panels, and dedicated variables."
   }
 
   assert {
@@ -63,6 +68,7 @@ run "creates_runner_logs_ingestion_dashboard" {
       for program_text in [
         signalfx_single_value_chart.visible_backlog.program_text,
         signalfx_single_value_chart.oldest_message.program_text,
+        signalfx_single_value_chart.lambda_duration_guardrail.program_text,
         signalfx_single_value_chart.lambda_errors.program_text,
         signalfx_single_value_chart.kinesis_throttles.program_text,
         signalfx_single_value_chart.firehose_freshness.program_text,
@@ -74,6 +80,7 @@ run "creates_runner_logs_ingestion_dashboard" {
         signalfx_time_chart.kinesis_records.program_text,
         signalfx_time_chart.kinesis_throughput.program_text,
         signalfx_time_chart.kinesis_iterator_age.program_text,
+        signalfx_time_chart.oldest_message_trend.program_text,
         signalfx_time_chart.firehose_delivery.program_text,
         signalfx_time_chart.firehose_latency.program_text,
       ] :
@@ -92,13 +99,23 @@ run "creates_runner_logs_ingestion_dashboard" {
       strcontains(signalfx_time_chart.sqs_state.program_text, "splunk-s3-runner-logs-events")
       && strcontains(signalfx_time_chart.sqs_state.program_text, "splunk-s3-runner-logs-events-dlq")
       && strcontains(signalfx_time_chart.lambda_concurrency.program_text, "ConcurrentExecutions")
-      && strcontains(signalfx_time_chart.lambda_duration.program_text, "Duration")
+      && strcontains(signalfx_single_value_chart.lambda_duration_guardrail.program_text, "max(over='30m')")
+      && strcontains(signalfx_time_chart.lambda_duration.program_text, "filter('stat', 'mean')")
+      && strcontains(signalfx_time_chart.lambda_duration.program_text, "filter('stat', 'upper')")
+      && signalfx_time_chart.lambda_duration.time_range == 21600
+      && strcontains(signalfx_single_value_chart.lambda_errors.description, "timeouts")
       && strcontains(signalfx_time_chart.kinesis_throughput.program_text, "WriteProvisionedThroughputExceeded")
       && strcontains(signalfx_time_chart.kinesis_iterator_age.program_text, "GetRecords.IteratorAgeMilliseconds")
+      && strcontains(signalfx_time_chart.oldest_message_trend.program_text, "ApproximateAgeOfOldestMessage")
+      && signalfx_time_chart.oldest_message_trend.time_range == 21600
       && strcontains(signalfx_time_chart.firehose_delivery.program_text, "DeliveryToSplunk.Records")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataFreshness")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataAckLatency")
+      && strcontains(signalfx_text_chart.tuning_validation.markdown, "attempts > 1")
+      && strcontains(signalfx_text_chart.tuning_validation.markdown, "like(key, \"%.log\")")
+      && strcontains(signalfx_text_chart.tuning_validation.markdown, "BY bucket key offset")
+      && strcontains(signalfx_text_chart.tuning_validation.markdown, "REPORT RequestId Status: timeout")
     )
-    error_message = "The dashboard must preserve the SQS, Lambda, Kinesis, and Splunk delivery health signals."
+    error_message = "The dashboard must preserve the SQS, Lambda, Kinesis, Splunk delivery, and tuning validation signals."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
@@ -9,11 +9,6 @@ mock_provider "signalfx" {
       id = "time-chart-id"
     }
   }
-  mock_resource "signalfx_text_chart" {
-    defaults = {
-      id = "text-chart-id"
-    }
-  }
   mock_resource "signalfx_dashboard" {}
 }
 
@@ -57,10 +52,10 @@ run "creates_runner_logs_ingestion_dashboard" {
     condition = (
       signalfx_dashboard.runner_logs_ingestion.name == "Forge Runner Logs Ingestion"
       && signalfx_dashboard.runner_logs_ingestion.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.runner_logs_ingestion.chart) == 18
+      && length(signalfx_dashboard.runner_logs_ingestion.chart) == 17
       && length(signalfx_dashboard.runner_logs_ingestion.variable) == 3
     )
-    error_message = "The runner-log ingestion dashboard must keep its name, parent group, eighteen panels, and dedicated variables."
+    error_message = "The runner-log ingestion dashboard must keep its name, parent group, seventeen panels, and dedicated variables."
   }
 
   assert {
@@ -111,10 +106,6 @@ run "creates_runner_logs_ingestion_dashboard" {
       && strcontains(signalfx_time_chart.firehose_delivery.program_text, "DeliveryToSplunk.Records")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataFreshness")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataAckLatency")
-      && strcontains(signalfx_text_chart.tuning_validation.markdown, "attempts > 1")
-      && strcontains(signalfx_text_chart.tuning_validation.markdown, "like(key, \"%.log\")")
-      && strcontains(signalfx_text_chart.tuning_validation.markdown, "BY bucket key offset")
-      && strcontains(signalfx_text_chart.tuning_validation.markdown, "REPORT RequestId Status: timeout")
     )
     error_message = "The dashboard must preserve the SQS, Lambda, Kinesis, Splunk delivery, and tuning validation signals."
   }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_source_inventory.tftest.hcl
@@ -9,7 +9,13 @@ run "runner_logs_ingestion_dashboard_source_inventory" {
     module_path = "."
     expected_literals = [
       "resource \"signalfx_dashboard\" \"runner_logs_ingestion\"",
+      "resource \"signalfx_text_chart\" \"tuning_validation\"",
       "Forge Runner Logs Ingestion",
+      "Runner-log Lambda duration guardrail",
+      "Runner-log oldest message age - 6h trend",
+      "REPORT RequestId Status: timeout",
+      "BY bucket key offset",
+      "attempts > 1",
       "resource \"terraform_data\" \"dashboard_parent\"",
       "terraform_data.dashboard_parent,",
       "not filter('aws_tag_TenantName', '*')",

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_source_inventory.tftest.hcl
@@ -9,13 +9,9 @@ run "runner_logs_ingestion_dashboard_source_inventory" {
     module_path = "."
     expected_literals = [
       "resource \"signalfx_dashboard\" \"runner_logs_ingestion\"",
-      "resource \"signalfx_text_chart\" \"tuning_validation\"",
       "Forge Runner Logs Ingestion",
       "Runner-log Lambda duration guardrail",
       "Runner-log oldest message age - 6h trend",
-      "REPORT RequestId Status: timeout",
-      "BY bucket key offset",
-      "attempts > 1",
       "resource \"terraform_data\" \"dashboard_parent\"",
       "terraform_data.dashboard_parent,",
       "not filter('aws_tag_TenantName', '*')",

--- a/modules/integrations/splunk_o11y_conf_shared/tests/splunk_o11y_conf_shared_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/tests/splunk_o11y_conf_shared_behavior.tftest.hcl
@@ -23,7 +23,6 @@ mock_provider "signalfx" {
   mock_resource "signalfx_detector" {}
   mock_resource "signalfx_list_chart" {}
   mock_resource "signalfx_single_value_chart" {}
-  mock_resource "signalfx_text_chart" {}
   mock_resource "signalfx_time_chart" {}
 }
 

--- a/modules/integrations/splunk_o11y_conf_shared/tests/splunk_o11y_conf_shared_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/tests/splunk_o11y_conf_shared_behavior.tftest.hcl
@@ -23,6 +23,7 @@ mock_provider "signalfx" {
   mock_resource "signalfx_detector" {}
   mock_resource "signalfx_list_chart" {}
   mock_resource "signalfx_single_value_chart" {}
+  mock_resource "signalfx_text_chart" {}
   mock_resource "signalfx_time_chart" {}
 }
 


### PR DESCRIPTION
## Description

Adds tuning health gates to the `Forge Runner Logs Ingestion` dashboard so chunk-size and concurrency changes can be validated from one operational view.

- Adds a color-coded Lambda maximum-duration guardrail: green below 6 minutes, warning from 6 to 8 minutes, and critical at or above 8 minutes.
- Expands Lambda duration and oldest-message-age trends to six hours.
- Labels Lambda errors as including invocation timeouts.
- Keeps the existing Kinesis read/write throttle panels as the zero-throttle acceptance gate.

The AWS integration exposes mean and maximum Lambda duration statistics, not native p99, so the dashboard uses maximum as the conservative operational proxy.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu validate` in `dashboards/runner_logs_ingestion`
- Runner-log dashboard behavior, interface-contract, and source-inventory tests: 3 passed
- Parent `splunk_o11y_conf_shared` behavior test: 1 passed
- Repository pre-commit checks completed successfully during commit
