### PR TITLE
fix(eks): disable automatic instance refresh

### DIFF
--- a/modules/infra/eks/nodes.tf
+++ b/modules/infra/eks/nodes.tf
@@ -63,4 +63,11 @@ module "self_managed_node_group" {
 
   tags = merge(local.all_security_tags, { "calico_dependency" = local._wait_for_calico })
 
+  # The upstream module enables a rolling instance refresh by default whenever
+  # the ASG or launch template changes. That includes metadata-only tag changes
+  # and is not Kubernetes-aware, so it can terminate nodes running active jobs.
+  # Node replacement must instead be started by a rollout that cordons the node,
+  # waits for protected workloads to finish, and drains it before termination.
+  instance_refresh = {}
+
 }


### PR DESCRIPTION
## Description

Disable the upstream self-managed node group's default rolling instance refresh. This prevents launch-template and metadata-only tag updates from automatically terminating nodes that may be running active jobs.

Node replacement remains an explicit operation that must cordon the node, wait for protected workloads to finish, and drain it before termination.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `tofu fmt -check modules/infra/eks/nodes.tf`
- `git diff --check`
- All non-validation pre-commit hooks passed
- Validation hooks could not complete because clean initialization failed to download pinned upstream module commits; a retry then exhausted local disk while downloading providers
