### PR TITLE
chore(deps): remove explicit botocore dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ lambda-tests = [
     "pytest-cov==7.1.0",
     "moto[all]==5.2.2",
     "boto3==1.43.47",
-    "botocore==1.43.52",
     # Runtime libs provided by Klayers in production. Installing them here lets
     # tests import handlers the same way the Lambda runtime does.
     "PyJWT==2.13.0",
@@ -47,5 +46,4 @@ lambda-tests = [
 smoke-tests = [
     "pytest==9.1.1",
     "boto3==1.43.47",
-    "botocore==1.43.52",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -570,7 +570,6 @@ forge-github-app-register = [
 ]
 lambda-tests = [
     { name = "boto3" },
-    { name = "botocore" },
     { name = "cryptography" },
     { name = "hypothesis" },
     { name = "moto", extra = ["all"] },
@@ -588,7 +587,6 @@ pre-commit-image = [
 ]
 smoke-tests = [
     { name = "boto3" },
-    { name = "botocore" },
     { name = "pytest" },
 ]
 
@@ -603,7 +601,6 @@ forge-github-app-register = [
 ]
 lambda-tests = [
     { name = "boto3", specifier = "==1.43.47" },
-    { name = "botocore", specifier = "==1.43.52" },
     { name = "cryptography", specifier = "==49.0.0" },
     { name = "hypothesis", specifier = "==6.163.0" },
     { name = "moto", extras = ["all"], specifier = "==5.2.2" },
@@ -621,7 +618,6 @@ pre-commit-image = [
 ]
 smoke-tests = [
     { name = "boto3", specifier = "==1.43.47" },
-    { name = "botocore", specifier = "==1.43.52" },
     { name = "pytest", specifier = "==9.1.1" },
 ]
 


### PR DESCRIPTION
## Description

Remove the explicit `botocore` pins from the `lambda-tests` and `smoke-tests`
dependency groups. Both groups already depend on `boto3`, which installs a
compatible `botocore` transitively; AWS Lambda provides both libraries at
runtime.

The lockfile still resolves `boto3==1.43.47` to `botocore==1.43.52`.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: Dependency cleanup

## Testing

- `uv lock --check --offline`
- `uv tree --offline --package boto3 --group lambda-tests --depth 2`
- `uv tree --offline --package boto3 --group smoke-tests --depth 2`
- Repository pre-commit hooks
