### PR TITLE
fix(forge-runners): harden archiver SSM retries

### DIFF
--- a/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
+++ b/modules/platform/forge_runners/github_actions_job_logs/lambda/job_log_archiver/job_log_archiver.py
@@ -22,7 +22,7 @@ LOG.setLevel(getattr(logging, level_str, logging.INFO))
 SSM_CLIENT_CONFIG = Config(
     connect_timeout=5,
     read_timeout=10,
-    retries={'mode': 'standard', 'total_max_attempts': 4},
+    retries={'mode': 'adaptive', 'total_max_attempts': 8},
 )
 
 SSM = boto3.client('ssm', config=SSM_CLIENT_CONFIG)

--- a/tests/lambdas/job_log_archiver_test.py
+++ b/tests/lambdas/job_log_archiver_test.py
@@ -80,6 +80,17 @@ def _log_response(body=b'log-bytes', status_code=200):
     )
 
 
+def test_ssm_client_uses_adaptive_retries(aws):
+    mod = load_handler_module('job_log_archiver')
+
+    assert mod.SSM_CLIENT_CONFIG.connect_timeout == 5
+    assert mod.SSM_CLIENT_CONFIG.read_timeout == 10
+    assert mod.SSM_CLIENT_CONFIG.retries == {
+        'mode': 'adaptive',
+        'total_max_attempts': 8,
+    }
+
+
 def test_logs_written_only_to_configured_tenant_bucket(
     monkeypatch, s3_kms, ssm
 ):


### PR DESCRIPTION
## Description

Configure the job-log archiver SSM client to use adaptive retry mode with eight total attempts instead of standard mode with four attempts.

This gives transient SSM throttling more time to recover within the invocation before the SQS event-source retry is required. It preserves the existing connection and read timeouts and adds a regression test for the complete retry configuration.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `uv run --locked --only-group lambda-tests pytest -q tests/lambdas/job_log_archiver_test.py` (22 passed)
- `uv run --locked --only-group lambda-tests pytest -q tests/mutation/job_log_archiver_mutation_test.py tests/quality/automation_gates_test.py` (12 passed)
- Repository pre-commit checks passed
