### PR TITLE
test(observability): guard billing dashboard time range

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/billing_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/billing_dashboard_behavior.tftest.hcl
@@ -38,9 +38,10 @@ run "billing_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.billing.name == "Forge Billing and Cost - AWS"
       && signalfx_dashboard.billing.dashboard_group == "forge-dashboard-group"
+      && signalfx_dashboard.billing.time_range == "-31d"
       && length(signalfx_dashboard.billing.chart) == 8
     )
-    error_message = "Billing dashboard must keep its name, group input, and chart count."
+    error_message = "Billing dashboard must keep its name, group input, 31-day default time range, and chart count."
   }
 
   assert {


### PR DESCRIPTION
## Description

Adds a regression assertion that the **Forge Billing and Cost - AWS** dashboard keeps its existing `-31d` default time range.

This protects the 31-day billing view from silently reverting during future dashboard changes. There is no runtime dashboard change because the dashboard is already configured correctly.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Test coverage

## Testing

- Repository pre-commit hooks passed, including Terraform/OpenTofu formatting, validation, linting, and security checks.
- Billing interface-contract test passed.
- Billing source-inventory test passed.
- The direct behavior test could not instantiate `splunk-terraform/signalfx` v9.33.0 because the local provider process failed its plugin protocol handshake; the affected wiring run was skipped.
