### PR TITLE
refactor(observability): improve dispatcher dashboard searches

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_dispatcher_rejections.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_dispatcher_rejections.json.tftpl
@@ -191,55 +191,55 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "dispatcher_rejection_top_repos_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "dispatcher_rejection_top_repos_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "dispatcher_rejection_summary_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 700,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "dispatcher_rejection_summary_table",
+                        "position": {
+                            "h": 380,
+                            "w": 700,
+                            "x": 0,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "dispatcher_rejection_top_labels_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "dispatcher_rejection_top_labels_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "dispatcher_rejection_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 500,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 740
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "dispatcher_rejection_trend_chart",
+                        "position": {
+                            "h": 380,
+                            "w": 500,
+                            "x": 600,
+                            "y": 740
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "dispatcher_rejection_examples_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 440,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1120
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "dispatcher_rejection_examples_table",
+                        "position": {
+                            "h": 440,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1120
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_dispatcher_rejections.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_dispatcher_rejections.json.tftpl
@@ -191,22 +191,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "dispatcher_rejection_top_repos_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -216,7 +206,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 700,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -226,7 +216,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -236,7 +226,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 500,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 910
+                                                                                                                                                    "y": 740
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -246,7 +236,7 @@
                                                                                                                                                     "h": 440,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1290
+                                                                                                                                                    "y": 1120
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -266,14 +256,6 @@
     },
     "title": "Forge Runner Dispatcher Rejections",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with rejection summary, labels, and repositories, then inspect the latest structured sample. **Healthy:** no sustained production rejection pattern; isolated unsupported labels may be expected tenant input. **Action:** identify tenant, repository, workflow job, full labels, and rejection reason before checking runner mapping and policy. **Ownership:** deterministic dispatcher defects belong to Forge; labels and runner mapping belong to tenant configuration; GitHub delivery gaps are external or shared relay issues."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "dispatcher_rejection_examples_table": {
             "dataSources": {
                 "primary": "dispatcher_rejection_examples_search"

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_dispatcher_rejections.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_runner_dispatcher_rejections.json.tftpl
@@ -10,7 +10,7 @@
             "name": "Dispatcher rejection examples",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\"), request_id=coalesce('aws-request-id',aws_request_id)\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| rex field=message \"Job ID: (?<job_id>\\d+), Job Name: (?<job_name>.*), Run ID: (?<run_id>\\d+)\"\n| rex field=message \"Queue (?<queue_id>[^: ]+)\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo), job_id=coalesce(forgecicd_dispatcher_job_id,job_id), job_name=coalesce(forgecicd_dispatcher_job_name,job_name), run_id=coalesce(forgecicd_dispatcher_run_id,run_id)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    match(message,\"Failed to handle webhook event\"), \"webhook_handler_failed\",\n    match(message,\"Failed to send event to EventBridge\"), \"eventbridge_send_failed\",\n    match(message,\"Unsupported event type\"), \"unsupported_event_type\",\n    match(message,\"Received event from unauthorized repository\"), \"unauthorized_repository\",\n    true(), \"other_warn_error\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| eval event_time=strftime(_time,\"%Y-%m-%d %H:%M:%S\"), sample=substr(message,1,500)\n| table event_time tenant environment signal repo runner_labels queue_id job_id job_name run_id request_id service sample\n| sort - event_time\n| head 200\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*dispatch-to-runner:*\"\n| search forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\"), request_id=coalesce('aws-request-id',aws_request_id)\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| rex field=message \"Job ID: (?<job_id>\\d+), Job Name: (?<job_name>.*), Run ID: (?<run_id>\\d+)\"\n| rex field=message \"Queue (?<queue_id>[^: ]+)\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo), job_id=coalesce(forgecicd_dispatcher_job_id,job_id), job_name=coalesce(forgecicd_dispatcher_job_name,job_name), run_id=coalesce(forgecicd_dispatcher_run_id,run_id)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    match(message,\"Failed to handle webhook event\"), \"webhook_handler_failed\",\n    match(message,\"Failed to send event to EventBridge\"), \"eventbridge_send_failed\",\n    match(message,\"Unsupported event type\"), \"unsupported_event_type\",\n    match(message,\"Received event from unauthorized repository\"), \"unauthorized_repository\",\n    true(), \"other_warn_error\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| eval event_time=strftime(_time,\"%Y-%m-%d %H:%M:%S\"), sample=substr(message,1,500)\n| table event_time tenant environment signal repo runner_labels queue_id job_id job_name run_id request_id service sample\n| sort - event_time\n| head 200\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -22,7 +22,7 @@
             "name": "Dispatcher rejection summary",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\"), request_id=coalesce('aws-request-id',aws_request_id)\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| rex field=message \"Job ID: (?<job_id>\\d+), Job Name: (?<job_name>.*), Run ID: (?<run_id>\\d+)\"\n| rex field=message \"Queue (?<queue_id>[^: ]+)\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo), job_id=coalesce(forgecicd_dispatcher_job_id,job_id), job_name=coalesce(forgecicd_dispatcher_job_name,job_name), run_id=coalesce(forgecicd_dispatcher_run_id,run_id)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    match(message,\"Failed to handle webhook event\"), \"webhook_handler_failed\",\n    match(message,\"Failed to send event to EventBridge\"), \"eventbridge_send_failed\",\n    match(message,\"Unsupported event type\"), \"unsupported_event_type\",\n    match(message,\"Received event from unauthorized repository\"), \"unauthorized_repository\",\n    true(), \"other_warn_error\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| stats count as events dc(request_id) as lambda_invocations dc(job_id) as jobs dc(run_id) as runs dc(repo) as repos values(queue_id) as queues values(service) as services min(_time) as first_time max(_time) as last_time by tenant environment signal level module\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| eval pattern=case(events>=1000 AND duration_minutes>=60,\"persistent\", events>=50,\"repeating\", events>=5,\"burst\", true(),\"single\")\n| fields tenant environment signal pattern events jobs runs repos lambda_invocations duration_minutes first_seen last_seen level module services queues\n| sort - events\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*dispatch-to-runner:*\"\n| search forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\"), request_id=coalesce('aws-request-id',aws_request_id)\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| rex field=message \"Job ID: (?<job_id>\\d+), Job Name: (?<job_name>.*), Run ID: (?<run_id>\\d+)\"\n| rex field=message \"Queue (?<queue_id>[^: ]+)\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo), job_id=coalesce(forgecicd_dispatcher_job_id,job_id), job_name=coalesce(forgecicd_dispatcher_job_name,job_name), run_id=coalesce(forgecicd_dispatcher_run_id,run_id)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    match(message,\"Failed to handle webhook event\"), \"webhook_handler_failed\",\n    match(message,\"Failed to send event to EventBridge\"), \"eventbridge_send_failed\",\n    match(message,\"Unsupported event type\"), \"unsupported_event_type\",\n    match(message,\"Received event from unauthorized repository\"), \"unauthorized_repository\",\n    true(), \"other_warn_error\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| stats count as events dc(request_id) as lambda_invocations dc(job_id) as jobs dc(run_id) as runs dc(repo) as repos values(queue_id) as queues values(service) as services min(_time) as first_time max(_time) as last_time by tenant environment signal level module\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\"), age_minutes=round((now()-last_time)/60,1)\n| eval pattern=case(events>=1000 AND duration_minutes>=60,\"persistent\", events>=50,\"repeating\", events>=5,\"burst\", true(),\"single\")\n| fields tenant environment signal pattern events jobs runs repos lambda_invocations duration_minutes age_minutes first_seen last_seen level module services queues\n| sort - events\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -34,7 +34,7 @@
             "name": "Rejected labels",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| rex field=message \"Job ID: (?<job_id>\\d+), Job Name: (?<job_name>.*), Run ID: (?<run_id>\\d+)\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo), job_id=coalesce(forgecicd_dispatcher_job_id,job_id), job_name=coalesce(forgecicd_dispatcher_job_name,job_name), run_id=coalesce(forgecicd_dispatcher_run_id,run_id)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    true(), \"other_warn_error\")\n| where isnotnull(runner_labels)\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| stats count as events dc(repo) as repos dc(job_id) as jobs dc(run_id) as runs latest(_time) as last_time by tenant runner_labels signal\n| eval last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| sort - events\n| head 100\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*dispatch-to-runner:*\"\n| search forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| rex field=message \"Job ID: (?<job_id>\\d+), Job Name: (?<job_name>.*), Run ID: (?<run_id>\\d+)\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo), job_id=coalesce(forgecicd_dispatcher_job_id,job_id), job_name=coalesce(forgecicd_dispatcher_job_name,job_name), run_id=coalesce(forgecicd_dispatcher_run_id,run_id)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    true(), \"other_warn_error\")\n| where isnotnull(runner_labels)\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| stats count as events dc(repo) as repos dc(job_id) as jobs dc(run_id) as runs latest(_time) as last_time by tenant runner_labels signal\n| eval last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\"), age_minutes=round((now()-last_time)/60,1)\n| sort - events\n| head 100\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -46,7 +46,7 @@
             "name": "Rejected repositories",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| rex field=message \"Job ID: (?<job_id>\\d+), Job Name: (?<job_name>.*), Run ID: (?<run_id>\\d+)\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo), job_id=coalesce(forgecicd_dispatcher_job_id,job_id), job_name=coalesce(forgecicd_dispatcher_job_name,job_name), run_id=coalesce(forgecicd_dispatcher_run_id,run_id)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    match(message,\"Failed to handle webhook event\"), \"webhook_handler_failed\",\n    match(message,\"Failed to send event to EventBridge\"), \"eventbridge_send_failed\",\n    match(message,\"Unsupported event type\"), \"unsupported_event_type\",\n    match(message,\"Received event from unauthorized repository\"), \"unauthorized_repository\",\n    true(), \"other_warn_error\")\n| eval repo=coalesce(repo,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| stats count as events dc(job_id) as jobs dc(run_id) as runs values(runner_labels) as labels latest(_time) as last_time by tenant repo signal\n| eval last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| sort - events\n| head 100\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*dispatch-to-runner:*\"\n| search forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| rex field=message \"Job ID: (?<job_id>\\d+), Job Name: (?<job_name>.*), Run ID: (?<run_id>\\d+)\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo), job_id=coalesce(forgecicd_dispatcher_job_id,job_id), job_name=coalesce(forgecicd_dispatcher_job_name,job_name), run_id=coalesce(forgecicd_dispatcher_run_id,run_id)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    match(message,\"Failed to handle webhook event\"), \"webhook_handler_failed\",\n    match(message,\"Failed to send event to EventBridge\"), \"eventbridge_send_failed\",\n    match(message,\"Unsupported event type\"), \"unsupported_event_type\",\n    match(message,\"Received event from unauthorized repository\"), \"unauthorized_repository\",\n    true(), \"other_warn_error\")\n| eval repo=coalesce(repo,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| stats count as events dc(job_id) as jobs dc(run_id) as runs values(runner_labels) as labels latest(_time) as last_time by tenant repo signal\n| eval last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\"), age_minutes=round((now()-last_time)/60,1)\n| sort - events\n| head 100\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -58,7 +58,7 @@
             "name": "Dispatcher rejection trend",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    match(message,\"Failed to handle webhook event\"), \"webhook_handler_failed\",\n    match(message,\"Failed to send event to EventBridge\"), \"eventbridge_send_failed\",\n    match(message,\"Unsupported event type\"), \"unsupported_event_type\",\n    match(message,\"Received event from unauthorized repository\"), \"unauthorized_repository\",\n    true(), \"other_warn_error\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| timechart span=15m count by signal limit=12\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*dispatch-to-runner:*\"\n| search forgecicd_log_type=\"dispatch-to-runner\" (level=\"WARN\" OR level=\"ERROR\" OR level=\"warn\" OR level=\"error\")\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| rex field=message \"runner labels '(?<runner_labels>[^']+)' from '(?<repo>[^']+)'\"\n| eval runner_labels=coalesce(forgecicd_dispatcher_runner_labels,runner_labels), repo=coalesce(forgecicd_dispatcher_repository,repo)\n| eval signal=case(\n    match(message,\"runner labels .* are not accepted\"), \"labels_not_accepted\",\n    match(message,\"matches non-dynamic labels but does not allow dynamic labels\"), \"dynamic_labels_not_enabled\",\n    match(message,\"dynamic label .* does not match policy\"), \"dynamic_label_policy_reject\",\n    match(message,\"No queue accepts the dynamic labels\"), \"no_dynamic_label_queue\",\n    match(message,\"Dynamic label exceeds max length\"), \"dynamic_label_too_long\",\n    match(message,\"Dynamic label contains invalid characters\"), \"dynamic_label_invalid_chars\",\n    match(message,\"Failed to handle webhook event\"), \"webhook_handler_failed\",\n    match(message,\"Failed to send event to EventBridge\"), \"eventbridge_send_failed\",\n    match(message,\"Unsupported event type\"), \"unsupported_event_type\",\n    match(message,\"Received event from unauthorized repository\"), \"unauthorized_repository\",\n    true(), \"other_warn_error\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| where \"$repo$\"=\"*\" OR like(repo,\"%$repo$%\")\n| where \"$signal$\"=\"*\" OR signal=\"$signal$\"\n| timechart span=15m count by signal limit=12\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -191,55 +191,65 @@
                 },
                 "structure": [
                     {
-                        "item": "dispatcher_rejection_summary_table",
-                        "position": {
-                            "h": 380,
-                            "w": 700,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dispatcher_rejection_trend_chart",
-                        "position": {
-                            "h": 380,
-                            "w": 500,
-                            "x": 700,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dispatcher_rejection_top_repos_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dispatcher_rejection_top_repos_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 380
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dispatcher_rejection_summary_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 700,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dispatcher_rejection_top_labels_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 380
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dispatcher_rejection_top_labels_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dispatcher_rejection_examples_table",
-                        "position": {
-                            "h": 440,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 740
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "dispatcher_rejection_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 500,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "dispatcher_rejection_examples_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 440,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1290
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -256,6 +266,14 @@
     },
     "title": "Forge Runner Dispatcher Rejections",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with rejection summary, labels, and repositories, then inspect the latest structured sample. **Healthy:** no sustained production rejection pattern; isolated unsupported labels may be expected tenant input. **Action:** identify tenant, repository, workflow job, full labels, and rejection reason before checking runner mapping and policy. **Ownership:** deterministic dispatcher defects belong to Forge; labels and runner mapping belong to tenant configuration; GitHub delivery gaps are external or shared relay issues."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "dispatcher_rejection_examples_table": {
             "dataSources": {
                 "primary": "dispatcher_rejection_examples_search"
@@ -265,7 +283,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Latest Rejection Samples",
+            "description": "Answers \"Why were the latest workflow jobs rejected?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Why were the latest workflow jobs rejected?",
             "type": "splunk.table"
         },
         "dispatcher_rejection_summary_table": {
@@ -277,7 +296,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Rejection Summary",
+            "description": "Answers \"Which dispatcher rejection reasons are active?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which dispatcher rejection reasons are active?",
             "type": "splunk.table"
         },
         "dispatcher_rejection_top_labels_table": {
@@ -289,7 +309,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Rejected Labels",
+            "description": "Answers \"Which labels are being rejected?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which labels are being rejected?",
             "type": "splunk.table"
         },
         "dispatcher_rejection_top_repos_table": {
@@ -301,7 +322,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Rejected Repositories",
+            "description": "Answers \"Which repositories are affected by rejections?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which repositories are affected by rejections?",
             "type": "splunk.table"
         },
         "dispatcher_rejection_trend_chart": {
@@ -311,7 +333,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Rejection Trend",
+            "description": "Answers \"Are dispatcher rejections increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are dispatcher rejections increasing?",
             "type": "splunk.line"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_debug.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_debug.json.tftpl
@@ -146,65 +146,75 @@
                 },
                 "structure": [
                     {
-                        "item": "job_lifecycle_table",
-                        "position": {
-                            "h": 410,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "receiver_decision_detail_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 410
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "runner_group_summary_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_group_summary_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 410
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "job_lifecycle_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 410,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "delivery_attempts_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 770
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "delivery_attempts_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 940
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "failure_samples_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 770
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "receiver_decision_detail_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 940
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "latest_samples_table",
-                        "position": {
-                            "h": 420,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1130
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "failure_samples_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1300
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "latest_samples_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1660
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -221,6 +231,14 @@
     },
     "title": "Forge Stuck Workflow Job Dispatcher Debug",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nUse this drilldown only after the health dashboard identifies a stuck workflow job. Start with the end-to-end redelivery lifecycle, then inspect receiver decisions, capacity decisions, delivery attempts, and unique failure samples. **Healthy:** the job advances or redelivery completes without repeated failure. **Action:** filter to one tenant, repository, and workflow job ID and follow webhook, dispatcher, SQS, provider capacity, and runner start. **Ownership:** classify only after the failing stage is identified; global locks are not assumed causal."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "delivery_attempts_table": {
             "dataSources": {
                 "primary": "delivery_attempts_search"
@@ -230,7 +248,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "GitHub Delivery Attempts",
+            "description": "Answers \"Did GitHub delivery attempts succeed?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Did GitHub delivery attempts succeed?",
             "type": "splunk.table"
         },
         "failure_samples_table": {
@@ -242,7 +261,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Failure Samples",
+            "description": "Answers \"What failed in the latest redelivery attempts?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "What failed in the latest redelivery attempts?",
             "type": "splunk.table"
         },
         "job_lifecycle_table": {
@@ -254,7 +274,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "End-to-End Redelivery Lifecycle",
+            "description": "Answers \"Where did each redelivery attempt stop?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Where did each redelivery attempt stop?",
             "type": "splunk.table"
         },
         "latest_samples_table": {
@@ -266,7 +287,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Latest Log Samples",
+            "description": "Answers \"What do the latest correlated logs show?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "What do the latest correlated logs show?",
             "type": "splunk.table"
         },
         "receiver_decision_detail_table": {
@@ -278,7 +300,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Receiver Decision Detail",
+            "description": "Answers \"Why did the receiver accept, skip, or reject the job?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Why did the receiver accept, skip, or reject the job?",
             "type": "splunk.table"
         },
         "runner_group_summary_table": {
@@ -290,7 +313,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Group Capacity Decisions",
+            "description": "Answers \"Did runner-group capacity block redelivery?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Did runner-group capacity block redelivery?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_debug.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_debug.json.tftpl
@@ -146,65 +146,65 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "runner_group_summary_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "runner_group_summary_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "job_lifecycle_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 410,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "job_lifecycle_table",
+                        "position": {
+                            "h": 410,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "delivery_attempts_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 770
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "delivery_attempts_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 770
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "receiver_decision_detail_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 770
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "receiver_decision_detail_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 600,
+                            "y": 770
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "failure_samples_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1130
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "failure_samples_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 1130
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "latest_samples_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1490
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "latest_samples_table",
+                        "position": {
+                            "h": 420,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1490
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_debug.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_debug.json.tftpl
@@ -146,22 +146,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "runner_group_summary_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -171,7 +161,7 @@
                                                                                                                                                     "h": 410,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -181,7 +171,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 940
+                                                                                                                                                    "y": 770
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -191,7 +181,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 940
+                                                                                                                                                    "y": 770
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -201,7 +191,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1300
+                                                                                                                                                    "y": 1130
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -211,7 +201,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1660
+                                                                                                                                                    "y": 1490
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -231,14 +221,6 @@
     },
     "title": "Forge Stuck Workflow Job Dispatcher Debug",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nUse this drilldown only after the health dashboard identifies a stuck workflow job. Start with the end-to-end redelivery lifecycle, then inspect receiver decisions, capacity decisions, delivery attempts, and unique failure samples. **Healthy:** the job advances or redelivery completes without repeated failure. **Action:** filter to one tenant, repository, and workflow job ID and follow webhook, dispatcher, SQS, provider capacity, and runner start. **Ownership:** classify only after the failing stage is identified; global locks are not assumed causal."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "delivery_attempts_table": {
             "dataSources": {
                 "primary": "delivery_attempts_search"
@@ -287,7 +269,7 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "description": "Answers \"What do the latest correlated logs show?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "description": "Answers \"What do the latest correlated logs show?\" with investigation detail. Use this drilldown only after the health dashboard identifies the tenant and workflow job. Global locks are not assumed causal. An empty result can reflect filters or retention.",
             "title": "What do the latest correlated logs show?",
             "type": "splunk.table"
         },

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_health.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_health.json.tftpl
@@ -149,75 +149,75 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "hotspots_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 390,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "hotspots_table",
+                        "position": {
+                            "h": 390,
+                            "w": 600,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "failure_summary_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 390,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "failure_summary_table",
+                        "position": {
+                            "h": 390,
+                            "w": 600,
+                            "x": 600,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "worker_outcome_summary_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 390
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "worker_outcome_summary_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 390
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "stuck_job_control_plane_path_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 750
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "stuck_job_control_plane_path_table",
+                        "position": {
+                            "h": 420,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 750
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "alert_quality_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 330,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1170
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "alert_quality_table",
+                        "position": {
+                            "h": 330,
+                            "w": 600,
+                            "x": 0,
+                            "y": 1170
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "decision_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 330,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 1170
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "decision_trend_chart",
+                        "position": {
+                            "h": 330,
+                            "w": 600,
+                            "x": 600,
+                            "y": 1170
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "worker_outcome_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1500
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "worker_outcome_trend_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 1500
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_health.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_health.json.tftpl
@@ -149,75 +149,85 @@
                 },
                 "structure": [
                     {
-                        "item": "alert_quality_table",
-                        "position": {
-                            "h": 330,
-                            "w": 600,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "decision_trend_chart",
-                        "position": {
-                            "h": 330,
-                            "w": 600,
-                            "x": 600,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "hotspots_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 390,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "worker_outcome_summary_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 330
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "failure_summary_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 390,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "worker_outcome_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 330
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "worker_outcome_summary_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 560
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "hotspots_table",
-                        "position": {
-                            "h": 390,
-                            "w": 600,
-                            "x": 0,
-                            "y": 690
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "stuck_job_control_plane_path_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 920
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "failure_summary_table",
-                        "position": {
-                            "h": 390,
-                            "w": 600,
-                            "x": 600,
-                            "y": 690
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "alert_quality_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 330,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1340
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "stuck_job_control_plane_path_table",
-                        "position": {
-                            "h": 420,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1080
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "decision_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 330,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 1340
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "worker_outcome_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1670
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -234,6 +244,14 @@
     },
     "title": "Forge Stuck Workflow Job Dispatcher Health",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with the stuck-job control-plane path and worker outcomes, then use decision trends and hot spots for scope. **Healthy:** no job remains queued beyond the configured 15-minute alert boundary and redelivery reaches a terminal outcome. **Action:** identify tenant, repository, workflow job, labels, and last successful stage, then open the debug dashboard. **Ownership:** shared redelivery defects belong to Forge; runner mapping and capacity belong to tenant configuration; GitHub or AWS service failures may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "alert_quality_table": {
             "dataSources": {
                 "primary": "alert_quality_search"
@@ -243,7 +261,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Alert Quality and Receiver Decisions",
+            "description": "Answers \"Are stuck-job alerts producing actionable receiver decisions?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are stuck-job alerts producing actionable receiver decisions?",
             "type": "splunk.table"
         },
         "decision_trend_chart": {
@@ -253,7 +272,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Receiver Decision Trend",
+            "description": "Answers \"Are receiver skips or rejections increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are receiver skips or rejections increasing?",
             "type": "splunk.line"
         },
         "failure_summary_table": {
@@ -265,7 +285,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Failures and Warnings",
+            "description": "Answers \"Which redelivery failures or warnings need action?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which redelivery failures or warnings need action?",
             "type": "splunk.table"
         },
         "hotspots_table": {
@@ -277,7 +298,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Tenant and Repository Hot Spots",
+            "description": "Answers \"Which tenants or repositories are repeatedly affected?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which tenants or repositories are repeatedly affected?",
             "type": "splunk.table"
         },
         "stuck_job_control_plane_path_table": {
@@ -289,7 +311,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Stuck Job Control-Plane Path",
+            "description": "Answers \"Where are stuck jobs stopping in the control-plane path?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Where are stuck jobs stopping in the control-plane path?",
             "type": "splunk.table"
         },
         "worker_outcome_summary_table": {
@@ -301,7 +324,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Worker Outcomes",
+            "description": "Answers \"Did redelivery workers reach a terminal outcome?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Did redelivery workers reach a terminal outcome?",
             "type": "splunk.table"
         },
         "worker_outcome_trend_chart": {
@@ -311,7 +335,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Worker Outcome Trend",
+            "description": "Answers \"Are redelivery worker failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are redelivery worker failures increasing?",
             "type": "splunk.line"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_health.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_stuck_workflow_job_dispatcher_health.json.tftpl
@@ -149,22 +149,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "hotspots_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 390,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -174,7 +164,7 @@
                                                                                                                                                     "h": 390,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -184,7 +174,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 560
+                                                                                                                                                    "y": 390
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -194,7 +184,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 920
+                                                                                                                                                    "y": 750
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -204,7 +194,7 @@
                                                                                                                                                     "h": 330,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1340
+                                                                                                                                                    "y": 1170
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -214,7 +204,7 @@
                                                                                                                                                     "h": 330,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 1340
+                                                                                                                                                    "y": 1170
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -224,7 +214,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1670
+                                                                                                                                                    "y": 1500
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -244,14 +234,6 @@
     },
     "title": "Forge Stuck Workflow Job Dispatcher Health",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with the stuck-job control-plane path and worker outcomes, then use decision trends and hot spots for scope. **Healthy:** no job remains queued beyond the configured 15-minute alert boundary and redelivery reaches a terminal outcome. **Action:** identify tenant, repository, workflow job, labels, and last successful stage, then open the debug dashboard. **Ownership:** shared redelivery defects belong to Forge; runner mapping and capacity belong to tenant configuration; GitHub or AWS service failures may be external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "alert_quality_table": {
             "dataSources": {
                 "primary": "alert_quality_search"

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_dispatcher_dashboard_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_dispatcher_dashboard_operator_workflow_behavior.tftest.hcl
@@ -43,14 +43,13 @@ run "orders_dispatcher_dashboards_for_operator_triage" {
   assert {
     condition = (
       can(regex(
-        "\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"dispatcher_rejection_summary_table\"[\\s\\S]*\"item\": \"dispatcher_rejection_trend_chart\"[\\s\\S]*\"item\": \"dispatcher_rejection_examples_table\"",
+        "\"item\": \"dispatcher_rejection_summary_table\"[\\s\\S]*\"item\": \"dispatcher_rejection_trend_chart\"[\\s\\S]*\"item\": \"dispatcher_rejection_examples_table\"",
         splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data,
       ))
-      && strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "Healthy:")
-      && strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "Action:")
+      && !strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "\"operator_guide\"")
       && strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "age_minutes")
     )
-    error_message = "Dispatcher rejections must lead with guidance and actionable scope, explain healthy/action semantics, expose age, and leave raw samples last."
+    error_message = "Dispatcher rejections must lead with actionable scope, expose age, and leave raw samples last without a guide row."
   }
 
   assert {
@@ -64,11 +63,11 @@ run "orders_dispatcher_dashboards_for_operator_triage" {
 
   assert {
     condition = (
-      strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_health.eai_data, "How should I use this dashboard?")
+      !strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_health.eai_data, "\"operator_guide\"")
       && strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_debug.eai_data, "Use this drilldown only after the health dashboard")
-      && strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_debug.eai_data, "global locks are not assumed causal")
-      && strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_debug.eai_data, "Healthy:")
+      && strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_debug.eai_data, "Global locks are not assumed causal")
+      && !strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_debug.eai_data, "\"operator_guide\"")
     )
-    error_message = "Stuck-job health and debug dashboards must state their workflow, healthy state, and non-causal global-lock boundary."
+    error_message = "Stuck-job health and debug dashboards must keep compact workflow guidance and the non-causal global-lock boundary."
   }
 }

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_dispatcher_dashboard_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_dispatcher_dashboard_operator_workflow_behavior.tftest.hcl
@@ -1,0 +1,74 @@
+mock_provider "aws" {
+  mock_data "aws_secretsmanager_secret" {
+    defaults = {
+      id = "/cicd/common/splunk-cloud"
+    }
+  }
+
+  mock_data "aws_secretsmanager_secret_version" {
+    defaults = {
+      secret_string = "mock-splunk-secret"
+    }
+  }
+}
+
+mock_provider "splunk" {
+  mock_resource "splunk_data_ui_views" {}
+  mock_resource "splunk_configs_conf" {}
+  mock_resource "splunk_transforms_regex" {}
+}
+
+variables {
+  aws_profile  = "test"
+  aws_region   = "us-east-1"
+  default_tags = { Product = "Forge" }
+  splunk_conf = {
+    splunk_cloud = "https://example.splunkcloud.com"
+    acl = {
+      app     = "search_app_srea"
+      owner   = "nobody"
+      sharing = "app"
+      read    = ["*"]
+      write   = ["admin"]
+    }
+    index        = "srea-forge-prod-index"
+    tenant_names = ["tenant-a"]
+  }
+  stuck_workflow_job_dispatcher_name_prefix = "forge-dispatcher"
+}
+
+run "orders_dispatcher_dashboards_for_operator_triage" {
+  command = plan
+
+  assert {
+    condition = (
+      can(regex(
+        "\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"dispatcher_rejection_summary_table\"[\\s\\S]*\"item\": \"dispatcher_rejection_trend_chart\"[\\s\\S]*\"item\": \"dispatcher_rejection_examples_table\"",
+        splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data,
+      ))
+      && strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "Healthy:")
+      && strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "Action:")
+      && strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "age_minutes")
+    )
+    error_message = "Dispatcher rejections must lead with guidance and actionable scope, explain healthy/action semantics, expose age, and leave raw samples last."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "sourcetype IN (\\\"aws:cloudwatchlogs\\\",\\\"aws:cloudwatchlogs:forgecicd\\\") source=\\\"*:/aws/lambda/*dispatch-to-runner:*\\\"")
+      && strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "| search forgecicd_log_type=\\\"dispatch-to-runner\\\"")
+      && !strcontains(splunk_data_ui_views.forge_runner_dispatcher_rejections.eai_data, "index=\\\"srea-forge-prod-index\\\" forgecicd_log_type=")
+    )
+    error_message = "Dispatcher SPL must constrain indexed sourcetype and Lambda source before applying the search-time dispatcher field."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_health.eai_data, "How should I use this dashboard?")
+      && strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_debug.eai_data, "Use this drilldown only after the health dashboard")
+      && strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_debug.eai_data, "global locks are not assumed causal")
+      && strcontains(splunk_data_ui_views.stuck_workflow_job_dispatcher_debug.eai_data, "Healthy:")
+    )
+    error_message = "Stuck-job health and debug dashboards must state their workflow, healthy state, and non-causal global-lock boundary."
+  }
+}


### PR DESCRIPTION
## Description

Refactors dispatcher rejection and stuck-workflow-job health/debug dashboards while keeping the presentation compact.

- Removes the full-width operator-guide visualizations and their 170-pixel rows.
- Keeps workflow, healthy-state, failure, and action guidance in panel descriptions.
- Keeps global-lock cleanup diagnostic and separate from stuck-job causality.
- Constrains dispatcher searches by indexed CloudWatch sourcetype and `dispatch-to-runner` Lambda source before search-time fields.
- Adds rejection age and preserves tenant, repository, workflow-job, and global-time filters.

This PR remains separate from the presentation-only dashboard consolidation because it changes SPL filtering and result fields.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: ____________

## Testing

- `tofu test` in `modules/integrations/splunk_cloud_conf_shared`: 6 passed
- Changed-file pre-commit suite: passed
- `git diff --check`: passed
