### PR TITLE
feat(logs): trace runner log message processing

### DIFF
--- a/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs/splunk_s3_runner_logs.py
+++ b/modules/integrations/splunk_cloud_s3_runner_logs/lambda/splunk_s3_runner_logs/splunk_s3_runner_logs.py
@@ -51,6 +51,15 @@ def lambda_handler(event, _context):
 
     total_lines = 0
     for r in records:
+        message_id = r.get('messageId') or 'unknown'
+        receive_count = r.get(
+            'attributes', {}
+        ).get('ApproximateReceiveCount') or 'unknown'
+        LOG.info(
+            'sqs_message_received message_id=%s receive_count=%s',
+            message_id,
+            receive_count,
+        )
         body = r.get('body')
         if not body:
             continue
@@ -62,7 +71,11 @@ def lambda_handler(event, _context):
 
         checkpoint = body_json.get(CHECKPOINT_FIELD)
         if checkpoint is not None:
-            total_lines += process_log_checkpoint(checkpoint)
+            total_lines += process_log_checkpoint(
+                checkpoint,
+                sqs_message_id=message_id,
+                sqs_receive_count=receive_count,
+            )
             continue
 
         for s3_rec in body_json.get('Records', []):
@@ -77,6 +90,8 @@ def lambda_handler(event, _context):
                 bucket,
                 key,
                 object_size=object_size,
+                sqs_message_id=message_id,
+                sqs_receive_count=receive_count,
             )
 
     return {'statusCode': 200, 'body': json.dumps({'lines': total_lines})}
@@ -89,10 +104,15 @@ def process_s3_object(
     object_size: int | None = None,
     start_offset: int = 0,
     last_timestamp: float | None = None,
+    sqs_message_id: str = 'unknown',
+    sqs_receive_count: str = 'unknown',
 ) -> int:
     """Process a JSON object or one bounded, line-aligned log chunk."""
     LOG.info(
-        'processing_object bucket=%s key=%s offset=%d',
+        'processing_object message_id=%s receive_count=%s '
+        'bucket=%s key=%s offset=%d',
+        sqs_message_id,
+        sqs_receive_count,
         bucket,
         key,
         start_offset,
@@ -162,8 +182,10 @@ def process_s3_object(
     )
     last_timestamp = timestamp_after_lines(lines, last_timestamp)
     LOG.info(
-        'object_chunk_complete bucket=%s key=%s offset=%d next_offset=%d '
-        'size=%d lines=%d',
+        'object_chunk_complete message_id=%s receive_count=%s '
+        'bucket=%s key=%s offset=%d next_offset=%d size=%d lines=%d',
+        sqs_message_id,
+        sqs_receive_count,
         bucket,
         key,
         start_offset,
@@ -179,6 +201,7 @@ def process_s3_object(
             next_offset,
             object_size,
             last_timestamp,
+            parent_message_id=sqs_message_id,
         )
     else:
         LOG.info('object_complete bucket=%s key=%s lines=%d',
@@ -186,7 +209,12 @@ def process_s3_object(
     return shipped
 
 
-def process_log_checkpoint(checkpoint: Any) -> int:
+def process_log_checkpoint(
+    checkpoint: Any,
+    *,
+    sqs_message_id: str = 'unknown',
+    sqs_receive_count: str = 'unknown',
+) -> int:
     """Validate and process a continuation message from the runner-log queue."""
     if not isinstance(checkpoint, dict):
         raise ValueError('Runner-log checkpoint must be an object')
@@ -224,6 +252,8 @@ def process_log_checkpoint(checkpoint: Any) -> int:
         object_size=object_size,
         start_offset=offset,
         last_timestamp=last_timestamp,
+        sqs_message_id=sqs_message_id,
+        sqs_receive_count=sqs_receive_count,
     )
 
 
@@ -233,6 +263,8 @@ def enqueue_log_checkpoint(
     offset: int,
     object_size: int,
     last_timestamp: float | None,
+    *,
+    parent_message_id: str = 'unknown',
 ) -> None:
     """Enqueue the next byte offset after the current chunk is fully shipped."""
     if not SQS_QUEUE_URL:
@@ -247,12 +279,16 @@ def enqueue_log_checkpoint(
             'last_timestamp': last_timestamp,
         },
     }
-    sqs_client.send_message(
+    response = sqs_client.send_message(
         QueueUrl=SQS_QUEUE_URL,
         MessageBody=json.dumps(body, separators=(',', ':')),
     )
+    checkpoint_message_id = response.get('MessageId') or 'unknown'
     LOG.info(
-        'object_checkpoint_enqueued bucket=%s key=%s offset=%d size=%d',
+        'object_checkpoint_enqueued parent_message_id=%s message_id=%s '
+        'bucket=%s key=%s offset=%d size=%d',
+        parent_message_id,
+        checkpoint_message_id,
         bucket,
         key,
         offset,

--- a/tests/lambdas/splunk_s3_runner_logs_test.py
+++ b/tests/lambdas/splunk_s3_runner_logs_test.py
@@ -395,7 +395,7 @@ def test_read_s3_object_line_chunk_preserves_line_boundaries(
 
 
 def test_lambda_handler_checkpoints_large_log_after_successful_chunk(
-    monkeypatch, s3_kms
+    monkeypatch, s3_kms, caplog
 ):
     mod = _load_splunk(monkeypatch)
     bucket = s3_kms['buckets']['alpha']
@@ -432,6 +432,8 @@ def test_lambda_handler_checkpoints_large_log_after_successful_chunk(
 
     initial_event = {
         'Records': [{
+            'messageId': 'source-message-1',
+            'attributes': {'ApproximateReceiveCount': '1'},
             'body': json.dumps({
                 'Records': [{
                     's3': {
@@ -446,6 +448,19 @@ def test_lambda_handler_checkpoints_large_log_after_successful_chunk(
     initial_result = mod.lambda_handler(initial_event, None)
 
     assert json.loads(initial_result['body']) == {'lines': 1}
+    assert (
+        'sqs_message_received message_id=source-message-1 receive_count=1'
+        in caplog.text
+    )
+    assert (
+        'processing_object message_id=source-message-1 receive_count=1'
+        in caplog.text
+    )
+    assert (
+        'object_checkpoint_enqueued parent_message_id=source-message-1 '
+        'message_id=checkpoint-1'
+        in caplog.text
+    )
     assert kinesis_events == ['2026-07-03T22:26:04.000Z one']
     assert len(checkpoint_messages) == 1
     checkpoint = checkpoint_messages.pop()
@@ -462,7 +477,13 @@ def test_lambda_handler_checkpoints_large_log_after_successful_chunk(
     continuation_lines = 0
     while True:
         continuation_result = mod.lambda_handler(
-            {'Records': [{'body': json.dumps(checkpoint)}]},
+            {
+                'Records': [{
+                    'messageId': 'checkpoint-1',
+                    'attributes': {'ApproximateReceiveCount': '1'},
+                    'body': json.dumps(checkpoint),
+                }],
+            },
             None,
         )
         continuation_lines += json.loads(continuation_result['body'])['lines']
@@ -478,6 +499,57 @@ def test_lambda_handler_checkpoints_large_log_after_successful_chunk(
     ]
     assert kinesis_timestamps == [1783117564.0] * 3
     assert checkpoint_messages == []
+    assert (
+        'sqs_message_received message_id=checkpoint-1 receive_count=1'
+        in caplog.text
+    )
+    assert (
+        'processing_object message_id=checkpoint-1 receive_count=1'
+        in caplog.text
+    )
+
+
+def test_lambda_handler_logs_sqs_retry_identity(monkeypatch, aws, caplog):
+    mod = _load_splunk(monkeypatch)
+    checkpoint_calls = []
+    checkpoint = {
+        'version': 1,
+        'bucket': 'forge-gh-logs',
+        'key': 'acme/app/99/1/retry.log',
+        'offset': 1024,
+        'object_size': 2048,
+        'last_timestamp': None,
+    }
+
+    def _process_checkpoint(*args, **kwargs):
+        checkpoint_calls.append((args, kwargs))
+        return 0
+
+    monkeypatch.setattr(mod, 'process_log_checkpoint', _process_checkpoint)
+
+    result = mod.lambda_handler(
+        {
+            'Records': [{
+                'messageId': 'retried-message-1',
+                'attributes': {'ApproximateReceiveCount': '3'},
+                'body': json.dumps({mod.CHECKPOINT_FIELD: checkpoint}),
+            }],
+        },
+        None,
+    )
+
+    assert json.loads(result['body']) == {'lines': 0}
+    assert (
+        'sqs_message_received message_id=retried-message-1 receive_count=3'
+        in caplog.text
+    )
+    assert checkpoint_calls == [(
+        (checkpoint,),
+        {
+            'sqs_message_id': 'retried-message-1',
+            'sqs_receive_count': '3',
+        },
+    )]
 
 
 def test_process_s3_object_does_not_checkpoint_failed_chunk(


### PR DESCRIPTION
## Description

Add INFO-level correlation fields to runner-log SQS processing so operators can distinguish retries from large-log checkpoint continuations.

- Log the SQS message ID and `ApproximateReceiveCount` when a message is received.
- Carry that identity into object processing and chunk-completion events.
- Link each completed chunk's parent message ID to the newly enqueued checkpoint message ID and byte offset.
- Preserve safe fallbacks for events that omit SQS identity attributes.

A retry now appears as the same message ID with a higher receive count. A split large log appears as a parent message ID producing a new checkpoint message ID, followed by processing at the next byte offset.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: _________

## Testing

- `uv run --locked --only-group lambda-tests pytest -q tests/lambdas/splunk_s3_runner_logs_test.py` — 17 passed.
- Repository pre-commit hooks passed, including Python linting, security checks, and Terraform/OpenTofu validation.
