### PR TITLE
fix(observability): alert on runner log delivery integrity

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards.tf
@@ -102,6 +102,7 @@ module "dashboard_runner_logs_ingestion" {
 
   dynamic_variables       = var.dashboard_variables.runner_logs_ingestion.dynamic_variables
   dashboard_group         = signalfx_dashboard_group.forgecicd.id
+  detector_id             = module.detector_aws_regional_health.runner_log_delivery_detector_id
   lambda_dimension_filter = local.lambda_dimension_filter
 }
 

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
@@ -296,10 +296,10 @@ resource "signalfx_time_chart" "oldest_message_trend" {
 
 resource "signalfx_time_chart" "firehose_delivery" {
   name             = "Runner-log delivery to Splunk"
-  description      = "Records delivered successfully to Splunk per five minutes."
+  description      = "Records sent to Splunk and the average Firehose delivery success percentage per five minutes. Interpret success only while records are flowing."
   program_text     = <<-EOF
 records = data('DeliveryToSplunk.Records', filter=(${local.aws_platform_filter}) and (${local.firehose_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'DeliveryStreamName']).publish(label='A')
-success = data('DeliveryToSplunk.Success', filter=(${local.aws_platform_filter}) and (${local.firehose_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'DeliveryStreamName']).publish(label='B')
+success = data('DeliveryToSplunk.Success', filter=(${local.aws_platform_filter}) and (${local.firehose_filter}) and filter('stat', 'mean'), rollup='average').mean(over='5m').mean(by=['aws_region', 'DeliveryStreamName']).publish(label='B')
 EOF
   plot_type        = "LineChart"
   disable_sampling = true
@@ -310,8 +310,9 @@ EOF
     label        = "A"
   }
   viz_options {
-    display_name = "Successful deliveries"
+    display_name = "Delivery success"
     label        = "B"
+    value_suffix = "%"
   }
 }
 
@@ -345,7 +346,7 @@ resource "signalfx_dashboard" "runner_logs_ingestion" {
   name            = "Forge Runner Logs Ingestion"
   description     = "End-to-end health of the Forge runner-log ingestion path from SQS through Lambda and Kinesis to Firehose and Splunk HEC."
   dashboard_group = var.dashboard_group
-  time_range      = "-1h"
+  time_range      = "-24h"
 
   lifecycle {
     replace_triggered_by = [

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
@@ -116,6 +116,20 @@ resource "signalfx_single_value_chart" "firehose_freshness" {
   }
 }
 
+resource "signalfx_time_chart" "delivery_health_alerts" {
+  name             = "Runner-log delivery alerts"
+  description      = "Detector events for Firehose delivery failures, stale delivery, and runner-log DLQ occupancy."
+  program_text     = "A = alerts(detector_id='${var.detector_id}').publish(label='Runner-log delivery alerts')"
+  plot_type        = "LineChart"
+  show_event_lines = true
+  time_range       = 3600
+
+  viz_options {
+    display_name = "Delivery alerts"
+    label        = "A"
+  }
+}
+
 resource "signalfx_time_chart" "sqs_state" {
   name             = "Runner-log queue state"
   description      = "Visible, in-flight, and dead-letter runner-log messages by AWS region."
@@ -412,78 +426,85 @@ resource "signalfx_dashboard" "runner_logs_ingestion" {
     height   = 1
   }
   chart {
-    chart_id = signalfx_time_chart.sqs_state.id
+    chart_id = signalfx_time_chart.delivery_health_alerts.id
     row      = 1
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+  chart {
+    chart_id = signalfx_time_chart.sqs_state.id
+    row      = 2
     column   = 0
     width    = 6
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.sqs_flow.id
-    row      = 1
+    row      = 2
     column   = 6
     width    = 6
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.lambda_concurrency.id
-    row      = 2
+    row      = 3
     column   = 0
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.lambda_duration.id
-    row      = 2
+    row      = 3
     column   = 4
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.lambda_failures.id
-    row      = 2
+    row      = 3
     column   = 8
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.kinesis_records.id
-    row      = 3
+    row      = 4
     column   = 0
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.kinesis_throughput.id
-    row      = 3
+    row      = 4
     column   = 4
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.kinesis_iterator_age.id
-    row      = 3
+    row      = 4
     column   = 8
     width    = 4
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.firehose_delivery.id
-    row      = 4
+    row      = 5
     column   = 0
     width    = 6
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.firehose_latency.id
-    row      = 4
+    row      = 5
     column   = 6
     width    = 6
     height   = 1
   }
   chart {
     chart_id = signalfx_time_chart.oldest_message_trend.id
-    row      = 5
+    row      = 6
     column   = 0
     width    = 12
     height   = 1

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
@@ -346,7 +346,7 @@ resource "signalfx_dashboard" "runner_logs_ingestion" {
   name            = "Forge Runner Logs Ingestion"
   description     = "End-to-end health of the Forge runner-log ingestion path from SQS through Lambda and Kinesis to Firehose and Splunk HEC."
   dashboard_group = var.dashboard_group
-  time_range      = "-24h"
+  time_range      = "-1h"
 
   lifecycle {
     replace_triggered_by = [

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
@@ -14,6 +14,7 @@ mock_provider "signalfx" {
 
 variables {
   dashboard_group         = "forge-dashboard-group"
+  detector_id             = "runner-log-delivery-detector-id"
   lambda_dimension_filter = "filter('namespace', 'AWS/Lambda') and filter('Resource', '*') and (not filter('ExecutedVersion', '*'))"
   dynamic_variables = [
     {
@@ -53,10 +54,10 @@ run "creates_runner_logs_ingestion_dashboard" {
     condition = (
       signalfx_dashboard.runner_logs_ingestion.name == "Forge Runner Logs Ingestion"
       && signalfx_dashboard.runner_logs_ingestion.dashboard_group == "forge-dashboard-group"
-      && length(signalfx_dashboard.runner_logs_ingestion.chart) == 17
+      && length(signalfx_dashboard.runner_logs_ingestion.chart) == 18
       && length(signalfx_dashboard.runner_logs_ingestion.variable) == 3
     )
-    error_message = "The runner-log ingestion dashboard must keep its name, parent group, seventeen panels, and dedicated variables."
+    error_message = "The runner-log ingestion dashboard must keep its name, parent group, eighteen panels, and dedicated variables."
   }
 
   assert {
@@ -110,7 +111,10 @@ run "creates_runner_logs_ingestion_dashboard" {
       && strcontains(signalfx_time_chart.firehose_delivery.program_text, ".mean(over='5m').mean(by=['aws_region', 'DeliveryStreamName'])")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataFreshness")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataAckLatency")
+      && strcontains(signalfx_time_chart.delivery_health_alerts.program_text, "alerts(detector_id='runner-log-delivery-detector-id')")
+      && signalfx_time_chart.delivery_health_alerts.show_event_lines
+      && signalfx_time_chart.delivery_health_alerts.time_range == 3600
     )
-    error_message = "The dashboard must preserve the SQS, Lambda, Kinesis, Splunk delivery, and tuning validation signals."
+    error_message = "The dashboard must preserve the detector events, SQS, Lambda, Kinesis, Splunk delivery, and tuning validation signals."
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
@@ -53,6 +53,7 @@ run "creates_runner_logs_ingestion_dashboard" {
     condition = (
       signalfx_dashboard.runner_logs_ingestion.name == "Forge Runner Logs Ingestion"
       && signalfx_dashboard.runner_logs_ingestion.dashboard_group == "forge-dashboard-group"
+      && signalfx_dashboard.runner_logs_ingestion.time_range == "-24h"
       && length(signalfx_dashboard.runner_logs_ingestion.chart) == 17
       && length(signalfx_dashboard.runner_logs_ingestion.variable) == 3
     )
@@ -105,6 +106,9 @@ run "creates_runner_logs_ingestion_dashboard" {
       && strcontains(signalfx_time_chart.oldest_message_trend.program_text, "ApproximateAgeOfOldestMessage")
       && signalfx_time_chart.oldest_message_trend.time_range == 21600
       && strcontains(signalfx_time_chart.firehose_delivery.program_text, "DeliveryToSplunk.Records")
+      && strcontains(signalfx_time_chart.firehose_delivery.program_text, "filter('stat', 'mean')")
+      && strcontains(signalfx_time_chart.firehose_delivery.program_text, "rollup='average'")
+      && strcontains(signalfx_time_chart.firehose_delivery.program_text, ".mean(over='5m').mean(by=['aws_region', 'DeliveryStreamName'])")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataFreshness")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataAckLatency")
     )

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
@@ -53,7 +53,6 @@ run "creates_runner_logs_ingestion_dashboard" {
     condition = (
       signalfx_dashboard.runner_logs_ingestion.name == "Forge Runner Logs Ingestion"
       && signalfx_dashboard.runner_logs_ingestion.dashboard_group == "forge-dashboard-group"
-      && signalfx_dashboard.runner_logs_ingestion.time_range == "-24h"
       && length(signalfx_dashboard.runner_logs_ingestion.chart) == 17
       && length(signalfx_dashboard.runner_logs_ingestion.variable) == 3
     )

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_interface_contract.tftest.hcl
@@ -9,14 +9,17 @@ run "runner_logs_ingestion_dashboard_interface_contract" {
     module_path = "."
     expected_input_variables = [
       "dashboard_group",
+      "detector_id",
       "dynamic_variables",
       "lambda_dimension_filter",
     ]
     expected_output_values = []
     expected_interface_literals = [
       "variable \"dashboard_group\"",
+      "variable \"detector_id\"",
       "variable \"dynamic_variables\"",
       "variable \"lambda_dimension_filter\"",
+      "description = \"Runner-log delivery health detector ID used to display trigger and clear events.\"",
       "description = \"Canonical AWS Lambda resource-level SignalFlow filter.\"",
       "property               = string",
       "values_suggested       = list(string)",

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_source_inventory.tftest.hcl
@@ -10,6 +10,8 @@ run "runner_logs_ingestion_dashboard_source_inventory" {
     expected_literals = [
       "resource \"signalfx_dashboard\" \"runner_logs_ingestion\"",
       "Forge Runner Logs Ingestion",
+      "Runner-log delivery alerts",
+      "alerts(detector_id='$${var.detector_id}')",
       "Runner-log Lambda duration guardrail",
       "Runner-log oldest message age - 6h trend",
       "resource \"terraform_data\" \"dashboard_parent\"",

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/variables.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/variables.tf
@@ -16,6 +16,11 @@ variable "dashboard_group" {
   type        = string
 }
 
+variable "detector_id" {
+  description = "Runner-log delivery health detector ID used to display trigger and clear events."
+  type        = string
+}
+
 variable "lambda_dimension_filter" {
   description = "Canonical AWS Lambda resource-level SignalFlow filter."
   type        = string

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/main.tf
@@ -21,6 +21,48 @@ locals {
   control_plane_queue_filter    = "filter('namespace', 'AWS/SQS') and filter('QueueName', '*')"
   control_plane_lambda_filter   = "(${var.lambda_dimension_filter}) and filter('aws_function_name', '*')"
   dead_letter_queue_name_filter = "filter('QueueName', '*dead-letter*', '*dead_letter*', '*dlq*', '*DLQ*')"
+  runner_log_firehose_filter    = "filter('namespace', 'AWS/Firehose') and filter('DeliveryStreamName', 'splunk-s3-runner-logs-firehose-*')"
+  runner_log_dlq_filter         = "filter('namespace', 'AWS/SQS') and filter('QueueName', 'splunk-s3-runner-logs-events-dlq')"
+}
+
+resource "signalfx_detector" "runner_log_delivery_health" {
+  name        = "${var.detector_name_prefix} runner-log delivery integrity"
+  description = "Monitors the shared runner-log Firehose delivery path and its dead-letter queue. Idle delivery streams do not alert."
+  max_delay   = 120
+  tags        = local.detector_tags
+  teams       = [var.team]
+  time_range  = 86400
+
+  program_text = <<-EOF
+records = data('DeliveryToSplunk.Records', filter=(${local.control_plane_filter}) and (${local.runner_log_firehose_filter}) and filter('stat', 'sum'), rollup='sum', extrapolation='zero').sum(over='5m').sum(by=['aws_region', 'DeliveryStreamName'])
+success_pct = data('DeliveryToSplunk.Success', filter=(${local.control_plane_filter}) and (${local.runner_log_firehose_filter}) and filter('stat', 'mean'), rollup='average').mean(over='5m').mean(by=['aws_region', 'DeliveryStreamName'])
+freshness = data('DeliveryToSplunk.DataFreshness', filter=(${local.control_plane_filter}) and (${local.runner_log_firehose_filter}) and filter('stat', 'upper'), rollup='max').max(over='5m').max(by=['aws_region', 'DeliveryStreamName'])
+dlq = data('ApproximateNumberOfMessagesVisible', filter=(${local.control_plane_filter}) and (${local.runner_log_dlq_filter}) and filter('stat', 'upper'), rollup='latest').max(over='5m').max(by=['aws_region', 'QueueName'])
+detect(when(dlq > 0, '5m'), off=when(dlq == 0, '15m')).publish('Runner-log DLQ contains messages')
+detect(when((records > 0) and (success_pct < 100), '5m'), off=when((success_pct == 100) or (records == 0), '10m')).publish('Runner-log Splunk delivery failure')
+detect(when((records > 0) and (freshness > 300), '10m'), off=when(freshness <= 240, '10m')).publish('Runner-log Splunk delivery stale')
+EOF
+
+  rule {
+    description   = "Runner-log dead-letter queue contains messages for 5 minutes"
+    severity      = "Critical"
+    detect_label  = "Runner-log DLQ contains messages"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Runner-log delivery success remains below 100 percent for the configured 300-second retry window"
+    severity      = "Critical"
+    detect_label  = "Runner-log Splunk delivery failure"
+    notifications = var.detector_notifications
+  }
+
+  rule {
+    description   = "Runner-log delivery freshness exceeds the configured 300-second retry window for 10 minutes"
+    severity      = "Major"
+    detect_label  = "Runner-log Splunk delivery stale"
+    notifications = var.detector_notifications
+  }
 }
 
 resource "signalfx_detector" "aws_regional_platform_health" {

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/outputs.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/outputs.tf
@@ -12,3 +12,8 @@ output "sqs_control_plane_detector_id" {
   description = "AWS SQS control-plane detector ID for linking SQS health charts."
   value       = signalfx_detector.aws_sqs_control_plane_health.id
 }
+
+output "runner_log_delivery_detector_id" {
+  description = "Runner-log delivery integrity detector ID."
+  value       = signalfx_detector.runner_log_delivery_health.id
+}

--- a/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/detectors/aws_regional_health/tests/aws_regional_health_detector_behavior.tftest.hcl
@@ -132,4 +132,27 @@ run "creates_regional_platform_detector" {
     ])
     error_message = "Every SQS control-plane detector rule must use the configured notification routing."
   }
+
+  assert {
+    condition = (
+      signalfx_detector.runner_log_delivery_health.name == "Forge Prod runner-log delivery integrity"
+      && signalfx_detector.runner_log_delivery_health.max_delay == 120
+      && length(signalfx_detector.runner_log_delivery_health.rule) == 3
+      && strcontains(signalfx_detector.runner_log_delivery_health.program_text, "filter('DeliveryStreamName', 'splunk-s3-runner-logs-firehose-*')")
+      && strcontains(signalfx_detector.runner_log_delivery_health.program_text, "filter('QueueName', 'splunk-s3-runner-logs-events-dlq')")
+      && strcontains(signalfx_detector.runner_log_delivery_health.program_text, "filter('stat', 'mean')")
+      && strcontains(signalfx_detector.runner_log_delivery_health.program_text, "(records > 0) and (success_pct < 100), '5m'")
+      && strcontains(signalfx_detector.runner_log_delivery_health.program_text, "(records > 0) and (freshness > 300), '10m'")
+      && strcontains(signalfx_detector.runner_log_delivery_health.program_text, "dlq > 0, '5m'")
+    )
+    error_message = "The runner-log detector must use percentage delivery semantics, suppress idle streams, and cover stale delivery and DLQ occupancy."
+  }
+
+  assert {
+    condition = alltrue([
+      for rule in signalfx_detector.runner_log_delivery_health.rule :
+      toset(rule.notifications) == toset(["Email,forge@example.com"])
+    ])
+    error_message = "Every runner-log delivery detector rule must use the configured notification routing."
+  }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/tests/integrations_splunk_o11y_conf_shared_source_inventory.tftest.hcl
@@ -43,6 +43,7 @@ run "integrations_splunk_o11y_conf_shared_contract" {
       "detector_id             = module.detector_aws_regional_health.lambda_control_plane_detector_id",
       "dynamic_variables = var.dashboard_variables.kinesis_control_plane.dynamic_variables",
       "dynamic_variables       = var.dashboard_variables.runner_logs_ingestion.dynamic_variables",
+      "detector_id             = module.detector_aws_regional_health.runner_log_delivery_detector_id",
       "dynamic_variables = var.dashboard_variables.sqs_control_plane.dynamic_variables",
       "detector_id       = module.detector_aws_regional_health.sqs_control_plane_detector_id",
       "Forge Impact and tenant health detectors must use the same tenant_names.",


### PR DESCRIPTION
## Description

Corrects the Forge Runner Logs Ingestion dashboard so `DeliveryToSplunk.Success` is treated as an averaged percentage instead of an additive count.

Adds a shared runner-log delivery detector covering:

- sustained delivery success below 100% while records are flowing
- delivery freshness beyond the configured 300-second retry window
- runner-log DLQ occupancy

The dashboard keeps its existing one-hour operational default. Operators can select 24 hours or seven days when investigating history.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu test` in `modules/integrations/splunk_o11y_conf_shared` — 3 passed
- repository pre-commit checks for the changed files — passed
