### PR TITLE
feat(observability): alert on IAM trust failures

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/alert_forge_trust_failures.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/alert_forge_trust_failures.tf
@@ -1,0 +1,50 @@
+locals {
+  forge_trust_failure_alert_search = <<-EOT
+    index="${var.splunk_conf.index}" sourcetype="aws:cloudwatchlogs" source="*:/aws/lambda/*forge-trust-validator*" "Delayed validation run complete"
+    | rex field=source "^[^:]+:/aws/lambda/(?<lambda_name>[^:]+):"
+    | rex field=source "^[^:]+:/aws/lambda/(?<validator_tenant>[a-z0-9]+)-"
+    | rex field=_raw "Delayed validation run complete: (?<trust_json>\\{.*\\})"
+    | eventstats max(_time) as latest_validation by validator_tenant
+    | where _time=latest_validation
+    | spath input=trust_json path=validation_results{} output=result
+    | mvexpand result
+    | spath input=result path=forge_role_arn output=forge_role
+    | spath input=result path=tenant_results{} output=tenant_result
+    | mvexpand tenant_result
+    | spath input=tenant_result
+    | eval assume_ok=tostring(assume_role_success), tag_ok=tostring(tag_session_success)
+    | where assume_ok!="true" OR tag_ok!="true"
+    | table validator_tenant forge_role tenant_role_arn assume_ok assume_role_error tag_ok tag_session_error
+    | sort validator_tenant forge_role tenant_role_arn
+  EOT
+}
+
+resource "splunk_saved_searches" "forge_iam_trust_failures" {
+  name        = "Forge IAM trust validation failures"
+  description = "Tracks failed AssumeRole or TagSession edges from each tenant validator's latest completed validation. Investigate in the Forge Trust Failures dashboard."
+  search      = local.forge_trust_failure_alert_search
+
+  disabled               = false
+  is_scheduled           = true
+  cron_schedule          = "*/15 * * * *"
+  dispatch_earliest_time = "-24h"
+  dispatch_latest_time   = "now"
+
+  actions               = ""
+  alert_type            = "number of events"
+  alert_comparator      = "greater than"
+  alert_threshold       = "0"
+  alert_digest_mode     = true
+  alert_suppress        = true
+  alert_suppress_period = "30m"
+  alert_severity        = 5
+  alert_track           = true
+
+  acl {
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
+  }
+}

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_trust_failure_alert_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_trust_failure_alert_behavior.tftest.hcl
@@ -1,0 +1,68 @@
+mock_provider "aws" {
+  mock_data "aws_secretsmanager_secret" {
+    defaults = {
+      id = "/cicd/common/splunk-cloud"
+    }
+  }
+
+  mock_data "aws_secretsmanager_secret_version" {
+    defaults = {
+      secret_string = "mock-splunk-secret"
+    }
+  }
+}
+
+mock_provider "splunk" {
+  mock_resource "splunk_saved_searches" {}
+  mock_resource "splunk_data_ui_views" {}
+  mock_resource "splunk_configs_conf" {}
+  mock_resource "splunk_transforms_regex" {}
+}
+
+variables {
+  aws_profile  = "test"
+  aws_region   = "us-east-1"
+  default_tags = { Product = "Forge" }
+  splunk_conf = {
+    splunk_cloud = "https://example.splunkcloud.com"
+    acl = {
+      app     = "search_app_srea"
+      owner   = "nobody"
+      sharing = "app"
+      read    = ["*"]
+      write   = ["admin"]
+    }
+    index        = "srea-forge-prod-index"
+    tenant_names = ["tenant-a"]
+  }
+}
+
+run "creates_role_aware_trust_alert" {
+  command = plan
+
+  assert {
+    condition = (
+      splunk_saved_searches.forge_iam_trust_failures.name == "Forge IAM trust validation failures"
+      && splunk_saved_searches.forge_iam_trust_failures.cron_schedule == "*/15 * * * *"
+      && splunk_saved_searches.forge_iam_trust_failures.dispatch_earliest_time == "-24h"
+      && splunk_saved_searches.forge_iam_trust_failures.alert_type == "number of events"
+      && splunk_saved_searches.forge_iam_trust_failures.alert_comparator == "greater than"
+      && splunk_saved_searches.forge_iam_trust_failures.alert_threshold == "0"
+      && splunk_saved_searches.forge_iam_trust_failures.alert_track
+    )
+    error_message = "The trust alert must run every 15 minutes and track any failed latest validation edge."
+  }
+
+  assert {
+    condition = (
+      startswith(trimspace(splunk_saved_searches.forge_iam_trust_failures.search), "index=\"srea-forge-prod-index\" sourcetype=\"aws:cloudwatchlogs\" source=\"*:/aws/lambda/*forge-trust-validator*\"")
+      && strcontains(splunk_saved_searches.forge_iam_trust_failures.search, "\"Delayed validation run complete\"")
+      && strcontains(splunk_saved_searches.forge_iam_trust_failures.search, "eventstats max(_time) as latest_validation by validator_tenant")
+      && strcontains(splunk_saved_searches.forge_iam_trust_failures.search, "assume_ok!=\"true\" OR tag_ok!=\"true\"")
+      && strcontains(splunk_saved_searches.forge_iam_trust_failures.search, "tenant_role_arn")
+      && strcontains(splunk_saved_searches.forge_iam_trust_failures.search, "assume_role_error")
+      && strcontains(splunk_saved_searches.forge_iam_trust_failures.search, "tag_session_error")
+    )
+    error_message = "The alert must use indexed source filters and preserve role, action, and failure context from the latest completed validation."
+  }
+}

--- a/modules/integrations/splunk_cloud_conf_shared/tests/integrations_splunk_cloud_conf_shared_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/integrations_splunk_cloud_conf_shared_source_inventory.tftest.hcl
@@ -26,6 +26,7 @@ run "integrations_splunk_cloud_conf_shared_contract" {
       "resource \"splunk_data_ui_views\" \"forge_tenant_logs\"",
       "resource \"splunk_data_ui_views\" \"forge_troubleshooting\"",
       "resource \"splunk_data_ui_views\" \"forge_trust_failures\"",
+      "resource \"splunk_saved_searches\" \"forge_iam_trust_failures\"",
       "resource \"splunk_data_ui_views\" \"forge_webhook_job_log_pipeline\"",
       "resource \"splunk_configs_conf\" \"forgecicd_aws_billing_cur\"",
       "resource \"splunk_configs_conf\" \"forgecicd_cloudwatchlogs\"",


### PR DESCRIPTION
## Description

Adds a scheduled, tracked Splunk alert for IAM trust validation failures.

The search starts with indexed source and sourcetype filters, selects each tenant validator's latest completed validation, and reports failed `AssumeRole` or `TagSession` edges with the Forge role, tenant role, and exact error context.

The alert runs every 15 minutes, triggers when the latest validation contains any failed edge, and clears when a later completed validation has no failed edges.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu test` in `modules/integrations/splunk_cloud_conf_shared` — 4 passed
- repository pre-commit suite — passed
