### PR TITLE
feat(billing): attribute shared module costs

### DIFF
--- a/modules/helpers/ami_policy/service_catalog.tf
+++ b/modules/helpers/ami_policy/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_ami_policy_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/helpers/ami_policy/tags.tf
+++ b/modules/helpers/ami_policy/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/helpers/ami_sharing/service_catalog.tf
+++ b/modules/helpers/ami_sharing/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_ami_sharing_${var.aws_region}"
+  tags = var.default_tags
+}

--- a/modules/helpers/aws_config_recording/service_catalog.tf
+++ b/modules/helpers/aws_config_recording/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_aws_config_recording_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/helpers/aws_config_recording/tags.tf
+++ b/modules/helpers/aws_config_recording/tags.tf
@@ -1,5 +1,9 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
-  iam_role_name     = coalesce(var.iam_role_name, "forge-aws-config-recorder-${var.aws_region}")
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
+  iam_role_name = coalesce(var.iam_role_name, "forge-aws-config-recorder-${var.aws_region}")
 }

--- a/modules/helpers/cloud_custodian/service_catalog.tf
+++ b/modules/helpers/cloud_custodian/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_cloud_custodian_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/helpers/cloud_custodian/tags.tf
+++ b/modules/helpers/cloud_custodian/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/helpers/cloud_formation/service_catalog.tf
+++ b/modules/helpers/cloud_formation/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_cloud_formation_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/helpers/cloud_formation/tags.tf
+++ b/modules/helpers/cloud_formation/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/helpers/dedicated_mac_hosts/service_catalog.tf
+++ b/modules/helpers/dedicated_mac_hosts/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_dedicated_mac_hosts_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/helpers/dedicated_mac_hosts/tags.tf
+++ b/modules/helpers/dedicated_mac_hosts/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/helpers/ecr/service_catalog.tf
+++ b/modules/helpers/ecr/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_ecr_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/helpers/ecr/tags.tf
+++ b/modules/helpers/ecr/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/helpers/forge_subscription/service_catalog.tf
+++ b/modules/helpers/forge_subscription/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_forge_subscription_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/helpers/forge_subscription/tags.tf
+++ b/modules/helpers/forge_subscription/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/helpers/opt_in_regions/service_catalog.tf
+++ b/modules/helpers/opt_in_regions/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_opt_in_regions_${var.aws_region}"
+  tags = var.default_tags
+}

--- a/modules/helpers/service_linked_roles/service_catalog.tf
+++ b/modules/helpers/service_linked_roles/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_service_linked_roles_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/helpers/service_linked_roles/tags.tf
+++ b/modules/helpers/service_linked_roles/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/helpers/storage/service_catalog.tf
+++ b/modules/helpers/storage/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "helpers_storage_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/helpers/storage/tags.tf
+++ b/modules/helpers/storage/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/infra/eks/service_catalog.tf
+++ b/modules/infra/eks/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "infra_eks_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/infra/eks/tags.tf
+++ b/modules/infra/eks/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/integrations/github_webhook_relay_destination/service_catalog.tf
+++ b/modules/integrations/github_webhook_relay_destination/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_github_webhook_relay_destination_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/github_webhook_relay_destination/tags.tf
+++ b/modules/integrations/github_webhook_relay_destination/tags.tf
@@ -3,5 +3,6 @@ locals {
   all_security_tags = merge(
     var.default_tags,
     var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
   )
 }

--- a/modules/integrations/github_webhook_relay_destination_receivers/main.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/main.tf
@@ -31,6 +31,6 @@ module "webhook_relay_destination" {
     targets                    = local.targets
   }
 
-  tags         = var.tags
+  tags         = local.module_tags
   default_tags = var.default_tags
 }

--- a/modules/integrations/github_webhook_relay_destination_receivers/service_catalog.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/service_catalog.tf
@@ -1,0 +1,11 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_github_webhook_relay_destination_receivers_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}
+
+locals {
+  module_tags = merge(
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
+}

--- a/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay.tf
+++ b/modules/integrations/github_webhook_relay_destination_receivers/webex_webhook_relay.tf
@@ -23,6 +23,6 @@ module "webex_webhook_relay" {
   logging_retention_in_days = var.logging_retention_in_days
   log_level                 = var.log_level
   aws_region                = var.aws_region
-  tags                      = var.tags
+  tags                      = local.module_tags
   default_tags              = var.default_tags
 }

--- a/modules/integrations/splunk_aws_billing/README.md
+++ b/modules/integrations/splunk_aws_billing/README.md
@@ -17,6 +17,8 @@ Forge needs tenant-level cost visibility to make runner-size, warm-pool, and EC2
 
 - Billing data is delayed by AWS, so dashboards should not be treated as real-time usage telemetry.
 - Resource tags and runner metadata determine how useful tenant attribution will be.
+- Billing rows are accepted only when `user_aws_application` is a complete Forge tenant or module AppRegistry resource-group ARN; unsupported values are skipped.
+- Non-tenant module costs are emitted with `forgecicd_scope=module`, `forgecicd_module_group`, and `forgecicd_module` dimensions.
 - Keep S3 retention and access aligned with financial-data handling rules.
 
 <!-- BEGIN_TF_DOCS -->
@@ -35,7 +37,7 @@ Forge needs tenant-level cost visibility to make runner-size, warm-pool, and EC2
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.54.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.55.0 |
 
 ## Modules
 
@@ -65,6 +67,7 @@ Forge needs tenant-level cost visibility to make runner-size, warm-pool, and EC2
 | [aws_s3_bucket_public_access_block.aws_billing_report](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.aws_billing_report_settings](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.aws_billing_report](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_servicecatalogappregistry_application.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicecatalogappregistry_application) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.cur_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/modules/integrations/splunk_aws_billing/lambda/common.py
+++ b/modules/integrations/splunk_aws_billing/lambda/common.py
@@ -185,20 +185,48 @@ def send_metric_to_o11y_batch(metrics):
     return True
 
 
+TENANT_APPLICATION_ARN = re.compile(
+    r'arn:aws:resource-groups:'
+    r'(?P<aws_region>[\w-]+):'
+    r'(?P<account_id>\d+):'
+    r'group/'
+    r'(?P<forgecicd_tenant>[a-z0-9]+)-'
+    r'(?P<forgecicd_region_alias>[a-z0-9]+)-'
+    r'(?P<forgecicd_vpc_alias>[a-z0-9]+)'
+    r'/resources'
+)
+
+MODULE_APPLICATION_ARN = re.compile(
+    r'arn:aws:resource-groups:'
+    r'(?P<aws_region>[\w-]+):'
+    r'(?P<account_id>\d+):'
+    r'group/'
+    r'(?P<forgecicd_module_group>helpers|infra|integrations)_'
+    r'(?P<forgecicd_module>[a-z0-9_]+)_'
+    r'(?P=aws_region)'
+    r'/resources'
+)
+
+
 def extract_arn_parts(arn):
-    match = re.search(
-        r'arn:aws:resource-groups:(?P<aws_region>[\w-]+):(?P<account_id>\d+):group/(?P<forgecicd_tenant>[^-]+)-(?P<forgecicd_region_alias>[^-]+)-(?P<forgecicd_vpc_alias>[^/]+)/',
-        arn
-    )
+    if not isinstance(arn, str):
+        return None
+
+    match = MODULE_APPLICATION_ARN.fullmatch(arn)
     if match:
-        return match.groupdict()
-    return {
-        'aws_region': 'unknown',
-        'account_id': 'unknown',
-        'forgecicd_tenant': 'unknown',
-        'forgecicd_region_alias': 'unknown',
-        'forgecicd_vpc_alias': 'unknown'
-    }
+        return {
+            **match.groupdict(),
+            'forgecicd_scope': 'module',
+        }
+
+    match = TENANT_APPLICATION_ARN.fullmatch(arn)
+    if match:
+        return {
+            **match.groupdict(),
+            'forgecicd_scope': 'tenant',
+        }
+
+    return None
 
 
 def parse_tags(val):
@@ -227,7 +255,8 @@ def preprocess_df(df):
     df['resource_tags'] = df['resource_tags'].apply(parse_tags)
     df['user_aws_application'] = df['resource_tags'].apply(
         lambda tags: tags.get('user_aws_application', 'unknown'))
-    df = df[df['user_aws_application'] != 'unknown']
+    application_fields = df['user_aws_application'].apply(extract_arn_parts)
+    df = df[application_fields.notna()]
 
     LOG.info('Preprocessed DataFrame shape: %s', df.shape)
     return df

--- a/modules/integrations/splunk_aws_billing/lambda/handler_per_resource_process.py
+++ b/modules/integrations/splunk_aws_billing/lambda/handler_per_resource_process.py
@@ -59,6 +59,13 @@ def process_grouped_rows(grouped):
 
     for _, row in grouped.iterrows():
         fields = common.extract_arn_parts(row['user_aws_application'])
+        if fields is None:
+            LOG.warning(
+                'Skipping row with unsupported aws_application: %s',
+                row['user_aws_application'],
+            )
+            continue
+
         event_body = create_event_body(row, fields)
         line = json.dumps(event_body)
         line_size = len(line.encode())

--- a/modules/integrations/splunk_aws_billing/lambda/handler_per_service.py
+++ b/modules/integrations/splunk_aws_billing/lambda/handler_per_service.py
@@ -58,6 +58,13 @@ def process_grouped_rows(grouped):
 
     for _, row in grouped.iterrows():
         fields = common.extract_arn_parts(row['user_aws_application'])
+        if fields is None:
+            LOG.warning(
+                'Skipping row with unsupported aws_application: %s',
+                row['user_aws_application'],
+            )
+            continue
+
         event_body = create_event_body(row, fields)
         line = json.dumps(event_body)
         line_size = len(line.encode())

--- a/modules/integrations/splunk_aws_billing/service_catalog.tf
+++ b/modules/integrations/splunk_aws_billing/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_aws_billing_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_aws_billing/tags.tf
+++ b/modules/integrations/splunk_aws_billing/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/integrations/splunk_cloud_data_manager/service_catalog.tf
+++ b/modules/integrations/splunk_cloud_data_manager/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_cloud_data_manager_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_cloud_data_manager/tags.tf
+++ b/modules/integrations/splunk_cloud_data_manager/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/integrations/splunk_cloud_data_manager_common/service_catalog.tf
+++ b/modules/integrations/splunk_cloud_data_manager_common/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_cloud_data_manager_common_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_cloud_data_manager_common/tags.tf
+++ b/modules/integrations/splunk_cloud_data_manager_common/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/integrations/splunk_cloud_s3_runner_logs/firehose.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/firehose.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "firehose_role" {
       Action    = "sts:AssumeRole"
     }]
   })
-  tags = var.tags
+  tags = local.module_tags
 }
 
 resource "aws_iam_policy" "firehose_policy" {
@@ -107,7 +107,7 @@ resource "aws_kinesis_firehose_delivery_stream" "splunk_firehose" {
       log_stream_name = "delivery"
     }
   }
-  tags = var.tags
+  tags = local.module_tags
 }
 
 # CloudWatch Log Group for Firehose delivery diagnostics
@@ -116,5 +116,5 @@ resource "aws_cloudwatch_log_group" "firehose_splunk" {
   name              = "/aws/kinesisfirehose/${local.prefix_firehose}-${var.aws_region}"
   retention_in_days = var.logging_retention_in_days
   kms_key_id        = aws_kms_key.splunk_s3_runner_logs.arn
-  tags              = var.tags
+  tags              = local.module_tags
 }

--- a/modules/integrations/splunk_cloud_s3_runner_logs/kinesis.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/kinesis.tf
@@ -4,5 +4,5 @@ resource "aws_kinesis_stream" "splunk_s3_runner_logs" {
   encryption_type  = "KMS"
   kms_key_id       = aws_kms_key.splunk_s3_runner_logs.arn
   stream_mode_details { stream_mode = "ON_DEMAND" }
-  tags = var.tags
+  tags = local.module_tags
 }

--- a/modules/integrations/splunk_cloud_s3_runner_logs/kms.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/kms.tf
@@ -157,7 +157,7 @@ resource "aws_kms_key" "splunk_s3_runner_logs" {
   description             = "KMS key for GitHub logs ingestion pipeline"
   deletion_window_in_days = 30
   enable_key_rotation     = true
-  tags                    = var.tags
+  tags                    = local.module_tags
   policy                  = data.aws_iam_policy_document.kms_s3.json
 }
 

--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda.tf
@@ -35,9 +35,9 @@ module "splunk_s3_runner_logs_lambda" {
 
   policy_json = data.aws_iam_policy_document.splunk_s3_runner_logs_lambda.json
 
-  function_tags = var.tags
-  role_tags     = var.tags
-  tags          = var.tags
+  function_tags = local.module_tags
+  role_tags     = local.module_tags
+  tags          = local.module_tags
 
   depends_on = [aws_cloudwatch_log_group.splunk_s3_runner_logs_lambda]
 }
@@ -102,8 +102,8 @@ resource "aws_cloudwatch_log_group" "splunk_s3_runner_logs_lambda" {
   #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/lambda/${local.prefix_lambda}-lambda-${var.aws_region}"
   retention_in_days = var.logging_retention_in_days
-  tags              = var.tags
-  tags_all          = var.tags
+  tags              = local.module_tags
+  tags_all          = local.module_tags
 }
 
 resource "aws_lambda_event_source_mapping" "sqs_to_lambda" {

--- a/modules/integrations/splunk_cloud_s3_runner_logs/redrive.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/redrive.tf
@@ -30,9 +30,9 @@ module "splunk_s3_runner_logs_redrive_lambda" {
   attach_policy_json = true
   policy_json        = data.aws_iam_policy_document.splunk_s3_runner_logs_redrive.json
 
-  function_tags = var.tags
-  role_tags     = var.tags
-  tags          = var.tags
+  function_tags = local.module_tags
+  role_tags     = local.module_tags
+  tags          = local.module_tags
 
   depends_on = [aws_cloudwatch_log_group.splunk_s3_runner_logs_redrive]
 }
@@ -73,16 +73,16 @@ resource "aws_cloudwatch_log_group" "splunk_s3_runner_logs_redrive" {
   #checkov:skip=CKV_AWS_338:CloudWatch retention is intentionally operator-defined; teams may keep short CloudWatch windows when exporting logs to Splunk or Loki.
   name              = "/aws/lambda/${local.redrive_function_name}"
   retention_in_days = var.logging_retention_in_days
-  tags              = var.tags
-  tags_all          = var.tags
+  tags              = local.module_tags
+  tags_all          = local.module_tags
 }
 
 resource "aws_cloudwatch_event_rule" "splunk_s3_runner_logs_redrive" {
   name                = local.redrive_function_name
   description         = "Redrive failed runner-log events every 10 minutes"
   schedule_expression = "cron(*/10 * * * ? *)"
-  tags                = var.tags
-  tags_all            = var.tags
+  tags                = local.module_tags
+  tags_all            = local.module_tags
 }
 
 resource "aws_cloudwatch_event_target" "splunk_s3_runner_logs_redrive" {

--- a/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/s3_backup.tf
@@ -4,7 +4,7 @@ resource "aws_s3_bucket" "firehose_backup" {
   #checkov:skip=CKV2_AWS_61:Backup bucket lifecycle expiration is deferred until failed-delivery retention requirements are validated.
   #checkov:skip=CKV2_AWS_62:Backup bucket is only a failed-delivery target and has no event-driven consumer.
   bucket = "splunk-s3-runner-logs-failed-${data.aws_caller_identity.current.account_id}-${var.aws_region}"
-  tags   = var.tags
+  tags   = local.module_tags
 }
 
 resource "aws_s3_bucket_ownership_controls" "firehose_backup" {

--- a/modules/integrations/splunk_cloud_s3_runner_logs/service_catalog.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/service_catalog.tf
@@ -1,0 +1,11 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_cloud_s3_runner_logs_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}
+
+locals {
+  module_tags = merge(
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
+}

--- a/modules/integrations/splunk_cloud_s3_runner_logs/sqs.tf
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/sqs.tf
@@ -7,14 +7,14 @@ resource "aws_sqs_queue" "log_events_queue" {
     deadLetterTargetArn = aws_sqs_queue.log_events_dlq.arn
     maxReceiveCount     = var.sqs_redrive_max_receive_count
   })
-  tags = var.tags
+  tags = local.module_tags
 }
 
 resource "aws_sqs_queue" "log_events_dlq" {
   name                      = "splunk-s3-runner-logs-events-dlq"
   message_retention_seconds = 1209600 # 14 days
   kms_master_key_id         = aws_kms_key.splunk_s3_runner_logs.arn
-  tags                      = merge(var.tags, { Purpose = "dlq" })
+  tags                      = merge(local.module_tags, { Purpose = "dlq" })
 }
 
 resource "aws_sqs_queue_policy" "allow_s3" {

--- a/modules/integrations/splunk_dependency_monitor/service_catalog.tf
+++ b/modules/integrations/splunk_dependency_monitor/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_dependency_monitor_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_dependency_monitor/tags.tf
+++ b/modules/integrations/splunk_dependency_monitor/tags.tf
@@ -1,4 +1,8 @@
 locals {
   dependency_monitor_function_name = "splunk-dependency-monitor-${var.aws_region}"
-  all_security_tags                = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/integrations/splunk_o11y_aws_integration/service_catalog.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_o11y_aws_integration_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_o11y_aws_integration/tags.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/integrations/splunk_o11y_aws_integration_common/service_catalog.tf
+++ b/modules/integrations/splunk_o11y_aws_integration_common/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_o11y_aws_integration_common_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_o11y_aws_integration_common/tags.tf
+++ b/modules/integrations/splunk_o11y_aws_integration_common/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/README.md
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/README.md
@@ -4,18 +4,20 @@ This module creates the billing dashboard for Forge costs in Splunk Observabilit
 
 ## Why This Module Exists
 
-Cost is one of the core Forge operating signals because runner choices involve trade-offs between latency, isolation, and spend. This dashboard helps compare tenant and service cost trends instead of guessing.
+Cost is one of the core Forge operating signals because runner choices involve trade-offs between latency, isolation, and spend. This dashboard helps compare tenant, shared module, and service cost trends instead of guessing.
 
 ## What It Manages
 
 - Charts for cost and net cost by service and tenant.
 - Top tenant/service cost lists.
+- Charts for non-tenant cost and net cost by shared Forge module and AWS service.
+- Top non-tenant module/service cost lists.
 - Runner-related cost summaries.
 - Dashboard placement in the shared Forge O11y group.
 
 ## Operational Notes
 
-- The dashboard is only as accurate as billing exports, tags, and tenant dimensions.
+- The dashboard is only as accurate as billing exports, AppRegistry tags, and tenant or module dimensions.
 - Expect billing data to lag behind live infrastructure state.
 - Use this when reviewing warm pools, DinD node pools, and tenant right-sizing.
 
@@ -43,11 +45,15 @@ No modules.
 | Name | Type |
 | ---- | ---- |
 | [signalfx_dashboard.billing](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/dashboard) | resource |
+| [signalfx_list_chart.top_non_tenant_module_service_net_cost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_list_chart.top_tenant_service_net_cost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/list_chart) | resource |
 | [signalfx_time_chart.cost_per_service](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.cost_per_tenant](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.net_cost_per_service](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.net_cost_per_tenant](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.non_tenant_cost_per_module](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.non_tenant_net_cost_per_module](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
+| [signalfx_time_chart.non_tenant_net_cost_per_service](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.runner_related_net_cost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.total_cost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |
 | [signalfx_time_chart.total_net_cost](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/time_chart) | resource |

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/main.tf
@@ -274,13 +274,139 @@ EOF
   }
 }
 
+resource "signalfx_time_chart" "non_tenant_cost_per_module" {
+  name        = "Non-tenant cost per module"
+  description = "Shows unblended AWS cost for shared Forge modules that are not attributed to a tenant."
+
+  program_text = <<-EOF
+A = data('forge.per_service.cost_usd', filter=filter('forgecicd_scope', 'module'))
+B = A.max(by=['usage_date', 'service', 'forgecicd_module_group', 'forgecicd_module', 'usage_month', 'usage_year'])
+C = B.sum(by=['forgecicd_module_group', 'forgecicd_module', 'usage_month', 'usage_year'])
+C.publish(label='current')
+EOF
+
+  plot_type                 = "AreaChart"
+  axes_precision            = 0
+  on_chart_legend_dimension = "forgecicd_module"
+  time_range                = 3600
+
+  histogram_options {
+    color_theme = "gold"
+  }
+
+  viz_options {
+    axis         = "left"
+    color        = "blue"
+    display_name = "current"
+    label        = "current"
+  }
+}
+
+resource "signalfx_time_chart" "non_tenant_net_cost_per_module" {
+  name        = "Non-tenant net cost per module"
+  description = "Shows net AWS cost for shared Forge modules that are not attributed to a tenant."
+
+  program_text = <<-EOF
+A = data('forge.per_service.net_cost_usd', filter=filter('forgecicd_scope', 'module'))
+B = A.max(by=['usage_date', 'service', 'forgecicd_module_group', 'forgecicd_module', 'usage_month', 'usage_year'])
+C = B.sum(by=['forgecicd_module_group', 'forgecicd_module', 'usage_month', 'usage_year'])
+C.publish(label='current')
+EOF
+
+  plot_type                 = "AreaChart"
+  axes_precision            = 0
+  on_chart_legend_dimension = "forgecicd_module"
+  time_range                = 3600
+
+  histogram_options {
+    color_theme = "gold"
+  }
+
+  viz_options {
+    axis         = "left"
+    color        = "blue"
+    display_name = "current"
+    label        = "current"
+  }
+}
+
+resource "signalfx_time_chart" "non_tenant_net_cost_per_service" {
+  name        = "Non-tenant net cost per AWS service"
+  description = "Shows net AWS service cost across shared Forge modules that are not attributed to a tenant."
+
+  program_text = <<-EOF
+A = data('forge.per_service.net_cost_usd', filter=filter('forgecicd_scope', 'module'))
+B = A.max(by=['usage_date', 'service', 'forgecicd_module_group', 'forgecicd_module', 'usage_month', 'usage_year'])
+C = B.sum(by=['service', 'usage_month', 'usage_year'])
+C.publish(label='current')
+EOF
+
+  plot_type                 = "AreaChart"
+  axes_precision            = 0
+  on_chart_legend_dimension = "service"
+  time_range                = 3600
+
+  histogram_options {
+    color_theme = "gold"
+  }
+
+  viz_options {
+    axis         = "left"
+    color        = "blue"
+    display_name = "current"
+    label        = "current"
+  }
+}
+
+resource "signalfx_list_chart" "top_non_tenant_module_service_net_cost" {
+  name        = "Top non-tenant module/service net cost"
+  description = "Ranks shared Forge module and AWS service combinations by current net cost."
+
+  program_text = <<-EOF
+A = data('forge.per_service.net_cost_usd', filter=filter('forgecicd_scope', 'module'))
+B = A.max(by=['usage_date', 'service', 'forgecicd_module_group', 'forgecicd_module', 'usage_month', 'usage_year'])
+C = B.sum(by=['forgecicd_module_group', 'forgecicd_module', 'service']).top(count=20).publish(label='A')
+EOF
+
+  sort_by = "-value"
+
+  disable_sampling        = false
+  hide_missing_values     = true
+  max_precision           = 4
+  secondary_visualization = "None"
+  time_range              = 3600
+  unit_prefix             = "Metric"
+
+  legend_options_fields {
+    enabled  = true
+    property = "forgecicd_module_group"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "forgecicd_module"
+  }
+  legend_options_fields {
+    enabled  = true
+    property = "service"
+  }
+  legend_options_fields {
+    enabled  = false
+    property = "sf_metric"
+  }
+
+  viz_options {
+    display_name = "Net cost"
+    label        = "A"
+  }
+}
+
 resource "terraform_data" "dashboard_parent" {
   triggers_replace = var.dashboard_group
 }
 
 resource "signalfx_dashboard" "billing" {
   name            = "Forge Billing and Cost - AWS"
-  description     = "AWS billing cost and net cost for Forge, separated from OpenCost allocation estimates."
+  description     = "AWS billing cost and net cost for tenant and non-tenant Forge resources, separated from OpenCost allocation estimates."
   dashboard_group = var.dashboard_group
 
   lifecycle {
@@ -375,6 +501,38 @@ resource "signalfx_dashboard" "billing" {
   chart {
     chart_id = signalfx_list_chart.top_tenant_service_net_cost.id
     row      = 3
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.non_tenant_cost_per_module.id
+    row      = 4
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.non_tenant_net_cost_per_module.id
+    row      = 4
+    column   = 6
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.non_tenant_net_cost_per_service.id
+    row      = 5
+    column   = 0
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_non_tenant_module_service_net_cost.id
+    row      = 5
     column   = 6
     width    = 6
     height   = 1

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/billing_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/billing_dashboard_behavior.tftest.hcl
@@ -26,8 +26,14 @@ run "billing_dashboard_contract" {
       && strcontains(signalfx_time_chart.total_cost.program_text, "forge.per_service.cost_usd")
       && signalfx_list_chart.top_tenant_service_net_cost.sort_by == "-value"
       && strcontains(signalfx_list_chart.top_tenant_service_net_cost.program_text, ".top(count=20)")
+      && signalfx_time_chart.non_tenant_cost_per_module.name == "Non-tenant cost per module"
+      && strcontains(signalfx_time_chart.non_tenant_cost_per_module.program_text, "filter('forgecicd_scope', 'module')")
+      && strcontains(signalfx_time_chart.non_tenant_cost_per_module.program_text, "'forgecicd_module_group', 'forgecicd_module'")
+      && strcontains(signalfx_time_chart.non_tenant_net_cost_per_service.program_text, "B.sum(by=['service', 'usage_month', 'usage_year'])")
+      && signalfx_list_chart.top_non_tenant_module_service_net_cost.sort_by == "-value"
+      && strcontains(signalfx_list_chart.top_non_tenant_module_service_net_cost.program_text, ".top(count=20)")
     )
-    error_message = "Billing dashboard charts must keep total cost and top tenant/service cost SignalFlow behavior."
+    error_message = "Billing dashboard charts must keep tenant and non-tenant module cost SignalFlow behavior."
   }
 }
 
@@ -38,16 +44,19 @@ run "billing_dashboard_wiring_contract" {
     condition = (
       signalfx_dashboard.billing.name == "Forge Billing and Cost - AWS"
       && signalfx_dashboard.billing.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.billing.chart) == 8
+      && signalfx_dashboard.billing.time_range == "-31d"
+      && length(signalfx_dashboard.billing.chart) == 12
     )
-    error_message = "Billing dashboard must keep its name, group input, and chart count."
+    error_message = "Billing dashboard must keep its name, group input, 31-day default time range, and chart count."
   }
 
   assert {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.billing.chart : chart.chart_id], signalfx_time_chart.cost_per_service.id),
       contains([for chart in signalfx_dashboard.billing.chart : chart.chart_id], signalfx_list_chart.top_tenant_service_net_cost.id),
+      contains([for chart in signalfx_dashboard.billing.chart : chart.chart_id], signalfx_time_chart.non_tenant_cost_per_module.id),
+      contains([for chart in signalfx_dashboard.billing.chart : chart.chart_id], signalfx_list_chart.top_non_tenant_module_service_net_cost.id),
     ])
-    error_message = "Billing dashboard must keep its first and final chart wiring."
+    error_message = "Billing dashboard must keep tenant and non-tenant module chart wiring."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/integrations_splunk_o11y_conf_shared_dashboards_billing_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/billing/tests/integrations_splunk_o11y_conf_shared_dashboards_billing_source_inventory.tftest.hcl
@@ -16,6 +16,10 @@ run "integrations_splunk_o11y_conf_shared_dashboards_billing_source_inventory" {
       "resource \"signalfx_time_chart\" \"total_net_cost\"",
       "resource \"signalfx_time_chart\" \"runner_related_net_cost\"",
       "resource \"signalfx_list_chart\" \"top_tenant_service_net_cost\"",
+      "resource \"signalfx_time_chart\" \"non_tenant_cost_per_module\"",
+      "resource \"signalfx_time_chart\" \"non_tenant_net_cost_per_module\"",
+      "resource \"signalfx_time_chart\" \"non_tenant_net_cost_per_service\"",
+      "resource \"signalfx_list_chart\" \"top_non_tenant_module_service_net_cost\"",
       "resource \"terraform_data\" \"dashboard_parent\"",
       "terraform_data.dashboard_parent,",
       "resource \"signalfx_dashboard\" \"billing\"",
@@ -28,7 +32,7 @@ run "integrations_splunk_o11y_conf_shared_dashboards_billing_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 11
-    error_message = "Source inventory must keep 11 module-specific Terraform and lifecycle literals pinned."
+    condition     = output.expected_literal_count == 15
+    error_message = "Source inventory must keep 15 module-specific Terraform and lifecycle literals pinned."
   }
 }

--- a/modules/integrations/splunk_otel_eks/service_catalog.tf
+++ b/modules/integrations/splunk_otel_eks/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_otel_eks_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_otel_eks/tags.tf
+++ b/modules/integrations/splunk_otel_eks/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/integrations/splunk_secrets/service_catalog.tf
+++ b/modules/integrations/splunk_secrets/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_secrets_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_secrets/tags.tf
+++ b/modules/integrations/splunk_secrets/tags.tf
@@ -1,4 +1,8 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 }

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/service_catalog.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_splunk_stuck_workflow_job_dispatcher_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/tags.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/tags.tf
@@ -1,5 +1,9 @@
 locals {
-  all_security_tags = merge(var.default_tags, var.tags)
+  all_security_tags = merge(
+    var.default_tags,
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 
   redelivery_tenant_configs = [
     for tenant_config in var.redelivery_config.tenant_configs : {

--- a/modules/integrations/teleport/service_catalog.tf
+++ b/modules/integrations/teleport/service_catalog.tf
@@ -1,0 +1,4 @@
+resource "aws_servicecatalogappregistry_application" "this" {
+  name = "integrations_teleport_${var.aws_region}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/teleport/tags.tf
+++ b/modules/integrations/teleport/tags.tf
@@ -2,6 +2,7 @@
 locals {
   all_security_tags = merge(
     var.default_tags,
-    var.tags
+    var.tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
   )
 }

--- a/tests/lambdas/splunk_aws_billing_test.py
+++ b/tests/lambdas/splunk_aws_billing_test.py
@@ -311,8 +311,45 @@ def test_extract_arn_parts_for_resource_group_application(monkeypatch, aws):
         'forgecicd_tenant': 'acgw',
         'forgecicd_region_alias': 'usw2',
         'forgecicd_vpc_alias': 'dev',
+        'forgecicd_scope': 'tenant',
     }
-    assert common.extract_arn_parts('not-an-arn')['aws_region'] == 'unknown'
+    assert common.extract_arn_parts('not-an-arn') is None
+
+
+def test_extract_arn_parts_for_module_application(monkeypatch, aws):
+    common = _load_billing_module(monkeypatch, 'common')
+
+    parts = common.extract_arn_parts(
+        'arn:aws:resource-groups:us-west-2:123456789012:'
+        'group/integrations_splunk_aws_billing_us-west-2/resources'
+    )
+
+    assert parts == {
+        'aws_region': 'us-west-2',
+        'account_id': '123456789012',
+        'forgecicd_module_group': 'integrations',
+        'forgecicd_module': 'splunk_aws_billing',
+        'forgecicd_scope': 'module',
+    }
+
+
+def test_extract_arn_parts_requires_a_complete_match(monkeypatch, aws):
+    common = _load_billing_module(monkeypatch, 'common')
+    tenant_arn = (
+        'arn:aws:resource-groups:us-west-2:123456789012:'
+        'group/acgw-usw2-dev/resources'
+    )
+    module_arn = (
+        'arn:aws:resource-groups:us-west-2:123456789012:'
+        'group/helpers_ecr_us-west-2/resources'
+    )
+
+    assert common.extract_arn_parts(f'prefix-{tenant_arn}') is None
+    assert common.extract_arn_parts(f'{tenant_arn}/extra') is None
+    assert common.extract_arn_parts(module_arn.replace(
+        'helpers_ecr_us-west-2',
+        'helpers_ecr_us-east-1',
+    )) is None
 
 
 def test_per_service_event_body_rounds_costs(monkeypatch, aws):
@@ -410,6 +447,37 @@ def test_per_service_batches_events_and_o11y_metrics(monkeypatch, aws):
         'forge.per_service.cost_usd',
         'forge.per_service.net_cost_usd',
     ]
+
+
+def test_per_service_skips_rows_with_unsupported_applications(
+    monkeypatch, aws
+):
+    mod = _load_billing_module(monkeypatch, 'handler_per_service')
+    splunk_batches = []
+    metric_batches = []
+    monkeypatch.setattr(
+        mod.common,
+        'send_to_splunk_batch',
+        lambda batch: splunk_batches.append(list(batch)),
+    )
+    monkeypatch.setattr(
+        mod.common,
+        'send_metric_to_o11y_batch',
+        lambda batch: metric_batches.append(list(batch)),
+    )
+
+    mod.process_grouped_rows(_GroupedRows([
+        {
+            'usage_date': '2026-07-03',
+            'line_item_product_code': 'AmazonEC2',
+            'user_aws_application': 'not-a-supported-application',
+            'line_item_unblended_cost': '1.00',
+            'line_item_net_unblended_cost': '0.90',
+        },
+    ]))
+
+    assert splunk_batches == []
+    assert metric_batches == []
 
 
 def test_per_resource_batches_include_resource_dimensions(monkeypatch, aws):


### PR DESCRIPTION
## Description

Adds AWS Service Catalog AppRegistry applications for the 25 helper, infrastructure, and integration modules that deploy AWS resources. Each application is named from the module group, module name, and AWS region, and its application tag is propagated to the module's taggable AWS resources.

Extends the Splunk AWS billing processors to:

- require complete `user_aws_application` ARN matches;
- support existing tenant applications and new non-tenant module applications;
- emit `forgecicd_scope`, `forgecicd_module_group`, and `forgecicd_module` dimensions;
- skip unsupported application rows instead of emitting `unknown` dimensions.

Extends the AWS billing dashboard with a dedicated non-tenant section:

- cost per shared Forge module;
- net cost per shared Forge module;
- non-tenant net cost per AWS service;
- top non-tenant module/service net cost.

The new charts explicitly filter `forgecicd_scope=module`. Existing tenant charts remain unchanged. Modules that do not deploy AWS resources do not receive an AppRegistry application.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `uv run --project .. --locked --only-group lambda-tests pytest -q lambdas/splunk_aws_billing_test.py` — 16 passed
- Focused Splunk AWS billing OpenTofu interface and source-inventory contracts — 2 passed
- Focused billing dashboard behavior, interface, and source-inventory tests — 4 passed
- `tofu fmt -check -recursive modules/helpers modules/infra modules/integrations`
- `git diff --check`
- Catalog inventory check confirmed 25 catalogs and no catalog/resource mismatches
- Dashboard commit hooks passed the complete suite, including OpenTofu and Terraform validation, TFLint, security, and formatting.
- During the initial broad module commit, repository-wide provider initialization exhausted temporary disk; focused billing contracts passed and the dashboard follow-up completed the full hook suite successfully.
