### PR TITLE
refactor(observability): streamline Splunk dashboard layouts

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_dind_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_dind_runner_lifecycle.json.tftpl
@@ -137,65 +137,65 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "init_failures_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "init_failures_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "hook_sidecar_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "hook_sidecar_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 600,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "dind_categories_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 640,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 380
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "dind_categories_table",
+                        "position": {
+                            "h": 360,
+                            "w": 640,
+                            "x": 0,
+                            "y": 380
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "dind_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 560,
-                                                                                                                                                    "x": 640,
-                                                                                                                                                    "y": 380
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "dind_trend_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 560,
+                            "x": 640,
+                            "y": 380
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "dind_runner_volume_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "dind_runner_volume_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "runner_version_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "runner_version_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 600,
+                            "y": 740
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_dind_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_dind_runner_lifecycle.json.tftpl
@@ -137,22 +137,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "init_failures_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -162,7 +152,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -172,7 +162,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 640,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 550
+                                                                                                                                                    "y": 380
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -182,7 +172,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 560,
                                                                                                                                                     "x": 640,
-                                                                                                                                                    "y": 550
+                                                                                                                                                    "y": 380
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -192,7 +182,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -202,7 +192,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -222,14 +212,6 @@
     },
     "title": "Forge ARC DIND Runner Lifecycle",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with init-container and hook-sidecar failures; use lifecycle activity, versions, and log volume only after impact is established. **Healthy:** failure panels are empty while lifecycle and volume panels may show normal work. **Action:** identify the tenant and scale set, then inspect ARC listener/controller, Kubernetes capacity, image, storage, and network evidence. **Ownership:** shared ARC/controller faults belong to the Forge platform; scale-set configuration belongs to the tenant; registry or cloud-service failures may be external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "dind_categories_table": {
             "dataSources": {
                 "primary": "dind_categories_search"

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_dind_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_dind_runner_lifecycle.json.tftpl
@@ -137,65 +137,75 @@
                 },
                 "structure": [
                     {
-                        "item": "dind_categories_table",
-                        "position": {
-                            "h": 360,
-                            "w": 640,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dind_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 560,
-                            "x": 640,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "init_failures_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "init_failures_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "hook_sidecar_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "hook_sidecar_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dind_categories_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 640,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 550
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_version_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 740
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dind_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 560,
+                                                                                                                                                    "x": 640,
+                                                                                                                                                    "y": 550
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dind_runner_volume_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 740
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "dind_runner_volume_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "runner_version_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -212,6 +222,14 @@
     },
     "title": "Forge ARC DIND Runner Lifecycle",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with init-container and hook-sidecar failures; use lifecycle activity, versions, and log volume only after impact is established. **Healthy:** failure panels are empty while lifecycle and volume panels may show normal work. **Action:** identify the tenant and scale set, then inspect ARC listener/controller, Kubernetes capacity, image, storage, and network evidence. **Ownership:** shared ARC/controller faults belong to the Forge platform; scale-set configuration belongs to the tenant; registry or cloud-service failures may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "dind_categories_table": {
             "dataSources": {
                 "primary": "dind_categories_search"
@@ -221,7 +239,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "ARC DIND and Hook Categories",
+            "description": "Answers \"Which ARC DIND lifecycle signals are occurring?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which ARC DIND lifecycle signals are occurring?",
             "type": "splunk.table"
         },
         "dind_trend_chart": {
@@ -231,7 +250,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "ARC DIND and Hook Trend",
+            "description": "Answers \"Are ARC DIND lifecycle signals changing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are ARC DIND lifecycle signals changing?",
             "type": "splunk.line"
         },
         "hook_sidecar_table": {
@@ -243,7 +263,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Hook Sidecar Signals",
+            "description": "Answers \"Which hook-sidecar failures need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which hook-sidecar failures need attention?",
             "type": "splunk.table"
         },
         "init_failures_table": {
@@ -255,7 +276,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Init Container Failures",
+            "description": "Answers \"Which init containers are failing?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which init containers are failing?",
             "type": "splunk.table"
         },
         "runner_version_table": {
@@ -267,7 +289,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Versions",
+            "description": "Answers \"Which runner versions are active?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which runner versions are active?",
             "type": "splunk.table"
         },
         "dind_runner_volume_table": {
@@ -279,7 +302,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "DIND Runner Log Volume",
+            "description": "Answers \"Are DIND runner logs still arriving?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are DIND runner logs still arriving?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_k8s_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_k8s_runner_lifecycle.json.tftpl
@@ -137,22 +137,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "k8s_hook_categories_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 640,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -162,7 +152,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -172,7 +162,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -182,7 +172,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 560,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -192,7 +182,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 560,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -202,7 +192,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1290
+                                                                                                                                                    "y": 1120
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -222,14 +212,6 @@
     },
     "title": "Forge ARC K8S Runner Lifecycle",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with pod, PVC, and hook-sidecar failures; use lifecycle activity, versions, and log volume only after impact is established. **Healthy:** failure panels are empty while lifecycle and volume panels may show normal work. **Action:** identify the tenant and scale set, then inspect listener capacity, pending pods, scheduling, storage, image, and networking evidence. **Ownership:** shared ARC/Kubernetes faults belong to the Forge platform; scale-set configuration and workload demand belong to the tenant; registry or cloud-service failures may be external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "k8s_hook_categories_table": {
             "dataSources": {
                 "primary": "k8s_hook_categories_search"

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_k8s_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_k8s_runner_lifecycle.json.tftpl
@@ -137,65 +137,65 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "k8s_hook_categories_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 640,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "k8s_hook_categories_table",
+                        "position": {
+                            "h": 360,
+                            "w": 640,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "k8s_pod_events_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "k8s_pod_events_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 0,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "k8s_pod_scale_set_events_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "k8s_pod_scale_set_events_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 600,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "k8s_hook_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 560,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "k8s_hook_trend_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 560,
+                            "x": 0,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "k8s_runner_volume_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 560,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "k8s_runner_volume_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 560,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "k8s_runner_version_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1120
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "k8s_runner_version_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 0,
+                            "y": 1120
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_k8s_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_k8s_runner_lifecycle.json.tftpl
@@ -137,65 +137,75 @@
                 },
                 "structure": [
                     {
-                        "item": "k8s_hook_categories_table",
-                        "position": {
-                            "h": 360,
-                            "w": 640,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_hook_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 560,
-                            "x": 640,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "k8s_hook_categories_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 640,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_runner_volume_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "k8s_pod_events_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_runner_version_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "k8s_pod_scale_set_events_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_pod_events_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 740
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "k8s_hook_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 560,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_pod_scale_set_events_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 740
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "k8s_runner_volume_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 560,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "k8s_runner_version_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1290
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -212,6 +222,14 @@
     },
     "title": "Forge ARC K8S Runner Lifecycle",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with pod, PVC, and hook-sidecar failures; use lifecycle activity, versions, and log volume only after impact is established. **Healthy:** failure panels are empty while lifecycle and volume panels may show normal work. **Action:** identify the tenant and scale set, then inspect listener capacity, pending pods, scheduling, storage, image, and networking evidence. **Ownership:** shared ARC/Kubernetes faults belong to the Forge platform; scale-set configuration and workload demand belong to the tenant; registry or cloud-service failures may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "k8s_hook_categories_table": {
             "dataSources": {
                 "primary": "k8s_hook_categories_search"
@@ -221,7 +239,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Hook Sidecar Signals",
+            "description": "Answers \"Which hook-sidecar failures need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which hook-sidecar failures need attention?",
             "type": "splunk.table"
         },
         "k8s_hook_trend_chart": {
@@ -231,7 +250,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Hook Sidecar Trend",
+            "description": "Answers \"Are hook-sidecar failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are hook-sidecar failures increasing?",
             "type": "splunk.line"
         },
         "k8s_pod_events_table": {
@@ -243,7 +263,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "K8s Pod and PVC Events",
+            "description": "Answers \"Which runner pods or PVCs need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runner pods or PVCs need attention?",
             "type": "splunk.table"
         },
         "k8s_pod_scale_set_events_table": {
@@ -255,7 +276,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "K8s Pod and PVC Events by Scale Set",
+            "description": "Answers \"Which scale sets have pod or PVC impact?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which scale sets have pod or PVC impact?",
             "type": "splunk.table"
         },
         "k8s_runner_version_table": {
@@ -267,7 +289,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "K8s Runner Versions",
+            "description": "Answers \"Which Kubernetes runner versions are active?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which Kubernetes runner versions are active?",
             "type": "splunk.table"
         },
         "k8s_runner_volume_table": {
@@ -279,7 +302,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "K8s Runner Log Volume",
+            "description": "Answers \"Are Kubernetes runner logs still arriving?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are Kubernetes runner logs still arriving?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ci_job_details.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ci_job_details.json.tftpl
@@ -132,14 +132,6 @@
         }
     },
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with queued-job windows and runner timing, then drill into the affected repository, workflow, job, and runner. **Healthy:** queue and duration remain near that runner lane's historical baseline; non-empty usage panels are expected. **Action:** filter to one tenant and repository before comparing runner groups or changing capacity. **Ownership:** runner-platform failures belong to Forge; lane configuration belongs to the tenant; unusually expensive jobs are workload pressure."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "queued_windows_table": {
             "containerOptions": {},
             "dataSources": {
@@ -399,22 +391,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "queued_windows_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -424,7 +406,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -434,7 +416,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -444,7 +426,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -454,7 +436,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 890
+                                                                                                                                                    "y": 720
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -464,7 +446,7 @@
                                                                                                                                                     "h": 720,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1250
+                                                                                                                                                    "y": 1080
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -474,7 +456,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1970
+                                                                                                                                                    "y": 1800
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -484,7 +466,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 1970
+                                                                                                                                                    "y": 1800
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -494,7 +476,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 2390
+                                                                                                                                                    "y": 2220
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ci_job_details.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ci_job_details.json.tftpl
@@ -132,6 +132,14 @@
         }
     },
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with queued-job windows and runner timing, then drill into the affected repository, workflow, job, and runner. **Healthy:** queue and duration remain near that runner lane's historical baseline; non-empty usage panels are expected. **Action:** filter to one tenant and repository before comparing runner groups or changing capacity. **Ownership:** runner-platform failures belong to Forge; lane configuration belongs to the tenant; unusually expensive jobs are workload pressure."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "queued_windows_table": {
             "containerOptions": {},
             "dataSources": {
@@ -143,7 +151,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Queued Jobs by Time Window",
+            "description": "Answers \"Where is queued-job pressure concentrated?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Where is queued-job pressure concentrated?",
             "type": "splunk.table"
         },
         "runner_type_repo_windows_table": {
@@ -157,7 +166,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Busiest Windows by Runner Type and Repo",
+            "description": "Answers \"Which repositories create the busiest runner windows?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which repositories create the busiest runner windows?",
             "type": "splunk.table"
         },
         "runner_type_timing_table": {
@@ -171,7 +181,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Type Timing",
+            "description": "Answers \"Which runner types have unusual queue or run time?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which runner types have unusual queue or run time?",
             "type": "splunk.table"
         },
         "runner_type_usage_window_chart": {
@@ -183,7 +194,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Type Usage by Time Window",
+            "description": "Answers \"How is runner usage changing?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "How is runner usage changing?",
             "type": "splunk.line"
         },
         "workflow_run_duration_chart": {
@@ -195,7 +207,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Average Workflow Run Duration by Time Window",
+            "description": "Answers \"Is workflow duration changing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Is workflow duration changing?",
             "type": "splunk.line"
         },
         "workflow_run_duration_table": {
@@ -209,7 +222,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Workflow Run Duration by Workflow",
+            "description": "Answers \"Which workflows take the longest?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which workflows take the longest?",
             "type": "splunk.table"
         },
         "runner_type_workflow_windows_table": {
@@ -223,7 +237,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Busiest Windows by Runner Type and Workflow Job",
+            "description": "Answers \"Which workflow jobs drive the busiest windows?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which workflow jobs drive the busiest windows?",
             "type": "splunk.table"
         },
         "workflow_runner_usage_table": {
@@ -237,7 +252,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Workflow Job Runner Usage",
+            "description": "Answers \"Which runners handled each workflow job?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which runners handled each workflow job?",
             "type": "splunk.table"
         },
         "ci_job_details_table": {
@@ -251,7 +267,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "CI Job Details",
+            "description": "Answers \"Which CI jobs need investigation?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which CI jobs need investigation?",
             "type": "splunk.table"
         }
     },
@@ -382,95 +399,105 @@
                 },
                 "structure": [
                     {
-                        "item": "runner_type_timing_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "workflow_runner_usage_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "queued_windows_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "workflow_run_duration_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "runner_type_timing_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_type_usage_window_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "workflow_run_duration_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "workflow_run_duration_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 720
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "workflow_run_duration_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "queued_windows_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 720
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "workflow_runner_usage_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 890
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_type_repo_windows_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 0,
-                            "y": 1080
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "ci_job_details_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 720,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1250
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_type_workflow_windows_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 600,
-                            "y": 1080
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "runner_type_usage_window_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1970
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ci_job_details_table",
-                        "position": {
-                            "h": 720,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1500
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "runner_type_repo_windows_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 1970
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "runner_type_workflow_windows_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 2390
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ci_job_details.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ci_job_details.json.tftpl
@@ -391,95 +391,95 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "queued_windows_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "queued_windows_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "runner_type_timing_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "runner_type_timing_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 600,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "workflow_run_duration_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "workflow_run_duration_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "workflow_run_duration_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "workflow_run_duration_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 600,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "workflow_runner_usage_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 720
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "workflow_runner_usage_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 720
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ci_job_details_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 720,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1080
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "ci_job_details_table",
+                        "position": {
+                            "h": 720,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1080
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "runner_type_usage_window_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1800
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "runner_type_usage_window_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 1800
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "runner_type_repo_windows_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 1800
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "runner_type_repo_windows_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 600,
+                            "y": 1800
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "runner_type_workflow_windows_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 2220
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "runner_type_workflow_windows_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 0,
+                            "y": 2220
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ingestion_quality.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ingestion_quality.json.tftpl
@@ -116,55 +116,55 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "missing_fields_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "missing_fields_table",
+                        "position": {
+                            "h": 380,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "volume_anomaly_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 740,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 380
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "volume_anomaly_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 740,
+                            "x": 0,
+                            "y": 380
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ingestion_quality_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "ingestion_quality_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 0,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "sourcetype_inventory_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 460,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "sourcetype_inventory_table",
+                        "position": {
+                            "h": 360,
+                            "w": 460,
+                            "x": 600,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "source_inventory_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1160
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "source_inventory_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 0,
+                            "y": 1160
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ingestion_quality.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ingestion_quality.json.tftpl
@@ -116,55 +116,65 @@
                 },
                 "structure": [
                     {
-                        "item": "sourcetype_inventory_table",
-                        "position": {
-                            "h": 360,
-                            "w": 460,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "volume_anomaly_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 740,
-                            "x": 460,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "missing_fields_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "source_inventory_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "volume_anomaly_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 740,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 550
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ingestion_quality_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "ingestion_quality_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "missing_fields_table",
-                        "position": {
-                            "h": 380,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 780
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "sourcetype_inventory_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 460,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "source_inventory_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1330
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -181,6 +191,14 @@
     },
     "title": "Forge Ingestion Quality",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with missing structured fields and runner-log ingestion quality, then use source and sourcetype inventory to locate the affected pipeline. **Healthy:** missing-field panels are empty and expected sources continue arriving; high volume alone is not failure. **Action:** identify the source, sourcetype, tenant, and last event before checking Firehose, Kinesis, S3, Lambda, or Splunk delivery. **Ownership:** shared ingestion configuration belongs to Forge; malformed tenant-emitted events belong to the producer; Splunk or AWS delivery outages may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "ingestion_quality_table": {
             "dataSources": {
                 "primary": "ingestion_quality_search"
@@ -190,7 +208,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Log Ingestion Quality",
+            "description": "Answers \"Are runner logs arriving with required fields?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are runner logs arriving with required fields?",
             "type": "splunk.table"
         },
         "missing_fields_table": {
@@ -202,7 +221,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Missing Structured Fields",
+            "description": "Answers \"Which events are missing structured fields?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which events are missing structured fields?",
             "type": "splunk.table"
         },
         "source_inventory_table": {
@@ -214,7 +234,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Top Sources",
+            "description": "Answers \"Which sources produce the most events?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which sources produce the most events?",
             "type": "splunk.table"
         },
         "sourcetype_inventory_table": {
@@ -226,7 +247,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Sourcetype Inventory",
+            "description": "Answers \"Which sourcetypes are arriving?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which sourcetypes are arriving?",
             "type": "splunk.table"
         },
         "volume_anomaly_chart": {
@@ -236,7 +258,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "High-Volume Sourcetype Trend",
+            "description": "Answers \"Is ingestion volume changing unexpectedly?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Is ingestion volume changing unexpectedly?",
             "type": "splunk.line"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ingestion_quality.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ingestion_quality.json.tftpl
@@ -116,22 +116,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "missing_fields_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -141,7 +131,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 740,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 550
+                                                                                                                                                    "y": 380
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -151,7 +141,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -161,7 +151,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 460,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -171,7 +161,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1330
+                                                                                                                                                    "y": 1160
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -191,14 +181,6 @@
     },
     "title": "Forge Ingestion Quality",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with missing structured fields and runner-log ingestion quality, then use source and sourcetype inventory to locate the affected pipeline. **Healthy:** missing-field panels are empty and expected sources continue arriving; high volume alone is not failure. **Action:** identify the source, sourcetype, tenant, and last event before checking Firehose, Kinesis, S3, Lambda, or Splunk delivery. **Ownership:** shared ingestion configuration belongs to Forge; malformed tenant-emitted events belong to the producer; Splunk or AWS delivery outages may be external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "ingestion_quality_table": {
             "dataSources": {
                 "primary": "ingestion_quality_search"

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_kubernetes_storage_and_network.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_kubernetes_storage_and_network.json.tftpl
@@ -182,115 +182,125 @@
                 },
                 "structure": [
                     {
-                        "item": "kube_event_categories_table",
-                        "position": {
-                            "h": 340,
-                            "w": 600,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "kube_event_trend_chart",
-                        "position": {
-                            "h": 340,
-                            "w": 600,
-                            "x": 600,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "api_storage_errors_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "pvc_stuck_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 340
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "karpenter_controller_health_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 590
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ebs_wait_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 340
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "calico_tigera_health_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 590
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "api_storage_errors_table",
-                        "position": {
-                            "h": 420,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 720
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "ebs_csi_health_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1010
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "karpenter_controller_health_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 0,
-                            "y": 1140
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "eks_pod_identity_health_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 1010
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "calico_tigera_health_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 600,
-                            "y": 1140
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "component_job_window_correlation_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 460,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1430
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ebs_csi_health_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 0,
-                            "y": 1560
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "pvc_stuck_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1890
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "eks_pod_identity_health_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 600,
-                            "y": 1560
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "kube_event_categories_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 340,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 1890
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_job_correlation_table",
-                        "position": {
-                            "h": 460,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1980
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "runner_job_correlation_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 460,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 2270
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "component_job_window_correlation_table",
-                        "position": {
-                            "h": 460,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 2440
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "kube_event_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 340,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 2730
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "ebs_wait_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 2730
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -307,6 +317,14 @@
     },
     "title": "Forge Kubernetes Storage and Network",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with failed-job correlation and persistent storage, scheduling, CNI, or controller errors; use component inventories only after impact is established. **Healthy:** actionable error and aged-object panels are empty; routine controller events may still appear. **Action:** identify cluster, namespace, pod, PVC, node, scale set, and tenant before checking Karpenter, EBS CSI, CNI, image, and network paths. **Ownership:** shared cluster/controller faults belong to Forge; workload requests and scale-set configuration belong to the tenant; AWS or registry failures may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "api_storage_errors_table": {
             "dataSources": {
                 "primary": "api_storage_errors_search"
@@ -316,7 +334,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EKS API Storage and Controller Errors",
+            "description": "Answers \"Which EKS storage or controller calls are failing?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which EKS storage or controller calls are failing?",
             "type": "splunk.table"
         },
         "ebs_wait_table": {
@@ -328,7 +347,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EBS Provisioning Waits",
+            "description": "Answers \"Which EBS volumes are still waiting?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which EBS volumes are still waiting?",
             "type": "splunk.table"
         },
         "ebs_csi_health_table": {
@@ -340,7 +360,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EBS CSI Health",
+            "description": "Answers \"Which EBS CSI components need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which EBS CSI components need attention?",
             "type": "splunk.table"
         },
         "eks_pod_identity_health_table": {
@@ -352,7 +373,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EKS Pod Identity Health",
+            "description": "Answers \"Which pod-identity operations are failing?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which pod-identity operations are failing?",
             "type": "splunk.table"
         },
         "calico_tigera_health_table": {
@@ -364,7 +386,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Calico and Tigera Health",
+            "description": "Answers \"Which Calico or Tigera components need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which Calico or Tigera components need attention?",
             "type": "splunk.table"
         },
         "component_job_window_correlation_table": {
@@ -376,7 +399,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Controller and CNI Errors Correlated with Failed Jobs",
+            "description": "Answers \"Do controller or CNI errors overlap failed jobs?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Do controller or CNI errors overlap failed jobs?",
             "type": "splunk.table"
         },
         "karpenter_controller_health_table": {
@@ -388,7 +412,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Karpenter Controller Health",
+            "description": "Answers \"Which Karpenter operations need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which Karpenter operations need attention?",
             "type": "splunk.table"
         },
         "kube_event_categories_table": {
@@ -400,7 +425,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Storage, Scheduler, and CNI Signals",
+            "description": "Answers \"Which storage, scheduling, or CNI signals are actionable?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which storage, scheduling, or CNI signals are actionable?",
             "type": "splunk.table"
         },
         "kube_event_trend_chart": {
@@ -410,7 +436,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Storage, Scheduler, and CNI Trend",
+            "description": "Answers \"Are Kubernetes infrastructure failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are Kubernetes infrastructure failures increasing?",
             "type": "splunk.line"
         },
         "pvc_stuck_table": {
@@ -422,7 +449,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "PVC Still Attached",
+            "description": "Answers \"Which PVCs remain attached unexpectedly?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which PVCs remain attached unexpectedly?",
             "type": "splunk.table"
         },
         "runner_job_correlation_table": {
@@ -434,7 +462,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Kubernetes Issues Correlated with GitHub Jobs",
+            "description": "Answers \"Which GitHub jobs overlap Kubernetes issues?\" using time-window overlap. This is diagnostic proximity, not proof of causality. Healthy: no overlap with affected jobs. Action: validate the exact workflow job and resource identifiers in their source logs before assigning ownership.",
+            "title": "Which GitHub jobs overlap Kubernetes issues?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_kubernetes_storage_and_network.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_kubernetes_storage_and_network.json.tftpl
@@ -182,115 +182,115 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "api_storage_errors_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "api_storage_errors_table",
+                        "position": {
+                            "h": 420,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "karpenter_controller_health_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 420
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "karpenter_controller_health_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 0,
+                            "y": 420
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "calico_tigera_health_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 420
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "calico_tigera_health_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 600,
+                            "y": 420
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ebs_csi_health_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 840
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "ebs_csi_health_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 0,
+                            "y": 840
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "eks_pod_identity_health_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 840
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "eks_pod_identity_health_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 600,
+                            "y": 840
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "component_job_window_correlation_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 460,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1260
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "component_job_window_correlation_table",
+                        "position": {
+                            "h": 460,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1260
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "pvc_stuck_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1720
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "pvc_stuck_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 0,
+                            "y": 1720
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "kube_event_categories_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 340,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 1720
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "kube_event_categories_table",
+                        "position": {
+                            "h": 340,
+                            "w": 600,
+                            "x": 600,
+                            "y": 1720
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "runner_job_correlation_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 460,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 2100
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "runner_job_correlation_table",
+                        "position": {
+                            "h": 460,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 2100
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "kube_event_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 340,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 2560
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "kube_event_trend_chart",
+                        "position": {
+                            "h": 340,
+                            "w": 600,
+                            "x": 0,
+                            "y": 2560
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ebs_wait_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 2560
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "ebs_wait_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 600,
+                            "y": 2560
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_kubernetes_storage_and_network.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_kubernetes_storage_and_network.json.tftpl
@@ -182,22 +182,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "api_storage_errors_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -207,7 +197,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 590
+                                                                                                                                                    "y": 420
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -217,7 +207,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 590
+                                                                                                                                                    "y": 420
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -227,7 +217,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1010
+                                                                                                                                                    "y": 840
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -237,7 +227,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 1010
+                                                                                                                                                    "y": 840
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -247,7 +237,7 @@
                                                                                                                                                     "h": 460,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1430
+                                                                                                                                                    "y": 1260
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -257,7 +247,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1890
+                                                                                                                                                    "y": 1720
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -267,7 +257,7 @@
                                                                                                                                                     "h": 340,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 1890
+                                                                                                                                                    "y": 1720
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -277,7 +267,7 @@
                                                                                                                                                     "h": 460,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 2270
+                                                                                                                                                    "y": 2100
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -287,7 +277,7 @@
                                                                                                                                                     "h": 340,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 2730
+                                                                                                                                                    "y": 2560
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -297,7 +287,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 2730
+                                                                                                                                                    "y": 2560
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -317,14 +307,6 @@
     },
     "title": "Forge Kubernetes Storage and Network",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with failed-job correlation and persistent storage, scheduling, CNI, or controller errors; use component inventories only after impact is established. **Healthy:** actionable error and aged-object panels are empty; routine controller events may still appear. **Action:** identify cluster, namespace, pod, PVC, node, scale set, and tenant before checking Karpenter, EBS CSI, CNI, image, and network paths. **Ownership:** shared cluster/controller faults belong to Forge; workload requests and scale-set configuration belong to the tenant; AWS or registry failures may be external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "api_storage_errors_table": {
             "dataSources": {
                 "primary": "api_storage_errors_search"

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_lambda_operations.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_lambda_operations.json.tftpl
@@ -125,22 +125,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "lambda_errors_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 700,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -150,7 +140,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -160,7 +150,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -170,7 +160,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 500,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 890
+                                                                                                                                                    "y": 720
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -180,7 +170,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1250
+                                                                                                                                                    "y": 1080
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -200,14 +190,6 @@
     },
     "title": "Forge Lambda Operations",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with errors by Lambda and category, then inspect a unique request sample and retry outcome. **Healthy:** error and retry panels are empty or remain at the established healthy baseline; one duplicated stack trace is one invocation, not multiple failures. **Action:** identify Lambda, tenant, region, request ID, operation, and downstream dependency before assigning cause. **Ownership:** deterministic shared-code failures belong to Forge; tenant resource permissions belong to tenant configuration; AWS, GitHub, or Splunk failures may be external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "ingestion_retries_table": {
             "dataSources": {
                 "primary": "ingestion_retries_search"

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_lambda_operations.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_lambda_operations.json.tftpl
@@ -125,55 +125,65 @@
                 },
                 "structure": [
                     {
-                        "item": "lambda_errors_table",
-                        "position": {
-                            "h": 360,
-                            "w": 700,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "lambda_error_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 500,
-                            "x": 700,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "lambda_errors_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 700,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_tag_failures_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "runner_tag_failures_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ingestion_retries_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "ingestion_retries_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "lambda_samples_table",
-                        "position": {
-                            "h": 420,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 720
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "lambda_error_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 500,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 890
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "lambda_samples_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1250
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -190,6 +200,14 @@
     },
     "title": "Forge Lambda Operations",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with errors by Lambda and category, then inspect a unique request sample and retry outcome. **Healthy:** error and retry panels are empty or remain at the established healthy baseline; one duplicated stack trace is one invocation, not multiple failures. **Action:** identify Lambda, tenant, region, request ID, operation, and downstream dependency before assigning cause. **Ownership:** deterministic shared-code failures belong to Forge; tenant resource permissions belong to tenant configuration; AWS, GitHub, or Splunk failures may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "ingestion_retries_table": {
             "dataSources": {
                 "primary": "ingestion_retries_search"
@@ -199,7 +217,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Splunk S3 Runner Log Ingestion Retries",
+            "description": "Answers \"Which runner-log ingestion retries need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runner-log ingestion retries need attention?",
             "type": "splunk.table"
         },
         "lambda_error_trend_chart": {
@@ -209,7 +228,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Lambda Error Trend",
+            "description": "Answers \"Are Lambda errors increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are Lambda errors increasing?",
             "type": "splunk.line"
         },
         "lambda_errors_table": {
@@ -221,7 +241,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Lambda Errors by Category",
+            "description": "Answers \"Which Lambda error categories are affecting production?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which Lambda error categories are affecting production?",
             "type": "splunk.table"
         },
         "lambda_samples_table": {
@@ -233,7 +254,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Latest Lambda Error Samples",
+            "description": "Answers \"What failed in the latest unique Lambda invocations?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "What failed in the latest unique Lambda invocations?",
             "type": "splunk.table"
         },
         "runner_tag_failures_table": {
@@ -245,7 +267,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EC2 Runner Tagging Failures",
+            "description": "Answers \"Which runner-tagging operations failed?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runner-tagging operations failed?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_lambda_operations.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_lambda_operations.json.tftpl
@@ -125,55 +125,55 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "lambda_errors_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 700,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "lambda_errors_table",
+                        "position": {
+                            "h": 360,
+                            "w": 700,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "runner_tag_failures_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "runner_tag_failures_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ingestion_retries_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "ingestion_retries_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 600,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "lambda_error_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 500,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 720
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "lambda_error_trend_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 500,
+                            "x": 0,
+                            "y": 720
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "lambda_samples_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1080
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "lambda_samples_table",
+                        "position": {
+                            "h": 420,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1080
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_capacity.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_capacity.json.tftpl
@@ -113,22 +113,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "queue_pressure_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 720,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -138,7 +128,7 @@
                                                                                                                                                     "h": 460,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 590
+                                                                                                                                                    "y": 420
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -148,7 +138,7 @@
                                                                                                                                                     "h": 460,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 590
+                                                                                                                                                    "y": 420
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -158,7 +148,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 480,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1050
+                                                                                                                                                    "y": 880
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -178,14 +168,6 @@
     },
     "title": "Forge Runner Capacity",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with sustained queue pressure, then compare ARC runner-set state or EC2 pool symptoms for the same runner group. **Healthy:** queue delay stays near the lane's historical baseline and capacity signals show progress; one elevated percentile is not enough to infer failure. **Action:** identify tenant, labels, runner group, provider, and time window before changing capacity. **Ownership:** shared controller limits belong to Forge; lane size and mapping belong to tenant configuration; unusually heavy jobs are workload pressure."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "arc_runner_state_table": {
             "dataSources": {
                 "primary": "arc_runner_state_search"
@@ -221,7 +203,7 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "description": "Answers \"Which runner groups have sustained queue pressure?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "description": "Answers \"Which runner groups have sustained queue pressure?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. One elevated percentile is not enough to infer failure. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
             "title": "Which runner groups have sustained queue pressure?",
             "type": "splunk.table"
         },

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_capacity.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_capacity.json.tftpl
@@ -113,45 +113,45 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "queue_pressure_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 720,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "queue_pressure_table",
+                        "position": {
+                            "h": 420,
+                            "w": 720,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "arc_runner_state_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 460,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 420
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "arc_runner_state_table",
+                        "position": {
+                            "h": 460,
+                            "w": 600,
+                            "x": 0,
+                            "y": 420
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ec2_pool_symptoms_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 460,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 420
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "ec2_pool_symptoms_table",
+                        "position": {
+                            "h": 460,
+                            "w": 600,
+                            "x": 600,
+                            "y": 420
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "queue_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 480,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 880
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "queue_trend_chart",
+                        "position": {
+                            "h": 420,
+                            "w": 480,
+                            "x": 0,
+                            "y": 880
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_capacity.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_capacity.json.tftpl
@@ -113,45 +113,55 @@
                 },
                 "structure": [
                     {
-                        "item": "queue_pressure_table",
-                        "position": {
-                            "h": 420,
-                            "w": 720,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "queue_trend_chart",
-                        "position": {
-                            "h": 420,
-                            "w": 480,
-                            "x": 720,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "queue_pressure_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 720,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "arc_runner_state_table",
-                        "position": {
-                            "h": 460,
-                            "w": 600,
-                            "x": 0,
-                            "y": 420
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "arc_runner_state_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 460,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 590
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ec2_pool_symptoms_table",
-                        "position": {
-                            "h": 460,
-                            "w": 600,
-                            "x": 600,
-                            "y": 420
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "ec2_pool_symptoms_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 460,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 590
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "queue_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 480,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1050
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -168,6 +178,14 @@
     },
     "title": "Forge Runner Capacity",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with sustained queue pressure, then compare ARC runner-set state or EC2 pool symptoms for the same runner group. **Healthy:** queue delay stays near the lane's historical baseline and capacity signals show progress; one elevated percentile is not enough to infer failure. **Action:** identify tenant, labels, runner group, provider, and time window before changing capacity. **Ownership:** shared controller limits belong to Forge; lane size and mapping belong to tenant configuration; unusually heavy jobs are workload pressure."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "arc_runner_state_table": {
             "dataSources": {
                 "primary": "arc_runner_state_search"
@@ -177,7 +195,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "ARC Runner Set State",
+            "description": "Answers \"Can ARC runner sets accept more work?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Can ARC runner sets accept more work?",
             "type": "splunk.table"
         },
         "ec2_pool_symptoms_table": {
@@ -189,7 +208,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EC2 Runner Pool Symptoms",
+            "description": "Answers \"Which EC2 runner pools show capacity symptoms?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which EC2 runner pools show capacity symptoms?",
             "type": "splunk.table"
         },
         "queue_pressure_table": {
@@ -201,7 +221,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Queue Pressure by Runner Group",
+            "description": "Answers \"Which runner groups have sustained queue pressure?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runner groups have sustained queue pressure?",
             "type": "splunk.table"
         },
         "queue_trend_chart": {
@@ -211,7 +232,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Queue p95 Trend",
+            "description": "Answers \"Is runner-group queue latency increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Is runner-group queue latency increasing?",
             "type": "splunk.line"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_control_plane_health.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_control_plane_health.json.tftpl
@@ -181,85 +181,85 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "api_warning_summary_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "api_warning_summary_table",
+                        "position": {
+                            "h": 360,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "scale_up_registration_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 700,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "scale_up_registration_table",
+                        "position": {
+                            "h": 380,
+                            "w": 700,
+                            "x": 0,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "scale_down_cleanup_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 400,
-                                                                                                                                                    "w": 700,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "scale_down_cleanup_table",
+                        "position": {
+                            "h": 400,
+                            "w": 700,
+                            "x": 0,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "global_lock_cleanup_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1140
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "global_lock_cleanup_table",
+                        "position": {
+                            "h": 420,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1140
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "scale_up_registration_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 500,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1560
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "scale_up_registration_trend_chart",
+                        "position": {
+                            "h": 380,
+                            "w": 500,
+                            "x": 0,
+                            "y": 1560
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "scale_down_cleanup_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 400,
-                                                                                                                                                    "w": 500,
-                                                                                                                                                    "x": 500,
-                                                                                                                                                    "y": 1560
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "scale_down_cleanup_trend_chart",
+                        "position": {
+                            "h": 400,
+                            "w": 500,
+                            "x": 500,
+                            "y": 1560
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "pool_activity_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 700,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1960
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "pool_activity_table",
+                        "position": {
+                            "h": 380,
+                            "w": 700,
+                            "x": 0,
+                            "y": 1960
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "pool_topup_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 500,
-                                                                                                                                                    "x": 700,
-                                                                                                                                                    "y": 1960
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "pool_topup_trend_chart",
+                        "position": {
+                            "h": 380,
+                            "w": 500,
+                            "x": 700,
+                            "y": 1960
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_control_plane_health.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_control_plane_health.json.tftpl
@@ -181,85 +181,95 @@
                 },
                 "structure": [
                     {
-                        "item": "scale_up_registration_table",
-                        "position": {
-                            "h": 380,
-                            "w": 700,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "scale_up_registration_trend_chart",
-                        "position": {
-                            "h": 380,
-                            "w": 500,
-                            "x": 700,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "api_warning_summary_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "pool_activity_table",
-                        "position": {
-                            "h": 380,
-                            "w": 700,
-                            "x": 0,
-                            "y": 380
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "scale_up_registration_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 700,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "pool_topup_trend_chart",
-                        "position": {
-                            "h": 380,
-                            "w": 500,
-                            "x": 700,
-                            "y": 380
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "scale_down_cleanup_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 400,
+                                                                                                                                                    "w": 700,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "scale_down_cleanup_table",
-                        "position": {
-                            "h": 400,
-                            "w": 700,
-                            "x": 0,
-                            "y": 760
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "global_lock_cleanup_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1310
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "scale_down_cleanup_trend_chart",
-                        "position": {
-                            "h": 400,
-                            "w": 500,
-                            "x": 700,
-                            "y": 760
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "scale_up_registration_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 500,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1730
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "api_warning_summary_table",
-                        "position": {
-                            "h": 360,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1160
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "scale_down_cleanup_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 400,
+                                                                                                                                                    "w": 500,
+                                                                                                                                                    "x": 500,
+                                                                                                                                                    "y": 1730
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "global_lock_cleanup_table",
-                        "position": {
-                            "h": 420,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1520
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "pool_activity_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 700,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 2130
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "pool_topup_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 500,
+                                                                                                                                                    "x": 700,
+                                                                                                                                                    "y": 2130
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -276,6 +286,14 @@
     },
     "title": "Forge Runner Control Plane Health",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with scale-up registration failures and GitHub or SQS API warnings, then inspect pool and cleanup outcomes. **Healthy:** failure panels are empty while pool checks and successful cleanup activity may be present. **Action:** identify tenant, request, runner group, and downstream API; verify retry or later success before assigning cause. **Ownership:** shared dispatcher and lifecycle defects belong to Forge; runner configuration belongs to the tenant; GitHub and AWS API outages are external. Global-lock cleanup is diagnostic and is not causal evidence for a stuck job."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "api_warning_summary_table": {
             "dataSources": {
                 "primary": "api_warning_summary_search"
@@ -285,7 +303,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "GitHub and SQS API Warnings",
+            "description": "Answers \"Which GitHub or SQS API calls need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which GitHub or SQS API calls need attention?",
             "type": "splunk.table"
         },
         "global_lock_cleanup_table": {
@@ -297,7 +316,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Global-Lock Cleanup Outcomes",
+            "description": "Answers \"Did global-lock cleanup complete safely?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Did global-lock cleanup complete safely?",
             "type": "splunk.table"
         },
         "pool_activity_table": {
@@ -309,7 +329,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Pool Top-Up Activity",
+            "description": "Answers \"Are runner pools topping up successfully?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are runner pools topping up successfully?",
             "type": "splunk.table"
         },
         "pool_topup_trend_chart": {
@@ -319,7 +340,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Pool Top-Up Trend",
+            "description": "Answers \"Is pool top-up behavior changing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Is pool top-up behavior changing?",
             "type": "splunk.line"
         },
         "scale_down_cleanup_table": {
@@ -331,7 +353,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Scale-Down Cleanup Signals",
+            "description": "Answers \"Which runner cleanup operations need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runner cleanup operations need attention?",
             "type": "splunk.table"
         },
         "scale_down_cleanup_trend_chart": {
@@ -341,7 +364,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Scale-Down Cleanup Trend",
+            "description": "Answers \"Are runner cleanup failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are runner cleanup failures increasing?",
             "type": "splunk.line"
         },
         "scale_up_registration_table": {
@@ -353,7 +377,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Scale-Up Registration and Post-Launch Signals",
+            "description": "Answers \"Which runners failed provisioning or registration?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runners failed provisioning or registration?",
             "type": "splunk.table"
         },
         "scale_up_registration_trend_chart": {
@@ -363,7 +388,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Scale-Up Registration Trend",
+            "description": "Answers \"Are provisioning or registration failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are provisioning or registration failures increasing?",
             "type": "splunk.line"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_control_plane_health.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_control_plane_health.json.tftpl
@@ -181,22 +181,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "api_warning_summary_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -206,7 +196,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 700,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -216,7 +206,7 @@
                                                                                                                                                     "h": 400,
                                                                                                                                                     "w": 700,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -226,7 +216,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1310
+                                                                                                                                                    "y": 1140
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -236,7 +226,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 500,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1730
+                                                                                                                                                    "y": 1560
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -246,7 +236,7 @@
                                                                                                                                                     "h": 400,
                                                                                                                                                     "w": 500,
                                                                                                                                                     "x": 500,
-                                                                                                                                                    "y": 1730
+                                                                                                                                                    "y": 1560
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -256,7 +246,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 700,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 2130
+                                                                                                                                                    "y": 1960
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -266,7 +256,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 500,
                                                                                                                                                     "x": 700,
-                                                                                                                                                    "y": 2130
+                                                                                                                                                    "y": 1960
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -286,14 +276,6 @@
     },
     "title": "Forge Runner Control Plane Health",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with scale-up registration failures and GitHub or SQS API warnings, then inspect pool and cleanup outcomes. **Healthy:** failure panels are empty while pool checks and successful cleanup activity may be present. **Action:** identify tenant, request, runner group, and downstream API; verify retry or later success before assigning cause. **Ownership:** shared dispatcher and lifecycle defects belong to Forge; runner configuration belongs to the tenant; GitHub and AWS API outages are external. Global-lock cleanup is diagnostic and is not causal evidence for a stuck job."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "api_warning_summary_table": {
             "dataSources": {
                 "primary": "api_warning_summary_search"
@@ -316,7 +298,7 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "description": "Answers \"Did global-lock cleanup complete safely?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "description": "Answers \"Did global-lock cleanup complete safely?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Global-lock cleanup is diagnostic and is not causal evidence for a stuck job. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
             "title": "Did global-lock cleanup complete safely?",
             "type": "splunk.table"
         },

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_tenant_logs.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_tenant_logs.json.tftpl
@@ -73,14 +73,6 @@
         }
     },
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nUse this raw-event dashboard after a health dashboard identifies a tenant, instance, service, or request. **Healthy:** expected sources continue arriving; an empty result only means the current filters matched no retained events. **Action:** narrow the time range and correlate unique request, workflow job, run, runner, and instance identifiers. **Ownership:** raw logs provide evidence but do not assign Forge, tenant, workload, or external ownership by themselves."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "viz_KuqTQOYc": {
             "containerOptions": {},
             "context": {},
@@ -90,7 +82,7 @@
             "options": {},
             "showLastUpdated": false,
             "showProgressBar": false,
-            "description": "Shows retained raw Forge events for the selected tenant, log type, instance, and global time range. Healthy is not determined by row count; an empty result can mean no matching retained events. Action: correlate request, workflow-job, run, runner, instance, and region identifiers with the dashboard that identified impact.",
+            "description": "Shows retained raw Forge events for the selected tenant, log type, instance, and global time range. Healthy is not determined by row count; an empty result can mean no matching retained events. Action: correlate request, workflow-job, run, runner, instance, and region identifiers with the dashboard that identified impact. Raw logs provide evidence but do not assign ownership by themselves.",
             "title": "Which tenant log events match the investigation?",
             "type": "splunk.events"
         }
@@ -136,27 +128,17 @@
         "layoutDefinitions": {
             "layout_1": {
                 "options": {
-                    "height": 960,
+                    "height": 790,
                     "width": 1440
                 },
                 "structure": [
-                    {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
                     {
                                                                                                                                                 "item": "viz_KuqTQOYc",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 626,
                                                                                                                                                     "w": 1440,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_tenant_logs.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_tenant_logs.json.tftpl
@@ -73,6 +73,14 @@
         }
     },
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nUse this raw-event dashboard after a health dashboard identifies a tenant, instance, service, or request. **Healthy:** expected sources continue arriving; an empty result only means the current filters matched no retained events. **Action:** narrow the time range and correlate unique request, workflow job, run, runner, and instance identifiers. **Ownership:** raw logs provide evidence but do not assign Forge, tenant, workload, or external ownership by themselves."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "viz_KuqTQOYc": {
             "containerOptions": {},
             "context": {},
@@ -82,6 +90,8 @@
             "options": {},
             "showLastUpdated": false,
             "showProgressBar": false,
+            "description": "Shows retained raw Forge events for the selected tenant, log type, instance, and global time range. Healthy is not determined by row count; an empty result can mean no matching retained events. Action: correlate request, workflow-job, run, runner, instance, and region identifiers with the dashboard that identified impact.",
+            "title": "Which tenant log events match the investigation?",
             "type": "splunk.events"
         }
     },
@@ -131,15 +141,25 @@
                 },
                 "structure": [
                     {
-                        "item": "viz_KuqTQOYc",
-                        "position": {
-                            "h": 626,
-                            "w": 1440,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "viz_KuqTQOYc",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 626,
+                                                                                                                                                    "w": 1440,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_tenant_logs.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_tenant_logs.json.tftpl
@@ -133,15 +133,15 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "viz_KuqTQOYc",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 626,
-                                                                                                                                                    "w": 1440,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "viz_KuqTQOYc",
+                        "position": {
+                            "h": 626,
+                            "w": 1440,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_troubleshooting.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_troubleshooting.json.tftpl
@@ -290,22 +290,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "eks_api_errors_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -315,7 +305,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -325,7 +315,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 590
+                                                                                                                                                    "y": 420
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -335,7 +325,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 590
+                                                                                                                                                    "y": 420
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -543,14 +533,6 @@
     },
     "title": "Forge Troubleshooting",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with failed-job hot spots and the smallest affected tenant, repository, runner group, or resource, then move to the matching Lambda, EC2, ARC/Kubernetes, trust, or ingestion panel. **Healthy:** actionable failure panels are empty while inventory and activity panels may contain normal traffic. **Action:** correlate one workflow job or request across adjacent dashboards before assigning cause. **Ownership:** separate Forge code, shared platform configuration, tenant configuration, workload pressure, and external dependencies."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "arc_listener_activity_chart": {
             "dataSources": {
                 "primary": "arc_listener_activity_search"

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_troubleshooting.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_troubleshooting.json.tftpl
@@ -290,45 +290,45 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "eks_api_errors_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "eks_api_errors_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "eks_api_403_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "eks_api_403_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 600,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ec2_runner_symptoms_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 420
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "ec2_runner_symptoms_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 0,
+                            "y": 420
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ec2_runner_samples_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 420
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "ec2_runner_samples_table",
+                        "position": {
+                            "h": 420,
+                            "w": 600,
+                            "x": 600,
+                            "y": 420
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             },

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_troubleshooting.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_troubleshooting.json.tftpl
@@ -290,45 +290,55 @@
                 },
                 "structure": [
                     {
-                        "item": "ec2_runner_symptoms_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ec2_runner_samples_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 600,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "eks_api_errors_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "eks_api_errors_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 0,
-                            "y": 420
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "eks_api_403_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "eks_api_403_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 600,
-                            "y": 420
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "ec2_runner_symptoms_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 590
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "ec2_runner_samples_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 590
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             },
@@ -343,7 +353,7 @@
                             "h": 420,
                             "w": 650,
                             "x": 0,
-                            "y": 0
+                            "y": 170
                         },
                         "type": "block"
                     },
@@ -353,7 +363,7 @@
                             "h": 420,
                             "w": 550,
                             "x": 650,
-                            "y": 0
+                            "y": 170
                         },
                         "type": "block"
                     },
@@ -363,7 +373,7 @@
                             "h": 500,
                             "w": 1200,
                             "x": 0,
-                            "y": 420
+                            "y": 590
                         },
                         "type": "block"
                     }
@@ -381,7 +391,7 @@
                             "h": 300,
                             "w": 1200,
                             "x": 0,
-                            "y": 0
+                            "y": 170
                         },
                         "type": "block"
                     },
@@ -391,7 +401,7 @@
                             "h": 420,
                             "w": 1200,
                             "x": 0,
-                            "y": 300
+                            "y": 470
                         },
                         "type": "block"
                     },
@@ -401,7 +411,7 @@
                             "h": 460,
                             "w": 760,
                             "x": 0,
-                            "y": 720
+                            "y": 890
                         },
                         "type": "block"
                     },
@@ -411,7 +421,7 @@
                             "h": 460,
                             "w": 440,
                             "x": 760,
-                            "y": 720
+                            "y": 890
                         },
                         "type": "block"
                     }
@@ -429,7 +439,7 @@
                             "h": 420,
                             "w": 600,
                             "x": 0,
-                            "y": 0
+                            "y": 170
                         },
                         "type": "block"
                     },
@@ -439,7 +449,7 @@
                             "h": 420,
                             "w": 600,
                             "x": 600,
-                            "y": 0
+                            "y": 170
                         },
                         "type": "block"
                     },
@@ -449,7 +459,7 @@
                             "h": 420,
                             "w": 600,
                             "x": 0,
-                            "y": 420
+                            "y": 590
                         },
                         "type": "block"
                     },
@@ -459,7 +469,7 @@
                             "h": 420,
                             "w": 600,
                             "x": 600,
-                            "y": 420
+                            "y": 590
                         },
                         "type": "block"
                     }
@@ -477,7 +487,7 @@
                             "h": 360,
                             "w": 420,
                             "x": 0,
-                            "y": 0
+                            "y": 170
                         },
                         "type": "block"
                     },
@@ -487,7 +497,7 @@
                             "h": 360,
                             "w": 780,
                             "x": 420,
-                            "y": 0
+                            "y": 170
                         },
                         "type": "block"
                     },
@@ -497,7 +507,7 @@
                             "h": 520,
                             "w": 1200,
                             "x": 0,
-                            "y": 360
+                            "y": 530
                         },
                         "type": "block"
                     }
@@ -533,6 +543,14 @@
     },
     "title": "Forge Troubleshooting",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with failed-job hot spots and the smallest affected tenant, repository, runner group, or resource, then move to the matching Lambda, EC2, ARC/Kubernetes, trust, or ingestion panel. **Healthy:** actionable failure panels are empty while inventory and activity panels may contain normal traffic. **Action:** correlate one workflow job or request across adjacent dashboards before assigning cause. **Ownership:** separate Forge code, shared platform configuration, tenant configuration, workload pressure, and external dependencies."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "arc_listener_activity_chart": {
             "dataSources": {
                 "primary": "arc_listener_activity_search"
@@ -540,7 +558,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "ARC Listener Activity",
+            "description": "Answers \"Are ARC listeners receiving and assigning work?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are ARC listeners receiving and assigning work?",
             "type": "splunk.line"
         },
         "arc_runner_state_table": {
@@ -552,7 +571,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "ARC Runner Set State",
+            "description": "Answers \"Can ARC runner sets accept more work?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Can ARC runner sets accept more work?",
             "type": "splunk.table"
         },
         "ec2_runner_samples_table": {
@@ -564,7 +584,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EC2 Runner Symptom Samples",
+            "description": "Answers \"What do the latest EC2 runner symptoms show?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "What do the latest EC2 runner symptoms show?",
             "type": "splunk.table"
         },
         "ec2_runner_symptoms_table": {
@@ -576,7 +597,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Actionable EC2 Runner Symptoms",
+            "description": "Answers \"Which EC2 runner symptoms need action?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which EC2 runner symptoms need action?",
             "type": "splunk.table"
         },
         "eks_api_403_table": {
@@ -588,7 +610,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EKS API 403 Authorization Errors",
+            "description": "Answers \"Which EKS API calls are denied?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which EKS API calls are denied?",
             "type": "splunk.table"
         },
         "eks_api_errors_table": {
@@ -600,7 +623,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EKS API Errors by Cluster and Resource",
+            "description": "Answers \"Which clusters and resources have EKS API failures?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which clusters and resources have EKS API failures?",
             "type": "splunk.table"
         },
         "ingestion_trend_chart": {
@@ -610,7 +634,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Ingestion Trend by Sourcetype",
+            "description": "Answers \"Are expected sourcetypes still arriving?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are expected sourcetypes still arriving?",
             "type": "splunk.line"
         },
         "job_failure_hotspots_table": {
@@ -622,7 +647,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Failure Hot Spots",
+            "description": "Answers \"Where is production impact concentrated?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Where is production impact concentrated?",
             "type": "splunk.table"
         },
         "job_result_overview_table": {
@@ -634,7 +660,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "GitHub Job Result Overview",
+            "description": "Answers \"How are GitHub jobs completing?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "How are GitHub jobs completing?",
             "type": "splunk.table"
         },
         "kube_event_categories_table": {
@@ -646,7 +673,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Kubernetes Event Categories",
+            "description": "Answers \"Which Kubernetes event categories need investigation?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which Kubernetes event categories need investigation?",
             "type": "splunk.table"
         },
         "lambda_error_categories_table": {
@@ -658,7 +686,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Lambda Errors by Category",
+            "description": "Answers \"Which Lambda error categories are affecting production?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which Lambda error categories are affecting production?",
             "type": "splunk.table"
         },
         "lambda_error_samples_table": {
@@ -670,7 +699,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Lambda Error Samples",
+            "description": "Answers \"What failed in the latest Lambda invocations?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "What failed in the latest Lambda invocations?",
             "type": "splunk.table"
         },
         "negative_queue_table": {
@@ -682,7 +712,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Negative Queue Time Data Quality",
+            "description": "Answers \"Which jobs have invalid queue-time data?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which jobs have invalid queue-time data?",
             "type": "splunk.table"
         },
         "queue_duration_table": {
@@ -694,7 +725,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Queue and Duration by Runner Group",
+            "description": "Answers \"Which runner groups have unusual queue or duration?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which runner groups have unusual queue or duration?",
             "type": "splunk.table"
         },
         "sourcetype_volume_table": {
@@ -706,7 +738,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Event Volume by Sourcetype",
+            "description": "Answers \"Which sourcetypes dominate event volume?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which sourcetypes dominate event volume?",
             "type": "splunk.table"
         },
         "top_sources_table": {
@@ -718,7 +751,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Top Sources",
+            "description": "Answers \"Which sources produce the most events?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which sources produce the most events?",
             "type": "splunk.table"
         },
         "trust_assume_role_table": {
@@ -730,7 +764,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Trust Validation AssumeRole Failures",
+            "description": "Answers \"Which trust validations fail AssumeRole?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which trust validations fail AssumeRole?",
             "type": "splunk.table"
         },
         "trust_latest_expanded_table": {
@@ -742,7 +777,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Latest Trust Validation Detail",
+            "description": "Answers \"What failed in the latest trust validation?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "What failed in the latest trust validation?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_trust_failures.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_trust_failures.json.tftpl
@@ -113,22 +113,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "validator_access_denied_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 520,
                                                                                                                                                     "w": 480,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -138,7 +128,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 760,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 690
+                                                                                                                                                    "y": 520
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -148,7 +138,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 440,
                                                                                                                                                     "x": 760,
-                                                                                                                                                    "y": 690
+                                                                                                                                                    "y": 520
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -158,7 +148,7 @@
                                                                                                                                                     "h": 520,
                                                                                                                                                     "w": 720,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1110
+                                                                                                                                                    "y": 940
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -178,14 +168,6 @@
     },
     "title": "Forge Trust Failures",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with AssumeRole and AccessDenied failures, then inspect the latest validation record and affected role. **Healthy:** failure panels are empty; successful validation or unrelated role activity is not a failure. **Action:** identify validator tenant, Forge role, tenant role, AWS account, denied operation, and whether TagSession was attempted. **Ownership:** validator defects belong to Forge; trust policy, permissions, KMS, and session-tag conditions belong to tenant configuration; STS outages are external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "assume_role_failures_table": {
             "dataSources": {
                 "primary": "assume_role_failures_search"
@@ -195,7 +177,7 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "description": "Answers \"Which roles fail AssumeRole?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "description": "Answers \"Which roles fail AssumeRole?\" for the selected filters and time range. Validate the exact principal, target role, denied action, trust conditions, and TagSession requirement. Action: use the tenant and role identifiers to inspect the matching IAM trust policy.",
             "title": "Which roles fail AssumeRole?",
             "type": "splunk.table"
         },

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_trust_failures.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_trust_failures.json.tftpl
@@ -113,45 +113,55 @@
                 },
                 "structure": [
                     {
-                        "item": "assume_role_failures_table",
-                        "position": {
-                            "h": 420,
-                            "w": 760,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "trust_failure_trend_chart",
-                        "position": {
-                            "h": 420,
-                            "w": 440,
-                            "x": 760,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "validator_access_denied_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 520,
+                                                                                                                                                    "w": 480,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "latest_validation_table",
-                        "position": {
-                            "h": 520,
-                            "w": 720,
-                            "x": 0,
-                            "y": 420
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "assume_role_failures_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 760,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 690
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "validator_access_denied_table",
-                        "position": {
-                            "h": 520,
-                            "w": 480,
-                            "x": 720,
-                            "y": 420
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "trust_failure_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 440,
+                                                                                                                                                    "x": 760,
+                                                                                                                                                    "y": 690
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "latest_validation_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 520,
+                                                                                                                                                    "w": 720,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1110
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -168,6 +178,14 @@
     },
     "title": "Forge Trust Failures",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with AssumeRole and AccessDenied failures, then inspect the latest validation record and affected role. **Healthy:** failure panels are empty; successful validation or unrelated role activity is not a failure. **Action:** identify validator tenant, Forge role, tenant role, AWS account, denied operation, and whether TagSession was attempted. **Ownership:** validator defects belong to Forge; trust policy, permissions, KMS, and session-tag conditions belong to tenant configuration; STS outages are external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "assume_role_failures_table": {
             "dataSources": {
                 "primary": "assume_role_failures_search"
@@ -177,7 +195,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Basic AssumeRole Failures",
+            "description": "Answers \"Which roles fail AssumeRole?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which roles fail AssumeRole?",
             "type": "splunk.table"
         },
         "latest_validation_table": {
@@ -189,6 +208,7 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
+            "description": "Answers \"Latest Validation Detail?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
             "title": "Latest Validation Detail",
             "type": "splunk.table"
         },
@@ -199,7 +219,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Trust Failure Trend",
+            "description": "Answers \"Are trust failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are trust failures increasing?",
             "type": "splunk.line"
         },
         "validator_access_denied_table": {
@@ -211,7 +232,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Validator AccessDenied Errors",
+            "description": "Answers \"Which validator operations receive AccessDenied?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which validator operations receive AccessDenied?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_trust_failures.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_trust_failures.json.tftpl
@@ -113,45 +113,45 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "validator_access_denied_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 520,
-                                                                                                                                                    "w": 480,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "validator_access_denied_table",
+                        "position": {
+                            "h": 520,
+                            "w": 480,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "assume_role_failures_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 760,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 520
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "assume_role_failures_table",
+                        "position": {
+                            "h": 420,
+                            "w": 760,
+                            "x": 0,
+                            "y": 520
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "trust_failure_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 440,
-                                                                                                                                                    "x": 760,
-                                                                                                                                                    "y": 520
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "trust_failure_trend_chart",
+                        "position": {
+                            "h": 420,
+                            "w": 440,
+                            "x": 760,
+                            "y": 520
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "latest_validation_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 520,
-                                                                                                                                                    "w": 720,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 940
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "latest_validation_table",
+                        "position": {
+                            "h": 520,
+                            "w": 720,
+                            "x": 0,
+                            "y": 940
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_webhook_job_log_pipeline.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_webhook_job_log_pipeline.json.tftpl
@@ -137,65 +137,75 @@
                 },
                 "structure": [
                     {
-                        "item": "pipeline_stage_table",
-                        "position": {
-                            "h": 360,
-                            "w": 640,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "pipeline_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 560,
-                            "x": 640,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "archiver_errors_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dispatcher_repos_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "pipeline_stage_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 640,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 550
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "archiver_errors_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dispatcher_repos_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "redrive_activity_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 740
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dispatcher_to_json_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dispatcher_to_json_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 740
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "pipeline_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 560,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1290
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "redrive_activity_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 560,
+                                                                                                                                                    "y": 1290
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -212,6 +222,14 @@
     },
     "title": "Forge Webhook Job Log Pipeline",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with pipeline-stage completeness, archiver failures, and DLQ redrive activity, then compare dispatcher and archived-object counts for the same repository and time window. **Healthy:** accepted jobs progress to archived JSON and ingestion without sustained DLQ or archiver errors; unequal broad totals alone are not proof of loss. **Action:** identify tenant, repository, workflow job, delivery, SQS message, S3 object, and retry outcome. **Ownership:** shared pipeline defects belong to Forge; tenant webhook configuration belongs to the tenant; GitHub, AWS, or Splunk delivery outages may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "archiver_errors_table": {
             "dataSources": {
                 "primary": "archiver_errors_search"
@@ -221,7 +239,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Archiver Errors",
+            "description": "Answers \"Which job-log archive operations failed?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which job-log archive operations failed?",
             "type": "splunk.table"
         },
         "dispatcher_repos_table": {
@@ -233,7 +252,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Dispatcher Enqueues by Repo",
+            "description": "Answers \"Which repositories enqueue job-log work?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which repositories enqueue job-log work?",
             "type": "splunk.table"
         },
         "dispatcher_to_json_table": {
@@ -245,7 +265,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Dispatcher to Archived JSON Counts",
+            "description": "Answers \"Do dispatcher and archived-object counts remain consistent?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Do dispatcher and archived-object counts remain consistent?",
             "type": "splunk.table"
         },
         "pipeline_stage_table": {
@@ -257,7 +278,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Pipeline Stage Summary",
+            "description": "Answers \"Where is the job-log pipeline losing progress?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Where is the job-log pipeline losing progress?",
             "type": "splunk.table"
         },
         "pipeline_trend_chart": {
@@ -267,7 +289,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Pipeline Trend",
+            "description": "Answers \"Is job-log pipeline health changing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Is job-log pipeline health changing?",
             "type": "splunk.line"
         },
         "redrive_activity_table": {
@@ -279,7 +302,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "DLQ Redrive Activity",
+            "description": "Answers \"Are DLQ messages being recovered?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are DLQ messages being recovered?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_webhook_job_log_pipeline.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_webhook_job_log_pipeline.json.tftpl
@@ -137,65 +137,65 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "archiver_errors_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "archiver_errors_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "pipeline_stage_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 640,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 380
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "pipeline_stage_table",
+                        "position": {
+                            "h": 360,
+                            "w": 640,
+                            "x": 0,
+                            "y": 380
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "dispatcher_repos_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "dispatcher_repos_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 0,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "dispatcher_to_json_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "dispatcher_to_json_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 600,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "pipeline_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 560,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1120
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "pipeline_trend_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 560,
+                            "x": 0,
+                            "y": 1120
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "redrive_activity_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 560,
-                                                                                                                                                    "y": 1120
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "redrive_activity_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 560,
+                            "y": 1120
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_webhook_job_log_pipeline.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_webhook_job_log_pipeline.json.tftpl
@@ -137,22 +137,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "archiver_errors_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -162,7 +152,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 640,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 550
+                                                                                                                                                    "y": 380
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -172,7 +162,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -182,7 +172,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -192,7 +182,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 560,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1290
+                                                                                                                                                    "y": 1120
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -202,7 +192,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 560,
-                                                                                                                                                    "y": 1290
+                                                                                                                                                    "y": 1120
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -222,14 +212,6 @@
     },
     "title": "Forge Webhook Job Log Pipeline",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with pipeline-stage completeness, archiver failures, and DLQ redrive activity, then compare dispatcher and archived-object counts for the same repository and time window. **Healthy:** accepted jobs progress to archived JSON and ingestion without sustained DLQ or archiver errors; unequal broad totals alone are not proof of loss. **Action:** identify tenant, repository, workflow job, delivery, SQS message, S3 object, and retry outcome. **Ownership:** shared pipeline defects belong to Forge; tenant webhook configuration belongs to the tenant; GitHub, AWS, or Splunk delivery outages may be external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "archiver_errors_table": {
             "dataSources": {
                 "primary": "archiver_errors_search"
@@ -265,7 +247,7 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "description": "Answers \"Do dispatcher and archived-object counts remain consistent?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "description": "Answers \"Do dispatcher and archived-object counts remain consistent?\" for the selected filters and time range. Unequal broad totals alone are not proof of loss. Action: identify a specific failed archive operation or workflow-job gap before escalating the pipeline.",
             "title": "Do dispatcher and archived-object counts remain consistent?",
             "type": "splunk.table"
         },

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_arc_kubernetes_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_arc_kubernetes_dashboards_operator_workflow_behavior.tftest.hcl
@@ -37,18 +37,17 @@ run "orders_arc_and_kubernetes_dashboards_for_operator_triage" {
         splunk_data_ui_views.forge_arc_k8s_runner_lifecycle.eai_data,
         splunk_data_ui_views.forge_kubernetes_storage_and_network.eai_data,
       ] :
-      strcontains(body, "How should I use this dashboard?")
-      && strcontains(body, "Healthy:")
-      && strcontains(body, "Action:")
+      !strcontains(body, "\"operator_guide\"")
+      && !strcontains(body, "\"type\": \"splunk.markdown\"")
       && strcontains(body, "\"description\": \"Answers")
     ])
-    error_message = "Every ARC and Kubernetes dashboard must provide operator guidance and panel-level healthy/action semantics."
+    error_message = "ARC and Kubernetes dashboards must keep guidance in compact panel descriptions."
   }
 
   assert {
     condition = (
-      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"init_failures_table\"[\\s\\S]*\"item\": \"dind_trend_chart\"[\\s\\S]*\"item\": \"runner_version_table\"", splunk_data_ui_views.forge_arc_dind_runner_lifecycle.eai_data))
-      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"k8s_pod_events_table\"[\\s\\S]*\"item\": \"k8s_hook_trend_chart\"[\\s\\S]*\"item\": \"k8s_runner_version_table\"", splunk_data_ui_views.forge_arc_k8s_runner_lifecycle.eai_data))
+      can(regex("\"item\": \"init_failures_table\"[\\s\\S]*\"item\": \"dind_trend_chart\"[\\s\\S]*\"item\": \"runner_version_table\"", splunk_data_ui_views.forge_arc_dind_runner_lifecycle.eai_data))
+      && can(regex("\"item\": \"k8s_pod_events_table\"[\\s\\S]*\"item\": \"k8s_hook_trend_chart\"[\\s\\S]*\"item\": \"k8s_runner_version_table\"", splunk_data_ui_views.forge_arc_k8s_runner_lifecycle.eai_data))
     )
     error_message = "ARC lifecycle dashboards must place actionable pod, PVC, hook, and init failures before trends and inventory."
   }

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_arc_kubernetes_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_arc_kubernetes_dashboards_operator_workflow_behavior.tftest.hcl
@@ -1,0 +1,63 @@
+mock_provider "aws" {
+  mock_data "aws_secretsmanager_secret" {
+    defaults = { id = "/cicd/common/splunk-cloud" }
+  }
+  mock_data "aws_secretsmanager_secret_version" {
+    defaults = { secret_string = "mock" }
+  }
+}
+
+mock_provider "splunk" {
+  mock_resource "splunk_data_ui_views" {}
+  mock_resource "splunk_configs_conf" {}
+  mock_resource "splunk_transforms_regex" {}
+}
+
+variables {
+  aws_profile  = "test"
+  aws_region   = "us-east-1"
+  default_tags = { Product = "Forge" }
+  splunk_conf = {
+    splunk_cloud = "https://example.splunkcloud.com"
+    index        = "srea-forge-prod-index"
+    tenant_names = ["tenant-a"]
+    acl = {
+      app = "search", owner = "nobody", sharing = "app", read = ["*"], write = ["admin"]
+    }
+  }
+}
+
+run "orders_arc_and_kubernetes_dashboards_for_operator_triage" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for body in [
+        splunk_data_ui_views.forge_arc_dind_runner_lifecycle.eai_data,
+        splunk_data_ui_views.forge_arc_k8s_runner_lifecycle.eai_data,
+        splunk_data_ui_views.forge_kubernetes_storage_and_network.eai_data,
+      ] :
+      strcontains(body, "How should I use this dashboard?")
+      && strcontains(body, "Healthy:")
+      && strcontains(body, "Action:")
+      && strcontains(body, "\"description\": \"Answers")
+    ])
+    error_message = "Every ARC and Kubernetes dashboard must provide operator guidance and panel-level healthy/action semantics."
+  }
+
+  assert {
+    condition = (
+      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"init_failures_table\"[\\s\\S]*\"item\": \"dind_trend_chart\"[\\s\\S]*\"item\": \"runner_version_table\"", splunk_data_ui_views.forge_arc_dind_runner_lifecycle.eai_data))
+      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"k8s_pod_events_table\"[\\s\\S]*\"item\": \"k8s_hook_trend_chart\"[\\s\\S]*\"item\": \"k8s_runner_version_table\"", splunk_data_ui_views.forge_arc_k8s_runner_lifecycle.eai_data))
+    )
+    error_message = "ARC lifecycle dashboards must place actionable pod, PVC, hook, and init failures before trends and inventory."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.forge_kubernetes_storage_and_network.eai_data, "This is diagnostic proximity, not proof of causality")
+      && strcontains(splunk_data_ui_views.forge_kubernetes_storage_and_network.eai_data, "validate the exact workflow job and resource identifiers")
+    )
+    error_message = "Kubernetes job-overlap panels must explicitly avoid claiming causality from time-window proximity."
+  }
+}

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_control_plane_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_control_plane_dashboards_operator_workflow_behavior.tftest.hcl
@@ -37,17 +37,16 @@ run "orders_control_plane_dashboards_for_operator_triage" {
         splunk_data_ui_views.forge_runner_control_plane_health.eai_data,
         splunk_data_ui_views.forge_trust_failures.eai_data,
       ] :
-      strcontains(body, "How should I use this dashboard?")
-      && strcontains(body, "Healthy:")
-      && strcontains(body, "Action:")
+      !strcontains(body, "\"operator_guide\"")
+      && !strcontains(body, "\"type\": \"splunk.markdown\"")
       && strcontains(body, "\"description\": \"Answers")
     ])
-    error_message = "Capacity, control-plane, and trust dashboards must provide operator guidance and panel-level healthy/action semantics."
+    error_message = "Capacity, control-plane, and trust dashboards must keep guidance in compact panel descriptions."
   }
 
   assert {
     condition = (
-      strcontains(splunk_data_ui_views.forge_runner_capacity.eai_data, "one elevated percentile is not enough to infer failure")
+      strcontains(splunk_data_ui_views.forge_runner_capacity.eai_data, "One elevated percentile is not enough to infer failure")
       && strcontains(splunk_data_ui_views.forge_runner_control_plane_health.eai_data, "Global-lock cleanup is diagnostic and is not causal evidence for a stuck job")
       && strcontains(splunk_data_ui_views.forge_trust_failures.eai_data, "TagSession")
     )
@@ -56,8 +55,8 @@ run "orders_control_plane_dashboards_for_operator_triage" {
 
   assert {
     condition = (
-      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"queue_pressure_table\"[\\s\\S]*\"item\": \"queue_trend_chart\"", splunk_data_ui_views.forge_runner_capacity.eai_data))
-      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"assume_role_failures_table\"[\\s\\S]*\"item\": \"trust_failure_trend_chart\"[\\s\\S]*\"item\": \"latest_validation_table\"", splunk_data_ui_views.forge_trust_failures.eai_data))
+      can(regex("\"item\": \"queue_pressure_table\"[\\s\\S]*\"item\": \"queue_trend_chart\"", splunk_data_ui_views.forge_runner_capacity.eai_data))
+      && can(regex("\"item\": \"assume_role_failures_table\"[\\s\\S]*\"item\": \"trust_failure_trend_chart\"[\\s\\S]*\"item\": \"latest_validation_table\"", splunk_data_ui_views.forge_trust_failures.eai_data))
     )
     error_message = "Capacity and trust dashboards must place actionable failures before trend and investigation detail."
   }

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_control_plane_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_control_plane_dashboards_operator_workflow_behavior.tftest.hcl
@@ -1,0 +1,64 @@
+mock_provider "aws" {
+  mock_data "aws_secretsmanager_secret" {
+    defaults = { id = "/cicd/common/splunk-cloud" }
+  }
+  mock_data "aws_secretsmanager_secret_version" {
+    defaults = { secret_string = "mock" }
+  }
+}
+
+mock_provider "splunk" {
+  mock_resource "splunk_data_ui_views" {}
+  mock_resource "splunk_configs_conf" {}
+  mock_resource "splunk_transforms_regex" {}
+}
+
+variables {
+  aws_profile  = "test"
+  aws_region   = "us-east-1"
+  default_tags = { Product = "Forge" }
+  splunk_conf = {
+    splunk_cloud = "https://example.splunkcloud.com"
+    index        = "srea-forge-prod-index"
+    tenant_names = ["tenant-a"]
+    acl = {
+      app = "search", owner = "nobody", sharing = "app", read = ["*"], write = ["admin"]
+    }
+  }
+}
+
+run "orders_control_plane_dashboards_for_operator_triage" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for body in [
+        splunk_data_ui_views.forge_runner_capacity.eai_data,
+        splunk_data_ui_views.forge_runner_control_plane_health.eai_data,
+        splunk_data_ui_views.forge_trust_failures.eai_data,
+      ] :
+      strcontains(body, "How should I use this dashboard?")
+      && strcontains(body, "Healthy:")
+      && strcontains(body, "Action:")
+      && strcontains(body, "\"description\": \"Answers")
+    ])
+    error_message = "Capacity, control-plane, and trust dashboards must provide operator guidance and panel-level healthy/action semantics."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.forge_runner_capacity.eai_data, "one elevated percentile is not enough to infer failure")
+      && strcontains(splunk_data_ui_views.forge_runner_control_plane_health.eai_data, "Global-lock cleanup is diagnostic and is not causal evidence for a stuck job")
+      && strcontains(splunk_data_ui_views.forge_trust_failures.eai_data, "TagSession")
+    )
+    error_message = "Control-plane guidance must prevent single-chart failure inference, false global-lock causality, and incomplete STS trust triage."
+  }
+
+  assert {
+    condition = (
+      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"queue_pressure_table\"[\\s\\S]*\"item\": \"queue_trend_chart\"", splunk_data_ui_views.forge_runner_capacity.eai_data))
+      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"assume_role_failures_table\"[\\s\\S]*\"item\": \"trust_failure_trend_chart\"[\\s\\S]*\"item\": \"latest_validation_table\"", splunk_data_ui_views.forge_trust_failures.eai_data))
+    )
+    error_message = "Capacity and trust dashboards must place actionable failures before trend and investigation detail."
+  }
+}

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_ingestion_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_ingestion_dashboards_operator_workflow_behavior.tftest.hcl
@@ -37,27 +37,26 @@ run "orders_ingestion_dashboards_for_operator_triage" {
         splunk_data_ui_views.forge_lambda_operations.eai_data,
         splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data,
       ] :
-      strcontains(body, "How should I use this dashboard?")
-      && strcontains(body, "Healthy:")
-      && strcontains(body, "Action:")
+      !strcontains(body, "\"operator_guide\"")
+      && !strcontains(body, "\"type\": \"splunk.markdown\"")
       && strcontains(body, "\"description\": \"Answers")
       && strcontains(body, "$global_time.earliest$")
       && strcontains(body, "$global_time.latest$")
     ])
-    error_message = "Ingestion dashboards must explain healthy/action semantics per panel and retain the global-time token."
+    error_message = "Ingestion dashboards must keep guidance in panel descriptions and retain the global-time token."
   }
 
   assert {
     condition = (
-      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"missing_fields_table\"[\\s\\S]*\"item\": \"volume_anomaly_chart\"[\\s\\S]*\"item\": \"source_inventory_table\"", splunk_data_ui_views.forge_ingestion_quality.eai_data))
-      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"lambda_errors_table\"[\\s\\S]*\"item\": \"lambda_error_trend_chart\"[\\s\\S]*\"item\": \"lambda_samples_table\"", splunk_data_ui_views.forge_lambda_operations.eai_data))
+      can(regex("\"item\": \"missing_fields_table\"[\\s\\S]*\"item\": \"volume_anomaly_chart\"[\\s\\S]*\"item\": \"source_inventory_table\"", splunk_data_ui_views.forge_ingestion_quality.eai_data))
+      && can(regex("\"item\": \"lambda_errors_table\"[\\s\\S]*\"item\": \"lambda_error_trend_chart\"[\\s\\S]*\"item\": \"lambda_samples_table\"", splunk_data_ui_views.forge_lambda_operations.eai_data))
     )
     error_message = "Actionable ingestion and Lambda failures must appear before trends, source inventory, and raw samples."
   }
 
   assert {
     condition = (
-      strcontains(splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data, "unequal broad totals alone are not proof of loss")
+      strcontains(splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data, "Unequal broad totals alone are not proof of loss")
       && strcontains(splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data, "Which job-log archive operations failed?")
     )
     error_message = "The job-log pipeline dashboard must distinguish confirmed failures from non-causal count differences."

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_ingestion_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_ingestion_dashboards_operator_workflow_behavior.tftest.hcl
@@ -1,0 +1,65 @@
+mock_provider "aws" {
+  mock_data "aws_secretsmanager_secret" {
+    defaults = { id = "/cicd/common/splunk-cloud" }
+  }
+  mock_data "aws_secretsmanager_secret_version" {
+    defaults = { secret_string = "mock" }
+  }
+}
+
+mock_provider "splunk" {
+  mock_resource "splunk_data_ui_views" {}
+  mock_resource "splunk_configs_conf" {}
+  mock_resource "splunk_transforms_regex" {}
+}
+
+variables {
+  aws_profile  = "test"
+  aws_region   = "us-east-1"
+  default_tags = { Product = "Forge" }
+  splunk_conf = {
+    splunk_cloud = "https://example.splunkcloud.com"
+    index        = "srea-forge-prod-index"
+    tenant_names = ["tenant-a"]
+    acl = {
+      app = "search", owner = "nobody", sharing = "app", read = ["*"], write = ["admin"]
+    }
+  }
+}
+
+run "orders_ingestion_dashboards_for_operator_triage" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for body in [
+        splunk_data_ui_views.forge_ingestion_quality.eai_data,
+        splunk_data_ui_views.forge_lambda_operations.eai_data,
+        splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data,
+      ] :
+      strcontains(body, "How should I use this dashboard?")
+      && strcontains(body, "Healthy:")
+      && strcontains(body, "Action:")
+      && strcontains(body, "\"description\": \"Answers")
+      && strcontains(body, "$global_time.earliest$")
+      && strcontains(body, "$global_time.latest$")
+    ])
+    error_message = "Ingestion dashboards must explain healthy/action semantics per panel and retain the global-time token."
+  }
+
+  assert {
+    condition = (
+      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"missing_fields_table\"[\\s\\S]*\"item\": \"volume_anomaly_chart\"[\\s\\S]*\"item\": \"source_inventory_table\"", splunk_data_ui_views.forge_ingestion_quality.eai_data))
+      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"lambda_errors_table\"[\\s\\S]*\"item\": \"lambda_error_trend_chart\"[\\s\\S]*\"item\": \"lambda_samples_table\"", splunk_data_ui_views.forge_lambda_operations.eai_data))
+    )
+    error_message = "Actionable ingestion and Lambda failures must appear before trends, source inventory, and raw samples."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data, "unequal broad totals alone are not proof of loss")
+      && strcontains(splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data, "Which job-log archive operations failed?")
+    )
+    error_message = "The job-log pipeline dashboard must distinguish confirmed failures from non-causal count differences."
+  }
+}

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_investigation_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_investigation_dashboards_operator_workflow_behavior.tftest.hcl
@@ -37,18 +37,18 @@ run "makes_investigation_dashboards_explicitly_diagnostic" {
         splunk_data_ui_views.forge_tenant_logs.eai_data,
         splunk_data_ui_views.forge_troubleshooting.eai_data,
       ] :
-      strcontains(body, "How should I use this dashboard?")
-      && strcontains(body, "Healthy:")
-      && strcontains(body, "Action:")
+      !strcontains(body, "\"operator_guide\"")
+      && !strcontains(body, "\"type\": \"splunk.markdown\"")
+      && strcontains(body, "\"description\":")
     ])
-    error_message = "Investigation dashboards must explain that their data is diagnostic and provide a next action."
+    error_message = "Investigation dashboards must keep guidance in compact panel descriptions rather than a dedicated guide row."
   }
 
   assert {
     condition = (
       strcontains(splunk_data_ui_views.forge_tenant_logs.eai_data, "Which tenant log events match the investigation?")
       && strcontains(splunk_data_ui_views.forge_tenant_logs.eai_data, "an empty result can mean no matching retained events")
-      && strcontains(splunk_data_ui_views.forge_tenant_logs.eai_data, "raw logs provide evidence but do not assign")
+      && strcontains(splunk_data_ui_views.forge_tenant_logs.eai_data, "Raw logs provide evidence but do not assign")
     )
     error_message = "Tenant logs must not present an empty raw-event result as proof of health or assign ownership by itself."
   }
@@ -57,7 +57,7 @@ run "makes_investigation_dashboards_explicitly_diagnostic" {
     condition = (
       strcontains(splunk_data_ui_views.forge_ci_job_details.eai_data, "\"description\": \"Answers")
       && strcontains(splunk_data_ui_views.forge_troubleshooting.eai_data, "\"description\": \"Answers")
-      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"queued_windows_table\"[\\s\\S]*\"item\": \"ci_job_details_table\"", splunk_data_ui_views.forge_ci_job_details.eai_data))
+      && can(regex("\"item\": \"queued_windows_table\"[\\s\\S]*\"item\": \"ci_job_details_table\"", splunk_data_ui_views.forge_ci_job_details.eai_data))
     )
     error_message = "CI and troubleshooting panels must have question-oriented descriptions and leave high-cardinality job detail after queue diagnostics."
   }

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_investigation_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_investigation_dashboards_operator_workflow_behavior.tftest.hcl
@@ -1,0 +1,64 @@
+mock_provider "aws" {
+  mock_data "aws_secretsmanager_secret" {
+    defaults = { id = "/cicd/common/splunk-cloud" }
+  }
+  mock_data "aws_secretsmanager_secret_version" {
+    defaults = { secret_string = "mock" }
+  }
+}
+
+mock_provider "splunk" {
+  mock_resource "splunk_data_ui_views" {}
+  mock_resource "splunk_configs_conf" {}
+  mock_resource "splunk_transforms_regex" {}
+}
+
+variables {
+  aws_profile  = "test"
+  aws_region   = "us-east-1"
+  default_tags = { Product = "Forge" }
+  splunk_conf = {
+    splunk_cloud = "https://example.splunkcloud.com"
+    index        = "srea-forge-prod-index"
+    tenant_names = ["tenant-a"]
+    acl = {
+      app = "search", owner = "nobody", sharing = "app", read = ["*"], write = ["admin"]
+    }
+  }
+}
+
+run "makes_investigation_dashboards_explicitly_diagnostic" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for body in [
+        splunk_data_ui_views.forge_ci_job_details.eai_data,
+        splunk_data_ui_views.forge_tenant_logs.eai_data,
+        splunk_data_ui_views.forge_troubleshooting.eai_data,
+      ] :
+      strcontains(body, "How should I use this dashboard?")
+      && strcontains(body, "Healthy:")
+      && strcontains(body, "Action:")
+    ])
+    error_message = "Investigation dashboards must explain that their data is diagnostic and provide a next action."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.forge_tenant_logs.eai_data, "Which tenant log events match the investigation?")
+      && strcontains(splunk_data_ui_views.forge_tenant_logs.eai_data, "an empty result can mean no matching retained events")
+      && strcontains(splunk_data_ui_views.forge_tenant_logs.eai_data, "raw logs provide evidence but do not assign")
+    )
+    error_message = "Tenant logs must not present an empty raw-event result as proof of health or assign ownership by itself."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.forge_ci_job_details.eai_data, "\"description\": \"Answers")
+      && strcontains(splunk_data_ui_views.forge_troubleshooting.eai_data, "\"description\": \"Answers")
+      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"queued_windows_table\"[\\s\\S]*\"item\": \"ci_job_details_table\"", splunk_data_ui_views.forge_ci_job_details.eai_data))
+    )
+    error_message = "CI and troubleshooting panels must have question-oriented descriptions and leave high-cardinality job detail after queue diagnostics."
+  }
+}

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/main.tf
@@ -221,8 +221,16 @@ resource "signalfx_dashboard" "aws_regional_health" {
   }
 
   chart {
-    chart_id = signalfx_time_chart.lambda_throttle_attempt_rate.id
+    chart_id = signalfx_time_chart.queue_health_alerts.id
     row      = 0
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_time_chart.lambda_throttle_attempt_rate.id
+    row      = 1
     column   = 0
     width    = 6
     height   = 1
@@ -230,7 +238,7 @@ resource "signalfx_dashboard" "aws_regional_health" {
 
   chart {
     chart_id = signalfx_time_chart.lambda_throttle_count.id
-    row      = 0
+    row      = 1
     column   = 6
     width    = 6
     height   = 1
@@ -238,7 +246,7 @@ resource "signalfx_dashboard" "aws_regional_health" {
 
   chart {
     chart_id = signalfx_time_chart.build_queue_oldest_age.id
-    row      = 1
+    row      = 2
     column   = 0
     width    = 6
     height   = 1
@@ -246,7 +254,7 @@ resource "signalfx_dashboard" "aws_regional_health" {
 
   chart {
     chart_id = signalfx_time_chart.build_queue_visible_backlog.id
-    row      = 1
+    row      = 2
     column   = 6
     width    = 6
     height   = 1
@@ -254,14 +262,6 @@ resource "signalfx_dashboard" "aws_regional_health" {
 
   chart {
     chart_id = signalfx_time_chart.build_queue_dlq_sends.id
-    row      = 2
-    column   = 0
-    width    = 12
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_time_chart.queue_health_alerts.id
     row      = 3
     column   = 0
     width    = 12

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/aws_regional_health/tests/aws_regional_health_dashboard_behavior.tftest.hcl
@@ -56,6 +56,14 @@ run "creates_regional_platform_dashboard" {
   }
 
   assert {
+    condition = length([
+      for chart in signalfx_dashboard.aws_regional_health.chart : chart
+      if chart.chart_id == signalfx_time_chart.queue_health_alerts.id && chart.row == 0
+    ]) == 1
+    error_message = "The regional platform dashboard must lead with active alerts."
+  }
+
+  assert {
     condition = alltrue([
       for program_text in [
         signalfx_time_chart.lambda_throttle_attempt_rate.program_text,

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/main.tf
@@ -237,8 +237,16 @@ resource "signalfx_dashboard" "dependency_health" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.github_availability.id
+    chart_id = signalfx_time_chart.tenant_health_alerts.id
     row      = 0
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.github_availability.id
+    row      = 1
     column   = 0
     width    = 4
     height   = 1
@@ -246,7 +254,7 @@ resource "signalfx_dashboard" "dependency_health" {
 
   chart {
     chart_id = signalfx_list_chart.ssm_availability.id
-    row      = 0
+    row      = 1
     column   = 4
     width    = 4
     height   = 1
@@ -254,7 +262,7 @@ resource "signalfx_dashboard" "dependency_health" {
 
   chart {
     chart_id = signalfx_list_chart.rate_limit_budget.id
-    row      = 0
+    row      = 1
     column   = 8
     width    = 4
     height   = 1
@@ -262,14 +270,6 @@ resource "signalfx_dashboard" "dependency_health" {
 
   chart {
     chart_id = signalfx_time_chart.latency.id
-    row      = 1
-    column   = 0
-    width    = 12
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_time_chart.probe_execution.id
     row      = 2
     column   = 0
     width    = 12
@@ -277,7 +277,7 @@ resource "signalfx_dashboard" "dependency_health" {
   }
 
   chart {
-    chart_id = signalfx_time_chart.tenant_health_alerts.id
+    chart_id = signalfx_time_chart.probe_execution.id
     row      = 3
     column   = 0
     width    = 12

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/dependency_probes_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/dependency_probes/tests/dependency_probes_dashboard_behavior.tftest.hcl
@@ -40,7 +40,15 @@ run "creates_dependency_health_dashboard" {
 
   assert {
     condition     = length(signalfx_dashboard.dependency_health.chart) == 6
-    error_message = "The dashboard must retain GitHub, AWS, rate-limit, latency, telemetry, and central alert coverage."
+    error_message = "The dashboard must retain its GitHub, AWS, rate-limit, latency, telemetry, and central alert coverage."
+  }
+
+  assert {
+    condition = length([
+      for chart in signalfx_dashboard.dependency_health.chart : chart
+      if chart.chart_id == signalfx_time_chart.tenant_health_alerts.id && chart.row == 0
+    ]) == 1
+    error_message = "The dependency dashboard must lead with active alerts."
   }
 
   assert {

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/main.tf
@@ -60,8 +60,16 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.top_tenants_lambda_errors.id
+    chart_id = signalfx_time_chart.tenant_health_alerts.id
     row      = 0
+    column   = 0
+    width    = 12
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_lambda_errors.id
+    row      = 1
     column   = 0
     width    = 4
     height   = 1
@@ -69,7 +77,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.top_tenants_lambda_throttles.id
-    row      = 0
+    row      = 1
     column   = 4
     width    = 4
     height   = 1
@@ -77,7 +85,7 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.top_tenants_ec2_memory.id
-    row      = 0
+    row      = 1
     column   = 8
     width    = 4
     height   = 1
@@ -85,47 +93,15 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.top_tenants_ec2_cpu.id
-    row      = 1
-    column   = 0
-    width    = 4
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_list_chart.top_tenants_k8s_pending_pods.id
     row      = 2
     column   = 0
     width    = 4
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_list_chart.top_tenants_k8s_failed_pods.id
-    row      = 2
-    column   = 4
-    width    = 4
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_list_chart.top_tenants_sqs_backlog.id
-    row      = 3
-    column   = 0
-    width    = 6
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_list_chart.top_tenants_sqs_dlq_backlog.id
-    row      = 3
-    column   = 6
-    width    = 6
     height   = 1
   }
 
   chart {
     chart_id = signalfx_list_chart.top_tenants_ec2_disk.id
-    row      = 1
+    row      = 2
     column   = 4
     width    = 4
     height   = 1
@@ -133,14 +109,6 @@ resource "signalfx_dashboard" "forge_impact" {
 
   chart {
     chart_id = signalfx_list_chart.top_tenants_ec2_status_failures.id
-    row      = 1
-    column   = 8
-    width    = 4
-    height   = 1
-  }
-
-  chart {
-    chart_id = signalfx_list_chart.top_tenants_k8s_restarts.id
     row      = 2
     column   = 8
     width    = 4
@@ -148,7 +116,31 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.top_tenants_ebs_queue_length.id
+    chart_id = signalfx_list_chart.top_tenants_k8s_pending_pods.id
+    row      = 3
+    column   = 0
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_k8s_failed_pods.id
+    row      = 3
+    column   = 4
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_k8s_restarts.id
+    row      = 3
+    column   = 8
+    width    = 4
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_sqs_backlog.id
     row      = 4
     column   = 0
     width    = 6
@@ -156,7 +148,7 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_list_chart.top_tenants_ebs_iops_exceeded.id
+    chart_id = signalfx_list_chart.top_tenants_sqs_dlq_backlog.id
     row      = 4
     column   = 6
     width    = 6
@@ -164,10 +156,18 @@ resource "signalfx_dashboard" "forge_impact" {
   }
 
   chart {
-    chart_id = signalfx_time_chart.tenant_health_alerts.id
+    chart_id = signalfx_list_chart.top_tenants_ebs_queue_length.id
     row      = 5
     column   = 0
-    width    = 12
+    width    = 6
+    height   = 1
+  }
+
+  chart {
+    chart_id = signalfx_list_chart.top_tenants_ebs_iops_exceeded.id
+    row      = 5
+    column   = 6
+    width    = 6
     height   = 1
   }
 }

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/forge_impact/tests/forge_impact_dashboard_behavior.tftest.hcl
@@ -126,6 +126,14 @@ run "forge_impact_dashboard_wiring_contract" {
   }
 
   assert {
+    condition = length([
+      for chart in signalfx_dashboard.forge_impact.chart : chart
+      if chart.chart_id == signalfx_time_chart.tenant_health_alerts.id && chart.row == 0
+    ]) == 1
+    error_message = "Tenant impact must lead with active alerts."
+  }
+
+  assert {
     condition = alltrue([
       contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_lambda_errors.id),
       contains([for chart in signalfx_dashboard.forge_impact.chart : chart.chart_id], signalfx_list_chart.top_tenants_ec2_memory.id),


### PR DESCRIPTION
## Description

Consolidates the presentation-only Forge dashboard refactors from former PRs #574, #575, #578, and #579.

The affected Splunk Cloud dashboards cover:

- Investigation: CI job details, tenant logs, and troubleshooting
- Control plane: runner capacity, runner control-plane health, and trust failures
- ARC/Kubernetes: DinD lifecycle, Kubernetes lifecycle, and storage/network
- Ingestion: ingestion quality, Lambda operations, and webhook job-log pipeline

The change:

- removes full-width operator-guide visualizations and their oversized layout rows
- keeps concise operational guidance in relevant panel descriptions
- uses question-oriented panel titles
- places actionable failures before trends and raw investigation details
- promotes existing alert timelines to the first row of the Regional Platform Health, External Dependency Health, and Tenant Impact Observability dashboards
- preserves existing SPL, SignalFlow, filters, tokens, thresholds, detector conditions, and dashboard default time ranges
- retains interpretation boundaries, including non-causal global-lock evidence, TagSession trust checks, and broad count differences not proving loss

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: __________

## Testing

- Splunk Cloud shared-module OpenTofu tests: 9 passed
- Splunk Observability focused OpenTofu tests:
  - AWS Regional Platform Health: 3 passed
  - External Dependency Health: 3 passed
  - Tenant Impact: 4 passed
- changed-file pre-commit suite: passed
- `git diff --check`: passed
