### PR TITLE
refactor(observability): simplify ingestion dashboards

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ingestion_quality.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_ingestion_quality.json.tftpl
@@ -116,55 +116,65 @@
                 },
                 "structure": [
                     {
-                        "item": "sourcetype_inventory_table",
-                        "position": {
-                            "h": 360,
-                            "w": 460,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "volume_anomaly_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 740,
-                            "x": 460,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "missing_fields_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "source_inventory_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "volume_anomaly_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 740,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 550
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ingestion_quality_table",
-                        "position": {
-                            "h": 420,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "ingestion_quality_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "missing_fields_table",
-                        "position": {
-                            "h": 380,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 780
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "sourcetype_inventory_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 460,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "source_inventory_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1330
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -181,6 +191,14 @@
     },
     "title": "Forge Ingestion Quality",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with missing structured fields and runner-log ingestion quality, then use source and sourcetype inventory to locate the affected pipeline. **Healthy:** missing-field panels are empty and expected sources continue arriving; high volume alone is not failure. **Action:** identify the source, sourcetype, tenant, and last event before checking Firehose, Kinesis, S3, Lambda, or Splunk delivery. **Ownership:** shared ingestion configuration belongs to Forge; malformed tenant-emitted events belong to the producer; Splunk or AWS delivery outages may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "ingestion_quality_table": {
             "dataSources": {
                 "primary": "ingestion_quality_search"
@@ -190,7 +208,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Runner Log Ingestion Quality",
+            "description": "Answers \"Are runner logs arriving with required fields?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are runner logs arriving with required fields?",
             "type": "splunk.table"
         },
         "missing_fields_table": {
@@ -202,7 +221,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Missing Structured Fields",
+            "description": "Answers \"Which events are missing structured fields?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which events are missing structured fields?",
             "type": "splunk.table"
         },
         "source_inventory_table": {
@@ -214,7 +234,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Top Sources",
+            "description": "Answers \"Which sources produce the most events?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which sources produce the most events?",
             "type": "splunk.table"
         },
         "sourcetype_inventory_table": {
@@ -226,7 +247,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Sourcetype Inventory",
+            "description": "Answers \"Which sourcetypes are arriving?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which sourcetypes are arriving?",
             "type": "splunk.table"
         },
         "volume_anomaly_chart": {
@@ -236,7 +258,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "High-Volume Sourcetype Trend",
+            "description": "Answers \"Is ingestion volume changing unexpectedly?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Is ingestion volume changing unexpectedly?",
             "type": "splunk.line"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_lambda_operations.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_lambda_operations.json.tftpl
@@ -125,55 +125,65 @@
                 },
                 "structure": [
                     {
-                        "item": "lambda_errors_table",
-                        "position": {
-                            "h": 360,
-                            "w": 700,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "lambda_error_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 500,
-                            "x": 700,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "lambda_errors_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 700,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "runner_tag_failures_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "runner_tag_failures_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "ingestion_retries_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "ingestion_retries_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 530
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "lambda_samples_table",
-                        "position": {
-                            "h": 420,
-                            "w": 1200,
-                            "x": 0,
-                            "y": 720
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "lambda_error_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 500,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 890
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "lambda_samples_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 420,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1250
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -190,6 +200,14 @@
     },
     "title": "Forge Lambda Operations",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with errors by Lambda and category, then inspect a unique request sample and retry outcome. **Healthy:** error and retry panels are empty or remain at the established healthy baseline; one duplicated stack trace is one invocation, not multiple failures. **Action:** identify Lambda, tenant, region, request ID, operation, and downstream dependency before assigning cause. **Ownership:** deterministic shared-code failures belong to Forge; tenant resource permissions belong to tenant configuration; AWS, GitHub, or Splunk failures may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "ingestion_retries_table": {
             "dataSources": {
                 "primary": "ingestion_retries_search"
@@ -199,7 +217,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Splunk S3 Runner Log Ingestion Retries",
+            "description": "Answers \"Which runner-log ingestion retries need attention?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runner-log ingestion retries need attention?",
             "type": "splunk.table"
         },
         "lambda_error_trend_chart": {
@@ -209,7 +228,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Lambda Error Trend",
+            "description": "Answers \"Are Lambda errors increasing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are Lambda errors increasing?",
             "type": "splunk.line"
         },
         "lambda_errors_table": {
@@ -221,7 +241,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Lambda Errors by Category",
+            "description": "Answers \"Which Lambda error categories are affecting production?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which Lambda error categories are affecting production?",
             "type": "splunk.table"
         },
         "lambda_samples_table": {
@@ -233,7 +254,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Latest Lambda Error Samples",
+            "description": "Answers \"What failed in the latest unique Lambda invocations?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "What failed in the latest unique Lambda invocations?",
             "type": "splunk.table"
         },
         "runner_tag_failures_table": {
@@ -245,7 +267,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "EC2 Runner Tagging Failures",
+            "description": "Answers \"Which runner-tagging operations failed?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which runner-tagging operations failed?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/template_files/forge_webhook_job_log_pipeline.json.tftpl
+++ b/modules/integrations/splunk_cloud_conf_shared/template_files/forge_webhook_job_log_pipeline.json.tftpl
@@ -137,65 +137,75 @@
                 },
                 "structure": [
                     {
-                        "item": "pipeline_stage_table",
-                        "position": {
-                            "h": 360,
-                            "w": 640,
-                            "x": 0,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "operator_guide",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 170,
+                                                                                                                                                    "w": 1200,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 0
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "pipeline_trend_chart",
-                        "position": {
-                            "h": 360,
-                            "w": 560,
-                            "x": 640,
-                            "y": 0
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "archiver_errors_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 170
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dispatcher_repos_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 0,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "pipeline_stage_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 640,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 550
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "archiver_errors_table",
-                        "position": {
-                            "h": 380,
-                            "w": 600,
-                            "x": 600,
-                            "y": 360
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dispatcher_repos_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 380,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "redrive_activity_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 0,
-                            "y": 740
-                        },
-                        "type": "block"
-                    },
+                                                                                                                                                "item": "dispatcher_to_json_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 600,
+                                                                                                                                                    "y": 910
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
                     {
-                        "item": "dispatcher_to_json_table",
-                        "position": {
-                            "h": 360,
-                            "w": 600,
-                            "x": 600,
-                            "y": 740
-                        },
-                        "type": "block"
-                    }
+                                                                                                                                                "item": "pipeline_trend_chart",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 560,
+                                                                                                                                                    "x": 0,
+                                                                                                                                                    "y": 1290
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            },
+                    {
+                                                                                                                                                "item": "redrive_activity_table",
+                                                                                                                                                "position": {
+                                                                                                                                                    "h": 360,
+                                                                                                                                                    "w": 600,
+                                                                                                                                                    "x": 560,
+                                                                                                                                                    "y": 1290
+                                                                                                                                                },
+                                                                                                                                                "type": "block"
+                                                                                                                                            }
                 ],
                 "type": "grid"
             }
@@ -212,6 +222,14 @@
     },
     "title": "Forge Webhook Job Log Pipeline",
     "visualizations": {
+        "operator_guide": {
+            "options": {
+                "fontSize": "default",
+                "markdown": "### How to use this dashboard\nStart with pipeline-stage completeness, archiver failures, and DLQ redrive activity, then compare dispatcher and archived-object counts for the same repository and time window. **Healthy:** accepted jobs progress to archived JSON and ingestion without sustained DLQ or archiver errors; unequal broad totals alone are not proof of loss. **Action:** identify tenant, repository, workflow job, delivery, SQS message, S3 object, and retry outcome. **Ownership:** shared pipeline defects belong to Forge; tenant webhook configuration belongs to the tenant; GitHub, AWS, or Splunk delivery outages may be external."
+            },
+            "title": "How should I use this dashboard?",
+            "type": "splunk.markdown"
+        },
         "archiver_errors_table": {
             "dataSources": {
                 "primary": "archiver_errors_search"
@@ -221,7 +239,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Archiver Errors",
+            "description": "Answers \"Which job-log archive operations failed?\" using records that matched an explicit failure or actionable condition. Healthy: no rows, unless the panel documents an expected baseline. Failure: one or more rows persist or affect workflow jobs. Action: start with tenant, repository, region, job or run ID, and the named AWS or Kubernetes resource, then inspect the adjacent workflow stage.",
+            "title": "Which job-log archive operations failed?",
             "type": "splunk.table"
         },
         "dispatcher_repos_table": {
@@ -233,7 +252,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Dispatcher Enqueues by Repo",
+            "description": "Answers \"Which repositories enqueue job-log work?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Which repositories enqueue job-log work?",
             "type": "splunk.table"
         },
         "dispatcher_to_json_table": {
@@ -245,7 +265,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Dispatcher to Archived JSON Counts",
+            "description": "Answers \"Do dispatcher and archived-object counts remain consistent?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Do dispatcher and archived-object counts remain consistent?",
             "type": "splunk.table"
         },
         "pipeline_stage_table": {
@@ -257,7 +278,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Pipeline Stage Summary",
+            "description": "Answers \"Where is the job-log pipeline losing progress?\" for the selected filters and time range. Healthy depends on the workflow stage and is not inferred from a high count alone. Action: identify the affected tenant and resource, then use the next causal-stage panel or raw details to verify impact.",
+            "title": "Where is the job-log pipeline losing progress?",
             "type": "splunk.table"
         },
         "pipeline_trend_chart": {
@@ -267,7 +289,8 @@
             "options": {},
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "Pipeline Trend",
+            "description": "Answers \"Is job-log pipeline health changing?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Is job-log pipeline health changing?",
             "type": "splunk.line"
         },
         "redrive_activity_table": {
@@ -279,7 +302,8 @@
             },
             "showLastUpdated": true,
             "showProgressBar": false,
-            "title": "DLQ Redrive Activity",
+            "description": "Answers \"Are DLQ messages being recovered?\" with a time series over the selected global range. Healthy: error, retry, delay, or backlog series remain at the established baseline; activity volume alone is not a failure. Failure: a sustained adverse series aligns with affected jobs or resources. Action: use the actionable table above for tenant and resource identifiers before opening raw events.",
+            "title": "Are DLQ messages being recovered?",
             "type": "splunk.table"
         }
     }

--- a/modules/integrations/splunk_cloud_conf_shared/tests/forge_ingestion_dashboards_operator_workflow_behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/forge_ingestion_dashboards_operator_workflow_behavior.tftest.hcl
@@ -1,0 +1,65 @@
+mock_provider "aws" {
+  mock_data "aws_secretsmanager_secret" {
+    defaults = { id = "/cicd/common/splunk-cloud" }
+  }
+  mock_data "aws_secretsmanager_secret_version" {
+    defaults = { secret_string = "mock" }
+  }
+}
+
+mock_provider "splunk" {
+  mock_resource "splunk_data_ui_views" {}
+  mock_resource "splunk_configs_conf" {}
+  mock_resource "splunk_transforms_regex" {}
+}
+
+variables {
+  aws_profile  = "test"
+  aws_region   = "us-east-1"
+  default_tags = { Product = "Forge" }
+  splunk_conf = {
+    splunk_cloud = "https://example.splunkcloud.com"
+    index        = "srea-forge-prod-index"
+    tenant_names = ["tenant-a"]
+    acl = {
+      app = "search", owner = "nobody", sharing = "app", read = ["*"], write = ["admin"]
+    }
+  }
+}
+
+run "orders_ingestion_dashboards_for_operator_triage" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for body in [
+        splunk_data_ui_views.forge_ingestion_quality.eai_data,
+        splunk_data_ui_views.forge_lambda_operations.eai_data,
+        splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data,
+      ] :
+      strcontains(body, "How should I use this dashboard?")
+      && strcontains(body, "Healthy:")
+      && strcontains(body, "Action:")
+      && strcontains(body, "\"description\": \"Answers")
+      && strcontains(body, "$global_time.earliest$")
+      && strcontains(body, "$global_time.latest$")
+    ])
+    error_message = "Ingestion dashboards must explain healthy/action semantics per panel and retain the global-time token."
+  }
+
+  assert {
+    condition = (
+      can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"missing_fields_table\"[\\s\\S]*\"item\": \"volume_anomaly_chart\"[\\s\\S]*\"item\": \"source_inventory_table\"", splunk_data_ui_views.forge_ingestion_quality.eai_data))
+      && can(regex("\"item\": \"operator_guide\"[\\s\\S]*\"item\": \"lambda_errors_table\"[\\s\\S]*\"item\": \"lambda_error_trend_chart\"[\\s\\S]*\"item\": \"lambda_samples_table\"", splunk_data_ui_views.forge_lambda_operations.eai_data))
+    )
+    error_message = "Actionable ingestion and Lambda failures must appear before trends, source inventory, and raw samples."
+  }
+
+  assert {
+    condition = (
+      strcontains(splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data, "unequal broad totals alone are not proof of loss")
+      && strcontains(splunk_data_ui_views.forge_webhook_job_log_pipeline.eai_data, "Which job-log archive operations failed?")
+    )
+    error_message = "The job-log pipeline dashboard must distinguish confirmed failures from non-causal count differences."
+  }
+}


### PR DESCRIPTION
## Description

Refactors the ingestion quality, Lambda operations, and webhook job-log pipeline dashboards for loss, retry, and processing-stage triage.

- Moves explicit malformed-event, delivery, retry, Lambda, tagging, archiver, and DLQ failures before trends and inventory.
- Adds question-oriented titles and descriptions defining healthy results, failure results, and operator actions.
- States that broad dispatcher/archive count differences do not by themselves prove data loss.
- Preserves indexed searches, identifiers, tokens, and existing global-time behavior.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: ______

## Testing

- `tofu test` in `modules/integrations/splunk_cloud_conf_shared` (6 passed)
- Repository quality gates (26 passed)
- Changed-file pre-commit hooks
- `git diff --check`
