### PR TITLE
refactor(observability): improve EC2 dashboard searches

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_fleet_scale_up_failures.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_fleet_scale_up_failures.json.tftpl
@@ -10,7 +10,7 @@
             "name": "CreateFleet error trend",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| bin _time span=5m\n| stats dc(request_id) as failed_requests by _time error_code\n| timechart span=5m sum(failed_requests) as failed_requests by error_code limit=15\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| bin _time span=5m\n| stats dc(request_id) as failed_requests by _time error_code\n| timechart span=5m sum(failed_requests) as failed_requests by error_code limit=15\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -22,7 +22,7 @@
             "name": "Tenant and error summary",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| spath input=fleet_error path=ErrorMessage output=error_message\n| spath input=fleet_error path=Lifecycle output=lifecycle\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.InstanceType output=instance_type\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.SubnetId output=subnet_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.ImageId output=image_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.LaunchTemplateId output=launch_template_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.Version output=launch_template_version\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| eval error_family=case(\n    error_code=\"InvalidAMIID.NotFound\", \"configuration\",\n    match(error_code,\"(?i)capacity|unfulfillable|host|addresses\"), \"capacity\",\n    match(error_code,\"(?i)limit|quota|throttl|requestlimit\"), \"quota_or_rate\",\n    match(error_code,\"(?i)unauthorized|accessdenied\"), \"permissions\",\n    true(), \"other\")\n| stats dc(request_id) as failed_requests count as failed_overrides dc(image_id) as images dc(instance_type) as instance_types dc(subnet_id) as subnets values(image_id) as image_ids values(launch_template_id) as launch_template_ids values(launch_template_version) as launch_template_versions values(error_message) as error_messages min(_time) as first_time max(_time) as last_time by tenant region environment error_family error_code\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| eval pattern=case(failed_requests>=20 AND duration_minutes>=30,\"persistent\", failed_requests>=5,\"repeating\", failed_requests>1,\"burst\", true(),\"single\")\n| fields tenant region environment error_family error_code pattern failed_requests failed_overrides images instance_types subnets image_ids launch_template_ids launch_template_versions duration_minutes first_seen last_seen error_messages\n| sort - failed_requests - failed_overrides\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| spath input=fleet_error path=ErrorMessage output=error_message\n| spath input=fleet_error path=Lifecycle output=lifecycle\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.InstanceType output=instance_type\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.SubnetId output=subnet_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.ImageId output=image_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.LaunchTemplateId output=launch_template_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.Version output=launch_template_version\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| eval error_family=case(\n    error_code=\"InvalidAMIID.NotFound\", \"configuration\",\n    match(error_code,\"(?i)capacity|unfulfillable|host|addresses\"), \"capacity\",\n    match(error_code,\"(?i)limit|quota|throttl|requestlimit\"), \"quota_or_rate\",\n    match(error_code,\"(?i)unauthorized|accessdenied\"), \"permissions\",\n    true(), \"other\")\n| stats dc(request_id) as failed_requests count as failed_overrides dc(image_id) as images dc(instance_type) as instance_types dc(subnet_id) as subnets values(image_id) as image_ids values(launch_template_id) as launch_template_ids values(launch_template_version) as launch_template_versions values(error_message) as error_messages min(_time) as first_time max(_time) as last_time by tenant region environment error_family error_code\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| eval pattern=case(failed_requests>=20 AND duration_minutes>=30,\"persistent\", failed_requests>=5,\"repeating\", failed_requests>1,\"burst\", true(),\"single\")\n| fields tenant region environment error_family error_code pattern failed_requests failed_overrides images instance_types subnets image_ids launch_template_ids launch_template_versions duration_minutes first_seen last_seen error_messages\n| sort - failed_requests - failed_overrides\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -34,7 +34,7 @@
             "name": "Recurrence windows",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| bin _time span=15m\n| stats dc(request_id) as failed_requests count as failed_overrides by _time tenant region environment error_code\n| stats sum(failed_requests) as failed_requests sum(failed_overrides) as failed_overrides count(eval(failed_requests>0)) as active_15m_windows max(failed_requests) as peak_requests_per_window min(_time) as first_time max(_time) as last_time by tenant region environment error_code\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| eval pattern=case(active_15m_windows>=4 AND duration_minutes>=45,\"persistent\", active_15m_windows>=2,\"repeating\", failed_requests>=5,\"burst\", true(),\"single_window\")\n| fields tenant region environment error_code pattern active_15m_windows failed_requests peak_requests_per_window failed_overrides duration_minutes first_seen last_seen\n| sort - active_15m_windows - failed_requests\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| bin _time span=15m\n| stats dc(request_id) as failed_requests count as failed_overrides by _time tenant region environment error_code\n| stats sum(failed_requests) as failed_requests sum(failed_overrides) as failed_overrides count(eval(failed_requests>0)) as active_15m_windows max(failed_requests) as peak_requests_per_window min(_time) as first_time max(_time) as last_time by tenant region environment error_code\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| eval pattern=case(active_15m_windows>=4 AND duration_minutes>=45,\"persistent\", active_15m_windows>=2,\"repeating\", failed_requests>=5,\"burst\", true(),\"single_window\")\n| fields tenant region environment error_code pattern active_15m_windows failed_requests peak_requests_per_window failed_overrides duration_minutes first_seen last_seen\n| sort - active_15m_windows - failed_requests\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -46,7 +46,7 @@
             "name": "Override breakdown",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| spath input=fleet_error path=ErrorMessage output=error_message\n| spath input=fleet_error path=Lifecycle output=lifecycle\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.InstanceType output=instance_type\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.SubnetId output=subnet_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.ImageId output=image_id\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| stats dc(request_id) as failed_requests count as failed_overrides latest(_time) as last_time values(error_message) as error_messages by tenant region environment error_code lifecycle instance_type subnet_id image_id\n| eval last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| sort - failed_requests - failed_overrides\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| spath input=fleet_error path=ErrorMessage output=error_message\n| spath input=fleet_error path=Lifecycle output=lifecycle\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.InstanceType output=instance_type\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.SubnetId output=subnet_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.ImageId output=image_id\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| stats dc(request_id) as failed_requests count as failed_overrides latest(_time) as last_time values(error_message) as error_messages by tenant region environment error_code lifecycle instance_type subnet_id image_id\n| eval last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| sort - failed_requests - failed_overrides\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -58,7 +58,7 @@
             "name": "AMI and launch template failures",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.ImageId output=image_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.LaunchTemplateId output=launch_template_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.Version output=launch_template_version\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| stats dc(request_id) as failed_requests count as failed_overrides dc(error_code) as error_codes values(error_code) as error_code_values latest(_time) as last_time by tenant region environment image_id launch_template_id launch_template_version\n| eval last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| sort - failed_requests - failed_overrides\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.ImageId output=image_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.LaunchTemplateId output=launch_template_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.Version output=launch_template_version\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| stats dc(request_id) as failed_requests count as failed_overrides dc(error_code) as error_codes values(error_code) as error_code_values latest(_time) as last_time by tenant region environment image_id launch_template_id launch_template_version\n| eval last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| sort - failed_requests - failed_overrides\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -70,7 +70,7 @@
             "name": "CreateFleet request drilldown",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.FleetId output=fleet_id\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| spath input=fleet_error path=ErrorMessage output=error_message\n| spath input=fleet_error path=Lifecycle output=lifecycle\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.InstanceType output=instance_type\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.SubnetId output=subnet_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.ImageId output=image_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.LaunchTemplateId output=launch_template_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.Version output=launch_template_version\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| stats count as failed_overrides values(error_code) as error_codes values(error_message) as error_messages values(lifecycle) as lifecycles values(instance_type) as instance_types values(subnet_id) as subnet_ids values(image_id) as image_ids values(launch_template_id) as launch_template_ids values(launch_template_version) as launch_template_versions latest(_time) as request_time by tenant region environment request_id fleet_id\n| eval request_seen=strftime(request_time,\"%Y-%m-%d %H:%M:%S\")\n| fields request_seen tenant region environment request_id fleet_id failed_overrides error_codes image_ids instance_types subnet_ids launch_template_ids launch_template_versions error_messages\n| sort - request_seen\n| head 200\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"No instances created.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=data.FleetId output=fleet_id\n| spath path=data.Errors{} output=fleet_error\n| mvexpand fleet_error\n| spath input=fleet_error path=ErrorCode output=error_code\n| spath input=fleet_error path=ErrorMessage output=error_message\n| spath input=fleet_error path=Lifecycle output=lifecycle\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.InstanceType output=instance_type\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.SubnetId output=subnet_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.Overrides.ImageId output=image_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.LaunchTemplateId output=launch_template_id\n| spath input=fleet_error path=LaunchTemplateAndOverrides.LaunchTemplateSpecification.Version output=launch_template_version\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| stats count as failed_overrides values(error_code) as error_codes values(error_message) as error_messages values(lifecycle) as lifecycles values(instance_type) as instance_types values(subnet_id) as subnet_ids values(image_id) as image_ids values(launch_template_id) as launch_template_ids values(launch_template_version) as launch_template_versions latest(_time) as request_time by tenant region environment request_id fleet_id\n| eval request_seen=strftime(request_time,\"%Y-%m-%d %H:%M:%S\")\n| fields request_seen tenant region environment request_id fleet_id failed_overrides error_codes image_ids instance_types subnet_ids launch_template_ids launch_template_versions error_messages\n| sort - request_seen\n| head 200\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -211,65 +211,75 @@
                 },
                 "structure": [
                     {
-                        "item": "fleet_error_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "tenant_error_summary_table",
-                        "position": {
-                            "h": 390,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "tenant_error_summary_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 390,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "recurrence_windows_table",
-                        "position": {
-                            "h": 360,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 750
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "recurrence_windows_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 560
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "override_breakdown_table",
-                        "position": {
-                            "h": 380,
-                            "w": 700,
-                            "x": 0,
-                            "y": 1110
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "override_breakdown_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 700,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 920
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ami_launch_template_table",
-                        "position": {
-                            "h": 380,
-                            "w": 500,
-                            "x": 700,
-                            "y": 1110
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "ami_launch_template_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 500,
+                                                                                                                                                    "x": 700,
+                                                                                                                                                    "y": 920
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "request_drilldown_table",
-                        "position": {
-                            "h": 420,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1490
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "fleet_error_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1300
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "request_drilldown_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1660
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -286,6 +296,14 @@
     },
     "title": "Forge EC2 Fleet Scale-Up Failures",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with the tenant error summary and recurrence window, then inspect the exact CreateFleet request and failed override. **Healthy:** failure panels are empty; a single transient AWS error without job impact is not a Forge incident. **Action:** identify error code, region, subnet, instance type, AMI, and launch template before assigning cause. **Ownership:** shared request construction is Forge code; AMI, KMS, subnet, and launch-template configuration is tenant-owned; Spot or AWS capacity is external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "ami_launch_template_table": {
             "dataSources": {
                 "primary": "ami_launch_template_search"
@@ -295,7 +313,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "AMI and Launch Template Failures",
+            "description": "Answers \"Which AMI or launch-template failures need action?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which AMI or launch-template failures need action?",
             "type": "splunk.table"
         },
         "fleet_error_trend_chart": {
@@ -305,7 +324,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Failed CreateFleet Requests by Error Code",
+            "description": "Answers \"Are CreateFleet failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are CreateFleet failures increasing?",
             "type": "splunk.line"
         },
         "override_breakdown_table": {
@@ -317,7 +337,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Failed Overrides by Instance Type and Subnet",
+            "description": "Answers \"Which instance-type and subnet overrides failed?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which instance-type and subnet overrides failed?",
             "type": "splunk.table"
         },
         "recurrence_windows_table": {
@@ -329,7 +350,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Temporary vs Repeating Fleet Failure Windows",
+            "description": "Answers \"Which CreateFleet failures are sustained?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which CreateFleet failures are sustained?",
             "type": "splunk.table"
         },
         "request_drilldown_table": {
@@ -341,7 +363,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Recent CreateFleet Request Drilldown",
+            "description": "Answers \"What failed in the latest CreateFleet requests?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "What failed in the latest CreateFleet requests?",
             "type": "splunk.table"
         },
         "tenant_error_summary_table": {
@@ -353,7 +376,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Fleet Tenant Error Summary",
+            "description": "Answers \"Which tenants are affected by CreateFleet failures?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which tenants are affected by CreateFleet failures?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_fleet_scale_up_failures.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_fleet_scale_up_failures.json.tftpl
@@ -211,22 +211,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "tenant_error_summary_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 390,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -236,7 +226,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 560
+                                                                                                                                                    "y": 390
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -246,7 +236,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 700,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 920
+                                                                                                                                                    "y": 750
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -256,7 +246,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 500,
                                                                                                                                                     "x": 700,
-                                                                                                                                                    "y": 920
+                                                                                                                                                    "y": 750
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -266,7 +256,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1300
+                                                                                                                                                    "y": 1130
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -276,7 +266,7 @@
                                                                                                                                                     "h": 420,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1660
+                                                                                                                                                    "y": 1490
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -296,14 +286,6 @@
     },
     "title": "Forge EC2 Fleet Scale-Up Failures",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with the tenant error summary and recurrence window, then inspect the exact CreateFleet request and failed override. **Healthy:** failure panels are empty; a single transient AWS error without job impact is not a Forge incident. **Action:** identify error code, region, subnet, instance type, AMI, and launch template before assigning cause. **Ownership:** shared request construction is Forge code; AMI, KMS, subnet, and launch-template configuration is tenant-owned; Spot or AWS capacity is external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "ami_launch_template_table": {
             "dataSources": {
                 "primary": "ami_launch_template_search"

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_fleet_scale_up_failures.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_fleet_scale_up_failures.json.tftpl
@@ -211,65 +211,65 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "tenant_error_summary_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 390,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "tenant_error_summary_table",
+                        "position": {
+                            "h": 390,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "recurrence_windows_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 390
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "recurrence_windows_table",
+                        "position": {
+                            "h": 360,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 390
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "override_breakdown_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 700,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 750
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "override_breakdown_table",
+                        "position": {
+                            "h": 380,
+                            "w": 700,
+                            "x": 0,
+                            "y": 750
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ami_launch_template_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 500,
-                                                                                                                                                    "x": 700,
-                                                                                                                                                    "y": 750
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "ami_launch_template_table",
+                        "position": {
+                            "h": 380,
+                            "w": 500,
+                            "x": 700,
+                            "y": 750
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "fleet_error_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1130
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "fleet_error_trend_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1130
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "request_drilldown_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 420,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1490
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "request_drilldown_table",
+                        "position": {
+                            "h": 420,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1490
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_run_instances_scale_up_failures.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_run_instances_scale_up_failures.json.tftpl
@@ -191,22 +191,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "run_instances_summary_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 390,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -216,7 +206,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 560
+                                                                                                                                                    "y": 390
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -226,7 +216,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 760,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 920
+                                                                                                                                                    "y": 750
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -236,7 +226,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 440,
                                                                                                                                                     "x": 760,
-                                                                                                                                                    "y": 920
+                                                                                                                                                    "y": 750
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -246,7 +236,7 @@
                                                                                                                                                     "h": 500,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1280
+                                                                                                                                                    "y": 1110
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -266,14 +256,6 @@
     },
     "title": "Forge EC2 RunInstances Scale-Up Failures",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with the tenant error summary and recurrence window, then inspect the exact RunInstances request and SQS retry pressure. **Healthy:** failure panels are empty; a single transient AWS error without job impact is not a Forge incident. **Action:** identify error code, region, instance or host requirement, and retry outcome before assigning cause. **Ownership:** shared request construction is Forge code; AMI, KMS, subnet, and dedicated-host configuration is tenant-owned; AWS capacity is external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "recurrence_windows_table": {
             "dataSources": {
                 "primary": "recurrence_windows_search"

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_run_instances_scale_up_failures.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_run_instances_scale_up_failures.json.tftpl
@@ -191,55 +191,55 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "run_instances_summary_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 390,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "run_instances_summary_table",
+                        "position": {
+                            "h": 390,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "recurrence_windows_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 390
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "recurrence_windows_table",
+                        "position": {
+                            "h": 360,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 390
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "run_instances_error_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 760,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 750
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "run_instances_error_trend_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 760,
+                            "x": 0,
+                            "y": 750
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "run_instances_retry_pressure_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 440,
-                                                                                                                                                    "x": 760,
-                                                                                                                                                    "y": 750
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "run_instances_retry_pressure_table",
+                        "position": {
+                            "h": 360,
+                            "w": 440,
+                            "x": 760,
+                            "y": 750
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "run_instances_drilldown_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 500,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1110
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "run_instances_drilldown_table",
+                        "position": {
+                            "h": 500,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1110
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_run_instances_scale_up_failures.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_run_instances_scale_up_failures.json.tftpl
@@ -10,7 +10,7 @@
             "name": "RunInstances error trend",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=error.name output=error_name\n| spath path=error.Code output=error_code_outer\n| spath path=error.Error.Code output=error_code_inner\n| eval error_code=coalesce(error_name,errorName,error_code_outer,error_code_inner)\n| where isnotnull(error_code)\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| bin _time span=5m\n| stats dc(request_id) as failed_requests by _time error_code\n| timechart span=5m sum(failed_requests) as failed_requests by error_code limit=15\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=error.name output=error_name\n| spath path=error.Code output=error_code_outer\n| spath path=error.Error.Code output=error_code_inner\n| eval error_code=coalesce(error_name,errorName,error_code_outer,error_code_inner)\n| where isnotnull(error_code)\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| bin _time span=5m\n| stats dc(request_id) as failed_requests by _time error_code\n| timechart span=5m sum(failed_requests) as failed_requests by error_code limit=15\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -22,7 +22,7 @@
             "name": "RunInstances summary",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id), function_name=coalesce('function-name',function_name)\n| spath path=error.name output=error_name\n| spath path=error.Code output=error_code_outer\n| spath path=error.Error.Code output=error_code_inner\n| spath path=error.message output=error_message_outer\n| spath path=error.Error.Message output=error_message_inner\n| spath path=runner.n_events output=runner_events\n| spath path=runner.type output=runner_type\n| eval error_code=coalesce(error_name,errorName,error_code_outer,error_code_inner)\n| eval error_message=coalesce(error_message_outer,error_message_inner)\n| where isnotnull(error_code)\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| eval error_family=case(\n    match(error_code,\"(?i)host|capacity|unfulfillable|addresses\"), \"capacity\",\n    match(error_code,\"(?i)limit|quota|throttl|requestlimit\"), \"quota_or_rate\",\n    match(error_code,\"(?i)unauthorized|accessdenied\"), \"permissions\",\n    true(), \"other\")\n| stats dc(request_id) as failed_requests count as events values(error_message) as error_messages values(function_name) as functions values(service) as services values(runner_type) as runner_types values(runner_events) as runner_events min(_time) as first_time max(_time) as last_time by tenant region environment error_family error_code\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| eval pattern=case(failed_requests>=20 AND duration_minutes>=30,\"persistent\", failed_requests>=5,\"repeating\", failed_requests>1,\"burst\", true(),\"single\")\n| fields tenant region environment error_family error_code pattern failed_requests events duration_minutes first_seen last_seen functions services runner_types runner_events error_messages\n| sort - failed_requests - events\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id), function_name=coalesce('function-name',function_name)\n| spath path=error.name output=error_name\n| spath path=error.Code output=error_code_outer\n| spath path=error.Error.Code output=error_code_inner\n| spath path=error.message output=error_message_outer\n| spath path=error.Error.Message output=error_message_inner\n| spath path=runner.n_events output=runner_events\n| spath path=runner.type output=runner_type\n| eval error_code=coalesce(error_name,errorName,error_code_outer,error_code_inner)\n| eval error_message=coalesce(error_message_outer,error_message_inner)\n| where isnotnull(error_code)\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| eval error_family=case(\n    match(error_code,\"(?i)host|capacity|unfulfillable|addresses\"), \"capacity\",\n    match(error_code,\"(?i)limit|quota|throttl|requestlimit\"), \"quota_or_rate\",\n    match(error_code,\"(?i)unauthorized|accessdenied\"), \"permissions\",\n    true(), \"other\")\n| stats dc(request_id) as failed_requests count as events values(error_message) as error_messages values(function_name) as functions values(service) as services values(runner_type) as runner_types values(runner_events) as runner_events min(_time) as first_time max(_time) as last_time by tenant region environment error_family error_code\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| eval pattern=case(failed_requests>=20 AND duration_minutes>=30,\"persistent\", failed_requests>=5,\"repeating\", failed_requests>1,\"burst\", true(),\"single\")\n| fields tenant region environment error_family error_code pattern failed_requests events duration_minutes first_seen last_seen functions services runner_types runner_events error_messages\n| sort - failed_requests - events\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -34,7 +34,7 @@
             "name": "Recurrence windows",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=error.name output=error_name\n| spath path=error.Code output=error_code_outer\n| spath path=error.Error.Code output=error_code_inner\n| eval error_code=coalesce(error_name,errorName,error_code_outer,error_code_inner)\n| where isnotnull(error_code)\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| bin _time span=15m\n| stats dc(request_id) as failed_requests count as events by _time tenant region environment error_code\n| stats sum(failed_requests) as failed_requests sum(events) as events count(eval(failed_requests>0)) as active_15m_windows max(failed_requests) as peak_requests_per_window min(_time) as first_time max(_time) as last_time by tenant region environment error_code\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| eval pattern=case(active_15m_windows>=4 AND duration_minutes>=45,\"persistent\", active_15m_windows>=2,\"repeating\", failed_requests>=5,\"burst\", true(),\"single_window\")\n| fields tenant region environment error_code pattern active_15m_windows failed_requests peak_requests_per_window events duration_minutes first_seen last_seen\n| sort - active_15m_windows - failed_requests\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| spath path=error.name output=error_name\n| spath path=error.Code output=error_code_outer\n| spath path=error.Error.Code output=error_code_inner\n| eval error_code=coalesce(error_name,errorName,error_code_outer,error_code_inner)\n| where isnotnull(error_code)\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| bin _time span=15m\n| stats dc(request_id) as failed_requests count as events by _time tenant region environment error_code\n| stats sum(failed_requests) as failed_requests sum(events) as events count(eval(failed_requests>0)) as active_15m_windows max(failed_requests) as peak_requests_per_window min(_time) as first_time max(_time) as last_time by tenant region environment error_code\n| eval duration_minutes=round((last_time-first_time)/60,1), first_seen=strftime(first_time,\"%Y-%m-%d %H:%M:%S\"), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| eval pattern=case(active_15m_windows>=4 AND duration_minutes>=45,\"persistent\", active_15m_windows>=2,\"repeating\", failed_requests>=5,\"burst\", true(),\"single_window\")\n| fields tenant region environment error_code pattern active_15m_windows failed_requests peak_requests_per_window events duration_minutes first_seen last_seen\n| sort - active_15m_windows - failed_requests\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -46,7 +46,7 @@
             "name": "RunInstances retry pressure",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" (message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\" OR (\"ScaleError\" \"A retry will be attempted via SQS.\"))\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| eval run_instances_failure=if(message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\",1,0)\n| eval retry_logged=if(match(message,\"A retry will be attempted via SQS\"),1,0)\n| eval failed_instances=tonumber('error.failedInstanceCount')\n| stats max(run_instances_failure) as run_instances_failure max(retry_logged) as retry_logged values(failed_instances) as failed_instance_counts latest(_time) as last_time by tenant region environment request_id\n| where run_instances_failure=1\n| stats count as run_instances_requests sum(retry_logged) as retry_events sum(failed_instance_counts) as failed_instances max(last_time) as last_time by tenant region environment\n| eval failed_instances=coalesce(failed_instances,0), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| sort - run_instances_requests\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" (message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\" OR (\"ScaleError\" \"A retry will be attempted via SQS.\"))\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id)\n| eval run_instances_failure=if(message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\",1,0)\n| eval retry_logged=if(match(message,\"A retry will be attempted via SQS\"),1,0)\n| eval failed_instances=tonumber('error.failedInstanceCount')\n| stats max(run_instances_failure) as run_instances_failure max(retry_logged) as retry_logged values(failed_instances) as failed_instance_counts latest(_time) as last_time by tenant region environment request_id\n| where run_instances_failure=1\n| stats count as run_instances_requests sum(retry_logged) as retry_events sum(failed_instance_counts) as failed_instances max(last_time) as last_time by tenant region environment\n| eval failed_instances=coalesce(failed_instances,0), last_seen=strftime(last_time,\"%Y-%m-%d %H:%M:%S\")\n| sort - run_instances_requests\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -58,7 +58,7 @@
             "name": "RunInstances request drilldown",
             "options": {
                 "enableSmartSources": true,
-                "query": "index=\"${splunk_index}\" forgecicd_log_type=\"scale-up\" message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id), function_name=coalesce('function-name',function_name)\n| spath path=error.name output=error_name\n| spath path=error.Code output=error_code_outer\n| spath path=error.Error.Code output=error_code_inner\n| spath path=error.message output=error_message_outer\n| spath path=error.Error.Message output=error_message_inner\n| spath path=error.$metadata.requestId output=ec2_request_id\n| spath path=error.$metadata.httpStatusCode output=http_status\n| spath path=runner.n_events output=runner_events\n| spath path=runner.type output=runner_type\n| eval error_code=coalesce(error_name,errorName,error_code_outer,error_code_inner)\n| eval error_message=coalesce(error_message_outer,error_message_inner)\n| where isnotnull(error_code)\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| eval request_seen=strftime(_time,\"%Y-%m-%d %H:%M:%S\")\n| table request_seen tenant region environment request_id ec2_request_id http_status error_code error_message function_name service runner_type runner_events\n| sort - request_seen\n| head 200\n",
+                "query": "index=\"${splunk_index}\" sourcetype IN (\"aws:cloudwatchlogs\",\"aws:cloudwatchlogs:forgecicd\") source=\"*:/aws/lambda/*scale-up:*\"\n| search forgecicd_log_type=\"scale-up\" message=\"RunInstances failed with a scale error, ScaleError will be thrown to trigger retry.\"\n| eval tenant=coalesce(forgecicd_tenant,\"unknown\")\n| where \"$tenant$\"=\"*\" OR tenant=\"$tenant$\"\n| where \"$region$\"=\"*\" OR region=\"$region$\"\n| where \"$environment$\"=\"*\" OR like(environment,\"%$environment$%\")\n| eval request_id=coalesce('aws-request-id',aws_request_id), function_name=coalesce('function-name',function_name)\n| spath path=error.name output=error_name\n| spath path=error.Code output=error_code_outer\n| spath path=error.Error.Code output=error_code_inner\n| spath path=error.message output=error_message_outer\n| spath path=error.Error.Message output=error_message_inner\n| spath path=error.$metadata.requestId output=ec2_request_id\n| spath path=error.$metadata.httpStatusCode output=http_status\n| spath path=runner.n_events output=runner_events\n| spath path=runner.type output=runner_type\n| eval error_code=coalesce(error_name,errorName,error_code_outer,error_code_inner)\n| eval error_message=coalesce(error_message_outer,error_message_inner)\n| where isnotnull(error_code)\n| where \"$error_code$\"=\"*\" OR error_code=\"$error_code$\"\n| eval request_seen=strftime(_time,\"%Y-%m-%d %H:%M:%S\")\n| table request_seen tenant region environment request_id ec2_request_id http_status error_code error_message function_name service runner_type runner_events\n| sort - request_seen\n| head 200\n",
                 "queryParameters": {
                     "earliest": "$global_time.earliest$",
                     "latest": "$global_time.latest$"
@@ -191,55 +191,65 @@
                 },
                 "structure": [
                     {
-                        "item": "run_instances_error_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 760,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "run_instances_retry_pressure_table",
-                        "position": {
-                            "h": 360,
-                            "w": 440,
-                            "x": 760,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "run_instances_summary_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 390,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "run_instances_summary_table",
-                        "position": {
-                            "h": 390,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "recurrence_windows_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 560
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "recurrence_windows_table",
-                        "position": {
-                            "h": 360,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 750
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "run_instances_error_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 760,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 920
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "run_instances_drilldown_table",
-                        "position": {
-                            "h": 500,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1110
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "run_instances_retry_pressure_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 440,
+                                                                                                                                                    "x": 760,
+                                                                                                                                                    "y": 920
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "run_instances_drilldown_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 500,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1280
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -256,6 +266,14 @@
     },
     "title": "Forge EC2 RunInstances Scale-Up Failures",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with the tenant error summary and recurrence window, then inspect the exact RunInstances request and SQS retry pressure. **Healthy:** failure panels are empty; a single transient AWS error without job impact is not a Forge incident. **Action:** identify error code, region, instance or host requirement, and retry outcome before assigning cause. **Ownership:** shared request construction is Forge code; AMI, KMS, subnet, and dedicated-host configuration is tenant-owned; AWS capacity is external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "recurrence_windows_table": {
             "dataSources": {
                 "primary": "recurrence_windows_search"
@@ -265,7 +283,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Temporary vs Repeating RunInstances Failure Windows",
+            "description": "Answers \"Which RunInstances failures are sustained?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which RunInstances failures are sustained?",
             "type": "splunk.table"
         },
         "run_instances_drilldown_table": {
@@ -277,7 +296,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Recent RunInstances Request Drilldown",
+            "description": "Answers \"What failed in the latest RunInstances requests?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "What failed in the latest RunInstances requests?",
             "type": "splunk.table"
         },
         "run_instances_error_trend_chart": {
@@ -287,7 +307,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Failed RunInstances Requests by Error Code",
+            "description": "Answers \"Are RunInstances failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are RunInstances failures increasing?",
             "type": "splunk.line"
         },
         "run_instances_retry_pressure_table": {
@@ -299,7 +320,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "SQS Retry Pressure for RunInstances",
+            "description": "Answers \"Is RunInstances failure causing SQS retry pressure?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Is RunInstances failure causing SQS retry pressure?",
             "type": "splunk.table"
         },
         "run_instances_summary_table": {
@@ -311,7 +333,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "RunInstances Tenant Error Summary",
+            "description": "Answers \"Which tenants are affected by RunInstances failures?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which tenants are affected by RunInstances failures?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_runner_lifecycle.json.tftpl
@@ -149,75 +149,85 @@
                 },
                 "structure": [
                     {
-                        "item": "lifecycle_lambda_table",
-                        "position": {
-                            "h": 360,
-                            "w": 640,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "lifecycle_lambda_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 560,
-                            "x": 640,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "lifecycle_lambda_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 640,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "scale_capacity_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "scale_capacity_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ami_ssm_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "ami_ssm_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_log_symptoms_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 720
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "runner_log_symptoms_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 890
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "hook_activity_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 720
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "hook_activity_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 890
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_version_table",
-                        "position": {
-                            "h": 360,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 1100
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "lifecycle_lambda_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 560,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1270
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "runner_version_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1630
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -234,6 +244,14 @@
     },
     "title": "Forge EC2 Runner Lifecycle",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with AMI, SSM, capacity, and lifecycle Lambda failures; use hook activity, versions, and runner symptoms as supporting evidence. **Healthy:** failure panels are empty while lifecycle activity is expected. **Action:** identify tenant, runner pool, instance, request, and region, then follow provisioning through registration, bootstrap, and cleanup. **Ownership:** shared lifecycle defects are Forge code; AMI, KMS, SSM, network, and runner-pool settings are tenant configuration; Spot capacity is external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "ami_ssm_table": {
             "dataSources": {
                 "primary": "ami_ssm_search"
@@ -243,7 +261,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "AMI and SSM Update Failures",
+            "description": "Answers \"Which AMI or SSM updates failed?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which AMI or SSM updates failed?",
             "type": "splunk.table"
         },
         "hook_activity_table": {
@@ -255,7 +274,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Hook Activity",
+            "description": "Answers \"What happened during runner hooks?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "What happened during runner hooks?",
             "type": "splunk.table"
         },
         "lifecycle_lambda_table": {
@@ -267,7 +287,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EC2 Lifecycle Lambda Signals",
+            "description": "Answers \"Which EC2 lifecycle signals need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which EC2 lifecycle signals need attention?",
             "type": "splunk.table"
         },
         "lifecycle_lambda_trend_chart": {
@@ -277,7 +298,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EC2 Lifecycle Lambda Trend",
+            "description": "Answers \"Are EC2 lifecycle failures increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are EC2 lifecycle failures increasing?",
             "type": "splunk.line"
         },
         "runner_log_symptoms_table": {
@@ -289,7 +311,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Instance Log Symptoms",
+            "description": "Answers \"Which runner instances show failure symptoms?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runner instances show failure symptoms?",
             "type": "splunk.table"
         },
         "runner_version_table": {
@@ -301,7 +324,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Versions",
+            "description": "Answers \"Which runner versions are active?\" with investigation detail. Healthy is not determined by row count; expected activity may be non-empty, while an empty result can also reflect filters or retention. Action: use this panel only after an impact or failure panel identifies the tenant, repository, workflow job, request, runner, pod, node, or AWS resource to correlate.",
+            "title": "Which runner versions are active?",
             "type": "splunk.table"
         },
         "scale_capacity_table": {
@@ -313,7 +337,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Scale Capacity and AWS API Errors",
+            "description": "Answers \"Which capacity or AWS API errors blocked runners?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which capacity or AWS API errors blocked runners?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_runner_lifecycle.json.tftpl
@@ -149,75 +149,75 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "lifecycle_lambda_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 640,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "lifecycle_lambda_table",
+                        "position": {
+                            "h": 360,
+                            "w": 640,
+                            "x": 0,
+                            "y": 0
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "scale_capacity_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "scale_capacity_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 0,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "ami_ssm_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 360
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "ami_ssm_table",
+                        "position": {
+                            "h": 360,
+                            "w": 600,
+                            "x": 600,
+                            "y": 360
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "runner_log_symptoms_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 720
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "runner_log_symptoms_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 0,
+                            "y": 720
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "hook_activity_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 380,
-                                                                                                                                                    "w": 600,
-                                                                                                                                                    "x": 600,
-                                                                                                                                                    "y": 720
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "hook_activity_table",
+                        "position": {
+                            "h": 380,
+                            "w": 600,
+                            "x": 600,
+                            "y": 720
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "lifecycle_lambda_trend_chart",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 560,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1100
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
+                        "item": "lifecycle_lambda_trend_chart",
+                        "position": {
+                            "h": 360,
+                            "w": 560,
+                            "x": 0,
+                            "y": 1100
+                        },
+                        "type": "block"
+                    },
                     {
-                                                                                                                                                "item": "runner_version_table",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 360,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 1460
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            }
+                        "item": "runner_version_table",
+                        "position": {
+                            "h": 360,
+                            "w": 1200,
+                            "x": 0,
+                            "y": 1460
+                        },
+                        "type": "block"
+                    }
                 ],
                 "type": "grid"
             }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_runner_lifecycle.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ec2_runner_lifecycle.json.tftpl
@@ -149,22 +149,12 @@
                 },
                 "structure": [
                     {
-                                                                                                                                                "item": "operator_guide",
-                                                                                                                                                "position": {
-                                                                                                                                                    "h": 170,
-                                                                                                                                                    "w": 1200,
-                                                                                                                                                    "x": 0,
-                                                                                                                                                    "y": 0
-                                                                                                                                                },
-                                                                                                                                                "type": "block"
-                                                                                                                                            },
-                    {
                                                                                                                                                 "item": "lifecycle_lambda_table",
                                                                                                                                                 "position": {
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 640,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 170
+                                                                                                                                                    "y": 0
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -174,7 +164,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -184,7 +174,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 530
+                                                                                                                                                    "y": 360
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -194,7 +184,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 890
+                                                                                                                                                    "y": 720
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -204,7 +194,7 @@
                                                                                                                                                     "h": 380,
                                                                                                                                                     "w": 600,
                                                                                                                                                     "x": 600,
-                                                                                                                                                    "y": 890
+                                                                                                                                                    "y": 720
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -214,7 +204,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 560,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1270
+                                                                                                                                                    "y": 1100
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             },
@@ -224,7 +214,7 @@
                                                                                                                                                     "h": 360,
                                                                                                                                                     "w": 1200,
                                                                                                                                                     "x": 0,
-                                                                                                                                                    "y": 1630
+                                                                                                                                                    "y": 1460
                                                                                                                                                 },
                                                                                                                                                 "type": "block"
                                                                                                                                             }
@@ -244,14 +234,6 @@
     },
     "title": "Forge EC2 Runner Lifecycle",
     "visualizations": {
-        "operator_guide": {
-            "options": {
-                "fontSize": "default",
-                "markdown": "### How to use this dashboard\nStart with AMI, SSM, capacity, and lifecycle Lambda failures; use hook activity, versions, and runner symptoms as supporting evidence. **Healthy:** failure panels are empty while lifecycle activity is expected. **Action:** identify tenant, runner pool, instance, request, and region, then follow provisioning through registration, bootstrap, and cleanup. **Ownership:** shared lifecycle defects are Forge code; AMI, KMS, SSM, network, and runner-pool settings are tenant configuration; Spot capacity is external."
-            },
-            "title": "How should I use this dashboard?",
-            "type": "splunk.markdown"
-        },
         "ami_ssm_table": {
             "dataSources": {
                 "primary": "ami_ssm_search"

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_ec2_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_ec2_dashboards_operator_workflow_behavior.tftest.hcl
@@ -37,12 +37,11 @@ run "orders_ec2_failure_dashboards_for_operator_triage" {
         splunk_data_ui_views.forge_ec2_run_instances_scale_up_failures.eai_data,
         splunk_data_ui_views.forge_ec2_runner_lifecycle.eai_data,
       ] :
-      strcontains(body, "How should I use this dashboard?")
-      && strcontains(body, "Healthy:")
-      && strcontains(body, "Action:")
+      !strcontains(body, "\"operator_guide\"")
+      && !strcontains(body, "\"type\": \"splunk.markdown\"")
       && strcontains(body, "\"description\": \"Answers")
     ])
-    error_message = "Every EC2 dashboard must provide operator guidance and panel-level measurement, healthy-state, and next-action descriptions."
+    error_message = "EC2 dashboards must keep operational guidance in compact panel descriptions."
   }
 
   assert {
@@ -57,8 +56,8 @@ run "orders_ec2_failure_dashboards_for_operator_triage" {
 
   assert {
     condition = (
-      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"tenant_error_summary_table\"[\\s\\S]*\"item\": \"fleet_error_trend_chart\"[\\s\\S]*\"item\": \"request_drilldown_table\"", splunk_data_ui_views.forge_ec2_fleet_scale_up_failures.eai_data))
-      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"run_instances_summary_table\"[\\s\\S]*\"item\": \"run_instances_error_trend_chart\"[\\s\\S]*\"item\": \"run_instances_drilldown_table\"", splunk_data_ui_views.forge_ec2_run_instances_scale_up_failures.eai_data))
+      can(regex("\"item\": \"tenant_error_summary_table\"[\\s\\S]*\"item\": \"fleet_error_trend_chart\"[\\s\\S]*\"item\": \"request_drilldown_table\"", splunk_data_ui_views.forge_ec2_fleet_scale_up_failures.eai_data))
+      && can(regex("\"item\": \"run_instances_summary_table\"[\\s\\S]*\"item\": \"run_instances_error_trend_chart\"[\\s\\S]*\"item\": \"run_instances_drilldown_table\"", splunk_data_ui_views.forge_ec2_run_instances_scale_up_failures.eai_data))
     )
     error_message = "EC2 failure dashboards must place scope and actionable failures before trends and request drilldowns."
   }

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_ec2_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_ec2_dashboards_operator_workflow_behavior.tftest.hcl
@@ -1,0 +1,65 @@
+mock_provider "aws" {
+  mock_data "aws_secretsmanager_secret" {
+    defaults = { id = "/cicd/common/splunk-cloud" }
+  }
+  mock_data "aws_secretsmanager_secret_version" {
+    defaults = { secret_string = "mock" }
+  }
+}
+
+mock_provider "splunk" {
+  mock_resource "splunk_data_ui_views" {}
+  mock_resource "splunk_configs_conf" {}
+  mock_resource "splunk_transforms_regex" {}
+}
+
+variables {
+  aws_profile  = "test"
+  aws_region   = "us-east-1"
+  default_tags = { Product = "Forge" }
+  splunk_conf = {
+    splunk_cloud = "https://example.splunkcloud.com"
+    index        = "srea-forge-prod-index"
+    tenant_names = ["tenant-a"]
+    acl = {
+      app = "search", owner = "nobody", sharing = "app", read = ["*"], write = ["admin"]
+    }
+  }
+}
+
+run "orders_ec2_failure_dashboards_for_operator_triage" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for body in [
+        splunk_data_ui_views.forge_ec2_fleet_scale_up_failures.eai_data,
+        splunk_data_ui_views.forge_ec2_run_instances_scale_up_failures.eai_data,
+        splunk_data_ui_views.forge_ec2_runner_lifecycle.eai_data,
+      ] :
+      strcontains(body, "How should I use this dashboard?")
+      && strcontains(body, "Healthy:")
+      && strcontains(body, "Action:")
+      && strcontains(body, "\"description\": \"Answers")
+    ])
+    error_message = "Every EC2 dashboard must provide operator guidance and panel-level measurement, healthy-state, and next-action descriptions."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.forge_ec2_fleet_scale_up_failures.eai_data, "source=\\\"*:/aws/lambda/*scale-up:*\\\"")
+      && strcontains(splunk_data_ui_views.forge_ec2_run_instances_scale_up_failures.eai_data, "source=\\\"*:/aws/lambda/*scale-up:*\\\"")
+      && strcontains(splunk_data_ui_views.forge_ec2_fleet_scale_up_failures.eai_data, "| search forgecicd_log_type=\\\"scale-up\\\"")
+      && strcontains(splunk_data_ui_views.forge_ec2_run_instances_scale_up_failures.eai_data, "| search forgecicd_log_type=\\\"scale-up\\\"")
+    )
+    error_message = "Scale-up failure searches must apply indexed sourcetype and Lambda-source constraints before search-time fields."
+  }
+
+  assert {
+    condition = (
+      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"tenant_error_summary_table\"[\\s\\S]*\"item\": \"fleet_error_trend_chart\"[\\s\\S]*\"item\": \"request_drilldown_table\"", splunk_data_ui_views.forge_ec2_fleet_scale_up_failures.eai_data))
+      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"run_instances_summary_table\"[\\s\\S]*\"item\": \"run_instances_error_trend_chart\"[\\s\\S]*\"item\": \"run_instances_drilldown_table\"", splunk_data_ui_views.forge_ec2_run_instances_scale_up_failures.eai_data))
+    )
+    error_message = "EC2 failure dashboards must place scope and actionable failures before trends and request drilldowns."
+  }
+}


### PR DESCRIPTION
## Description

Refactors CreateFleet, RunInstances, and EC2 runner lifecycle dashboards while keeping the presentation compact.

- Removes the full-width operator-guide visualizations and their 170-pixel rows.
- Keeps healthy-state, failure, ownership, and next-action guidance in panel descriptions.
- Orders capacity, permission, retry, provisioning, registration, bootstrap, and cleanup evidence for triage.
- Constrains scale-up failure searches by indexed CloudWatch sourcetype and scale-up Lambda source before semantic fields.
- Preserves tenant, region, environment, error-code, and global-time filters.

This PR remains separate from the presentation-only dashboard consolidation because it changes SPL filtering.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: ____________

## Testing

- `tofu test` in `modules/integrations/splunk_cloud_conf_shared`: 6 passed
- Changed-file pre-commit suite: passed
- `git diff --check`: passed
