### PR TITLE
refactor(observability): simplify ARC dashboards

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_dind_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_dind_runner_lifecycle.json.tftpl
@@ -137,65 +137,75 @@
                 },
                 "structure": [
                     {
-                        "item": "dind_categories_table",
-                        "position": {
-                            "h": 360,
-                            "w": 640,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dind_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 560,
-                            "x": 640,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "init_failures_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "init_failures_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "hook_sidecar_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "hook_sidecar_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dind_categories_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 640,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 550
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_version_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 740
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dind_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 560,
+                                                                                                                                                    "x": 640,
+                                                                                                                                                    "y": 550
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dind_runner_volume_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 740
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "dind_runner_volume_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "runner_version_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -212,6 +222,14 @@
     },
     "title": "Forge ARC DIND Runner Lifecycle",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with init-container and hook-sidecar failures; use lifecycle activity, versions, and log volume only after impact is established. **Healthy:** failure panels are empty while lifecycle and volume panels may show normal work. **Action:** identify the tenant and scale set, then inspect ARC listener/controller, Kubernetes capacity, image, storage, and network evidence. **Ownership:** shared ARC/controller faults belong to the Forge platform; scale-set configuration belongs to the tenant; registry or cloud-service failures may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "dind_categories_table": {
             "dataSources": {
                 "primary": "dind_categories_search"
@@ -221,7 +239,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "ARC DIND and Hook Categories",
+            "description": "Answers \"Which ARC DIND lifecycle signals are occurring?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which ARC DIND lifecycle signals are occurring?",
             "type": "splunk.table"
         },
         "dind_trend_chart": {
@@ -231,7 +250,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "ARC DIND and Hook Trend",
+            "description": "Answers \"Are ARC DIND lifecycle signals changing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are ARC DIND lifecycle signals changing?",
             "type": "splunk.line"
         },
         "hook_sidecar_table": {
@@ -243,7 +263,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Hook Sidecar Signals",
+            "description": "Answers \"Which hook-sidecar failures need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which hook-sidecar failures need attention?",
             "type": "splunk.table"
         },
         "init_failures_table": {
@@ -255,7 +276,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Init Container Failures",
+            "description": "Answers \"Which init containers are failing?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which init containers are failing?",
             "type": "splunk.table"
         },
         "runner_version_table": {
@@ -267,7 +289,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Versions",
+            "description": "Answers \"Which runner versions are active?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which runner versions are active?",
             "type": "splunk.table"
         },
         "dind_runner_volume_table": {
@@ -279,7 +302,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "DIND Runner Log Volume",
+            "description": "Answers \"Are DIND runner logs still arriving?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are DIND runner logs still arriving?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_k8s_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_arc_k8s_runner_lifecycle.json.tftpl
@@ -137,65 +137,75 @@
                 },
                 "structure": [
                     {
-                        "item": "k8s_hook_categories_table",
-                        "position": {
-                            "h": 360,
-                            "w": 640,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_hook_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 560,
-                            "x": 640,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "k8s_hook_categories_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 640,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_runner_volume_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "k8s_pod_events_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_runner_version_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "k8s_pod_scale_set_events_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_pod_events_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 740
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "k8s_hook_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 560,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "k8s_pod_scale_set_events_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 740
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "k8s_runner_volume_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 560,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "k8s_runner_version_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1290
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -212,6 +222,14 @@
     },
     "title": "Forge ARC K8S Runner Lifecycle",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with pod, PVC, and hook-sidecar failures; use lifecycle activity, versions, and log volume only after impact is established. **Healthy:** failure panels are empty while lifecycle and volume panels may show normal work. **Action:** identify the tenant and scale set, then inspect listener capacity, pending pods, scheduling, storage, image, and networking evidence. **Ownership:** shared ARC/Kubernetes faults belong to the Forge platform; scale-set configuration and workload demand belong to the tenant; registry or cloud-service failures may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "k8s_hook_categories_table": {
             "dataSources": {
                 "primary": "k8s_hook_categories_search"
@@ -221,7 +239,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Hook Sidecar Signals",
+            "description": "Answers \"Which hook-sidecar failures need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which hook-sidecar failures need attention?",
             "type": "splunk.table"
         },
         "k8s_hook_trend_chart": {
@@ -231,7 +250,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Hook Sidecar Trend",
+            "description": "Answers \"Are hook-sidecar failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are hook-sidecar failures increasing?",
             "type": "splunk.line"
         },
         "k8s_pod_events_table": {
@@ -243,7 +263,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "K8s Pod and PVC Events",
+            "description": "Answers \"Which runner pods or PVCs need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runner pods or PVCs need attention?",
             "type": "splunk.table"
         },
         "k8s_pod_scale_set_events_table": {
@@ -255,7 +276,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "K8s Pod and PVC Events by Scale Set",
+            "description": "Answers \"Which scale sets have pod or PVC impact?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which scale sets have pod or PVC impact?",
             "type": "splunk.table"
         },
         "k8s_runner_version_table": {
@@ -267,7 +289,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "K8s Runner Versions",
+            "description": "Answers \"Which Kubernetes runner versions are active?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which Kubernetes runner versions are active?",
             "type": "splunk.table"
         },
         "k8s_runner_volume_table": {
@@ -279,7 +302,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "K8s Runner Log Volume",
+            "description": "Answers \"Are Kubernetes runner logs still arriving?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are Kubernetes runner logs still arriving?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_kubernetes_storage_and_network.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_kubernetes_storage_and_network.json.tftpl
@@ -182,115 +182,125 @@
                 },
                 "structure": [
                     {
-                        "item": "kube_event_categories_table",
-                        "position": {
-                            "h": 340,
-                            "w": 600,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "kube_event_trend_chart",
-                        "position": {
-                            "h": 340,
-                            "w": 600,
-                            "x": 600,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "api_storage_errors_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "pvc_stuck_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 340
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "karpenter_controller_health_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 590
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ebs_wait_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 340
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "calico_tigera_health_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 590
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "api_storage_errors_table",
-                        "position": {
-                            "h": 420,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 720
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "ebs_csi_health_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1010
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "karpenter_controller_health_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 0,
-                            "y": 1140
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "eks_pod_identity_health_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 1010
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "calico_tigera_health_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 600,
-                            "y": 1140
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "component_job_window_correlation_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 460,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1430
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ebs_csi_health_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 0,
-                            "y": 1560
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "pvc_stuck_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1890
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "eks_pod_identity_health_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 600,
-                            "y": 1560
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "kube_event_categories_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 340,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 1890
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_job_correlation_table",
-                        "position": {
-                            "h": 460,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1980
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "runner_job_correlation_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 460,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 2270
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "component_job_window_correlation_table",
-                        "position": {
-                            "h": 460,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 2440
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "kube_event_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 340,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 2730
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "ebs_wait_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 2730
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -307,6 +317,14 @@
     },
     "title": "Forge Kubernetes Storage and Network",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with failed-job correlation and persistent storage, scheduling, CNI, or controller errors; use component inventories only after impact is established. **Healthy:** actionable error and aged-object panels are empty; routine controller events may still appear. **Action:** identify cluster, namespace, pod, PVC, node, scale set, and tenant before checking Karpenter, EBS CSI, CNI, image, and network paths. **Ownership:** shared cluster/controller faults belong to Forge; workload requests and scale-set configuration belong to the tenant; AWS or registry failures may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "api_storage_errors_table": {
             "dataSources": {
                 "primary": "api_storage_errors_search"
@@ -316,7 +334,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EKS API Storage and Controller Errors",
+            "description": "Answers \"Which EKS storage or controller calls are failing?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which EKS storage or controller calls are failing?",
             "type": "splunk.table"
         },
         "ebs_wait_table": {
@@ -328,7 +347,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EBS Provisioning Waits",
+            "description": "Answers \"Which EBS volumes are still waiting?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which EBS volumes are still waiting?",
             "type": "splunk.table"
         },
         "ebs_csi_health_table": {
@@ -340,7 +360,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EBS CSI Health",
+            "description": "Answers \"Which EBS CSI components need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which EBS CSI components need attention?",
             "type": "splunk.table"
         },
         "eks_pod_identity_health_table": {
@@ -352,7 +373,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EKS Pod Identity Health",
+            "description": "Answers \"Which pod-identity operations are failing?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which pod-identity operations are failing?",
             "type": "splunk.table"
         },
         "calico_tigera_health_table": {
@@ -364,7 +386,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Calico and Tigera Health",
+            "description": "Answers \"Which Calico or Tigera components need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which Calico or Tigera components need attention?",
             "type": "splunk.table"
         },
         "component_job_window_correlation_table": {
@@ -376,7 +399,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Controller and CNI Errors Correlated with Failed Jobs",
+            "description": "Answers \"Do controller or CNI errors overlap failed jobs?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Do controller or CNI errors overlap failed jobs?",
             "type": "splunk.table"
         },
         "karpenter_controller_health_table": {
@@ -388,7 +412,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Karpenter Controller Health",
+            "description": "Answers \"Which Karpenter operations need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which Karpenter operations need attention?",
             "type": "splunk.table"
         },
         "kube_event_categories_table": {
@@ -400,7 +425,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Storage, Scheduler, and CNI Signals",
+            "description": "Answers \"Which storage, scheduling, or CNI signals are actionable?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which storage, scheduling, or CNI signals are actionable?",
             "type": "splunk.table"
         },
         "kube_event_trend_chart": {
@@ -410,7 +436,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Storage, Scheduler, and CNI Trend",
+            "description": "Answers \"Are Kubernetes infrastructure failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are Kubernetes infrastructure failures increasing?",
             "type": "splunk.line"
         },
         "pvc_stuck_table": {
@@ -422,7 +449,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "PVC Still Attached",
+            "description": "Answers \"Which PVCs remain attached unexpectedly?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which PVCs remain attached unexpectedly?",
             "type": "splunk.table"
         },
         "runner_job_correlation_table": {
@@ -434,7 +462,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Kubernetes Issues Correlated with GitHub Jobs",
+            "description": "Answers \"Which GitHub jobs overlap Kubernetes issues?\" using time-window overlap. This is diagnostic proximity, not proof of causality. Healthy: no overlap with affected jobs. Action: validate the exact workflow job and resource identifiers in their source logs before assigning ownership.",
+            "title": "Which GitHub jobs overlap Kubernetes issues?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_arc_kubernetes_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_arc_kubernetes_dashboards_operator_workflow_behavior.tftest.hcl
@@ -1,0 +1,63 @@
+mock_provider "aws" {
+  mock_data "aws_secretsmanager_secret" {
+    defaults = { id = "/cicd/common/splunk-cloud" }
+  }
+  mock_data "aws_secretsmanager_secret_version" {
+    defaults = { secret_string = "mock" }
+  }
+}
+
+mock_provider "splunk" {
+  mock_resource "splunk_data_ui_views" {}
+  mock_resource "splunk_configs_conf" {}
+  mock_resource "splunk_transforms_regex" {}
+}
+
+variables {
+  aws_profile  = "test"
+  aws_region   = "us-east-1"
+  default_tags = { Product = "Forge" }
+  splunk_conf = {
+    splunk_cloud = "https://example.splunkcloud.com"
+    index        = "srea-forge-prod-index"
+    tenant_names = ["tenant-a"]
+    acl = {
+      app = "search", owner = "nobody", sharing = "app", read = ["*"], write = ["admin"]
+    }
+  }
+}
+
+run "orders_arc_and_kubernetes_dashboards_for_operator_triage" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for body in [
+        splunk_data_ui_views.forge_arc_dind_runner_lifecycle.eai_data,
+        splunk_data_ui_views.forge_arc_k8s_runner_lifecycle.eai_data,
+        splunk_data_ui_views.forge_kubernetes_storage_and_network.eai_data,
+      ] :
+      strcontains(body, "How should I use this dashboard?")
+      && strcontains(body, "Healthy:")
+      && strcontains(body, "Action:")
+      && strcontains(body, "\"description\": \"Answers")
+    ])
+    error_message = "Every ARC and Kubernetes dashboard must provide operator guidance and panel-level healthy/action semantics."
+  }
+
+  assert {
+    condition = (
+      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"init_failures_table\"[\\s\\S]*\"item\": \"dind_trend_chart\"[\\s\\S]*\"item\": \"runner_version_table\"", splunk_data_ui_views.forge_arc_dind_runner_lifecycle.eai_data))
+      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"k8s_pod_events_table\"[\\s\\S]*\"item\": \"k8s_hook_trend_chart\"[\\s\\S]*\"item\": \"k8s_runner_version_table\"", splunk_data_ui_views.forge_arc_k8s_runner_lifecycle.eai_data))
+    )
+    error_message = "ARC lifecycle dashboards must place actionable pod, PVC, hook, and init failures before trends and inventory."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.forge_kubernetes_storage_and_network.eai_data, "This is diagnostic proximity, not proof of causality")
+      && strcontains(splunk_data_ui_views.forge_kubernetes_storage_and_network.eai_data, "validate the exact workflow job and resource identifiers")
+    )
+    error_message = "Kubernetes job-overlap panels must explicitly avoid claiming causality from time-window proximity."
+  }
+}


### PR DESCRIPTION
## Description

Refactors the ARC DIND, ARC Kubernetes, and Kubernetes storage/network dashboards around actionable runner and cluster failures.

- Places init, hook, pod, PVC, scheduler, storage, CNI, Karpenter, and controller failures before trends and inventory.
- Adds question-oriented titles and panel-level healthy, failure, and next-action guidance.
- Labels job/infrastructure overlap as diagnostic proximity rather than proof of causality.
- Preserves tenant, scale-set, cluster, repository, and global-time filters.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: ______

## Testing

- `tofu test` in `modules/integrations/splunk_cloud_conf_shared` (6 passed)
- Repository quality gates (26 passed)
- Changed-file pre-commit hooks
- `git diff --check`
