### PR TITLE
feat(runners): tag resources with module version

### DIFF
--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -2,6 +2,12 @@ locals {
   # Templatized userdata (cloud-init) file.
   user_data_prefix               = "${path.module}/template_files"
   userdata_template_post_install = "${local.user_data_prefix}/post_install.tftpl"
+  terraform_aws_github_runner_tags = merge(
+    var.tenant_configs.tags,
+    {
+      terraform-aws-github-runner-ref = "v7.10.0"
+    }
+  )
   webhook_api_gateway_access_log_format = jsonencode({
     apiId                   = "$context.apiId"
     domainName              = "$context.domainName"
@@ -141,9 +147,9 @@ module "runners" {
     enable = true
   }
 
-  lambda_tags          = var.tenant_configs.tags
-  tags                 = var.tenant_configs.tags
-  parameter_store_tags = var.tenant_configs.tags
+  lambda_tags          = local.terraform_aws_github_runner_tags
+  tags                 = local.terraform_aws_github_runner_tags
+  parameter_store_tags = local.terraform_aws_github_runner_tags
 
   # Verbose logging.
   log_level = var.runner_configs.log_level

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,8 @@
                 "^.*\\.tf$"
             ],
             "matchStrings": [
-                "download_lambdas\\.sh\"\\s*,\\s*\"[^\"]+\"\\s*,\\s*\"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
+                "download_lambdas\\.sh\"\\s*,\\s*\"[^\"]+\"\\s*,\\s*\"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\"",
+                "terraform-aws-github-runner-ref\\s*=\\s*\"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\""
             ],
             "depNameTemplate": "github-aws-runners/terraform-aws-github-runner",
             "datasourceTemplate": "github-tags",


### PR DESCRIPTION
## Description

Adds the `terraform-aws-github-runner-ref` tag to the runner module's Lambda, general, and Parameter Store tags, initialized to `v7.10.0`.

Extends the existing Renovate regex manager so the tag value is updated together with the downloaded Lambda artifacts and Terraform module source.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: _________

## Testing

- `terraform fmt -check modules/platform/ec2_deployment/main.tf`
- `jq empty renovate.json`
- `renovate-config-validator renovate.json`
- Verified both custom Renovate regex matches resolve to `v7.10.0`
- Pre-commit hooks passed except `tofu-validate`, which could not download existing pinned external module refs in the local hook environment
