### PR TITLE
feat(arc): export high-cardinality metrics

### DIFF
--- a/modules/platform/arc/README.md
+++ b/modules/platform/arc/README.md
@@ -19,6 +19,8 @@ In Forge, the Kubernetes lane turns GitHub Actions jobs into ephemeral pods. Thi
 - `migrate_arc_cluster` is the blue/green cutover switch; it should be true only during an intentional tenant migration.
 - The DinD path depends on tenant-specific node pools for blast-radius isolation.
 - Provider configuration resolves from the EKS cluster name, so changing the target cluster name repoints the in-cluster resources.
+- The controller and scale-set listeners expose `/metrics` on port `8080` with Prometheus discovery annotations.
+- Listener metrics retain repository, job, event, result, and workflow dimensions. The managed Prometheus chart and Splunk OTel Prometheus autodiscovery can scrape the same endpoints independently; do not add Prometheus remote write to the collector unless direct collector scraping is disabled.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/modules/platform/arc/scale_set/helm.tf
+++ b/modules/platform/arc/scale_set/helm.tf
@@ -70,6 +70,7 @@ resource "helm_release" "gha_runner_scale_set" {
         runner_role                  = aws_iam_role.runner_role.arn
         tenant                       = var.controller.namespace
         debug                        = lower(var.log_level) == "debug"
+        metrics_values               = file("${path.module}/template_files/metrics.yml.tftpl")
       }
     )
   ]

--- a/modules/platform/arc/scale_set/template_files/dind.yml.tftpl
+++ b/modules/platform/arc/scale_set/template_files/dind.yml.tftpl
@@ -8,6 +8,8 @@ minRunners: ${min_runners}
 runnerGroup: "${runner_group_name}"
 runnerScaleSetName: "${scale_set_name}"
 
+${metrics_values}
+
 template:
   metadata:
     annotations:

--- a/modules/platform/arc/scale_set/template_files/k8s.yml.tftpl
+++ b/modules/platform/arc/scale_set/template_files/k8s.yml.tftpl
@@ -8,6 +8,8 @@ minRunners: ${min_runners}
 runnerGroup: "${runner_group_name}"
 runnerScaleSetName: "${scale_set_name}"
 
+${metrics_values}
+
 containerMode:
   type: "kubernetes"
   kubernetesModeWorkVolumeClaim:

--- a/modules/platform/arc/scale_set/template_files/metrics.yml.tftpl
+++ b/modules/platform/arc/scale_set/template_files/metrics.yml.tftpl
@@ -1,0 +1,74 @@
+listenerTemplate:
+  metadata:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/path: "/metrics"
+      prometheus.io/port: "8080"
+  spec:
+    containers:
+      - name: listener
+
+listenerMetrics:
+  counters:
+    gha_started_jobs_total:
+      labels:
+        - repository
+        - organization
+        - enterprise
+        - job_name
+        - event_name
+        - job_workflow_ref
+        - job_workflow_name
+        - job_workflow_target
+    gha_completed_jobs_total:
+      labels:
+        - repository
+        - organization
+        - enterprise
+        - job_name
+        - event_name
+        - job_result
+        - job_workflow_ref
+        - job_workflow_name
+        - job_workflow_target
+
+  gauges:
+    gha_assigned_jobs:
+      labels: [name, namespace, repository, organization, enterprise]
+    gha_running_jobs:
+      labels: [name, namespace, repository, organization, enterprise]
+    gha_registered_runners:
+      labels: [name, namespace, repository, organization, enterprise]
+    gha_busy_runners:
+      labels: [name, namespace, repository, organization, enterprise]
+    gha_min_runners:
+      labels: [name, namespace, repository, organization, enterprise]
+    gha_max_runners:
+      labels: [name, namespace, repository, organization, enterprise]
+    gha_desired_runners:
+      labels: [name, namespace, repository, organization, enterprise]
+    gha_idle_runners:
+      labels: [name, namespace, repository, organization, enterprise]
+
+  histograms:
+    gha_job_startup_duration_seconds:
+      labels:
+        - repository
+        - organization
+        - enterprise
+        - job_name
+        - event_name
+        - job_workflow_ref
+        - job_workflow_name
+        - job_workflow_target
+    gha_job_execution_duration_seconds:
+      labels:
+        - repository
+        - organization
+        - enterprise
+        - job_name
+        - event_name
+        - job_result
+        - job_workflow_ref
+        - job_workflow_name
+        - job_workflow_target

--- a/modules/platform/arc/scale_set/tests/scale_set_behavior.tftest.hcl
+++ b/modules/platform/arc/scale_set/tests/scale_set_behavior.tftest.hcl
@@ -96,8 +96,11 @@ run "scale_set_contract" {
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "tenant-a-linux")
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "forge-runners")
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "https://github.com/cisco-open")
+      && strcontains(helm_release.gha_runner_scale_set[0].values[0], "prometheus.io/scrape: \"true\"")
+      && strcontains(helm_release.gha_runner_scale_set[0].values[0], "gha_job_startup_duration_seconds")
+      && strcontains(helm_release.gha_runner_scale_set[0].values[0], "job_workflow_target")
     )
-    error_message = "ARC scale set Helm release must render runner set name, runner group, and GitHub config URL from inputs."
+    error_message = "ARC scale set Helm release must render runner configuration and annotated high-cardinality listener metrics."
   }
 
   assert {
@@ -132,8 +135,10 @@ run "scale_set_dind_contract" {
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "tenant-a-dind")
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "docker:dind-rootless")
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "pod-identity-token-custom")
+      && strcontains(helm_release.gha_runner_scale_set[0].values[0], "gha_completed_jobs_total")
+      && strcontains(helm_release.gha_runner_scale_set[0].values[0], "job_workflow_name")
     )
-    error_message = "DinD scale sets must skip tenant k8s RBAC, keep service account and Pod Identity wiring, and render GHES/DinD Helm values."
+    error_message = "DinD scale sets must keep tenant isolation, Pod Identity wiring, GHES/DinD values, and high-cardinality listener metrics."
   }
 }
 

--- a/modules/platform/arc/scale_set_controller/template_files/values.yml.tftpl
+++ b/modules/platform/arc/scale_set_controller/template_files/values.yml.tftpl
@@ -39,7 +39,10 @@ serviceAccount:
   # You can not use the default service account for this.
   name: ""
 
-podAnnotations: {}
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/path: "/metrics"
+  prometheus.io/port: "8080"
 
 podLabels: {}
 
@@ -88,11 +91,10 @@ priorityClassName: ""
 ## `--metrics-addr`, `--listener-metrics-addr`, `--listener-metrics-endpoint`.
 ## This will disable metrics.
 ##
-## To enable metrics, uncomment the following lines.
-# metrics:
-#   controllerManagerAddr: ":8080"
-#   listenerAddr: ":8080"
-#   listenerEndpoint: "/metrics"
+metrics:
+  controllerManagerAddr: ":8080"
+  listenerAddr: ":8080"
+  listenerEndpoint: "/metrics"
 
 flags:
   ## Log level can be set here with one of the following values: "debug", "info", "warn", "error".

--- a/modules/platform/arc/scale_set_controller/tests/scale_set_controller_behavior.tftest.hcl
+++ b/modules/platform/arc/scale_set_controller/tests/scale_set_controller_behavior.tftest.hcl
@@ -45,8 +45,11 @@ run "scale_set_controller_contract" {
       && helm_release.gha_runner_scale_set_controller[0].cleanup_on_fail == true
       && helm_release.gha_runner_scale_set_controller[0].timeout == 1200
       && strcontains(helm_release.gha_runner_scale_set_controller[0].values[0], "debug")
+      && strcontains(helm_release.gha_runner_scale_set_controller[0].values[0], "controllerManagerAddr: \":8080\"")
+      && strcontains(helm_release.gha_runner_scale_set_controller[0].values[0], "listenerEndpoint: \"/metrics\"")
+      && strcontains(helm_release.gha_runner_scale_set_controller[0].values[0], "prometheus.io/scrape: \"true\"")
     )
-    error_message = "ARC controller Helm release must keep chart inputs, safety flags, timeout, and lower-case log level values."
+    error_message = "ARC controller Helm release must keep chart inputs, safety flags, timeout, lower-case log level values, and annotated Prometheus metrics endpoints."
   }
 }
 


### PR DESCRIPTION
## Description

Adds an ARC metrics that:

- exposes controller and listener Prometheus endpoints on port 8080;
- annotates dynamic targets for the existing Prometheus server and Splunk OTel autodiscovery;
- emits repository, job, event, result, and workflow dimensions for listener counters, gauges, and histograms.

This intentionally relies on independent scraping by managed Prometheus and Splunk OTel. It does not add Prometheus remote write, avoiding duplicate Splunk O11y ingestion while collector autodiscovery is enabled.

High-cardinality labels and default histogram buckets can materially increase Splunk metric time series usage; validate this draft in a non-production tenant before adoption.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu test` in `modules/platform/arc/scale_set_controller` (4 passed)
- `tofu test` in `modules/platform/arc/scale_set` (5 passed)
- rendered `gha-runner-scale-set-controller` chart version `0.14.2`
- rendered `gha-runner-scale-set` chart version `0.14.2`
- repository pre-commit hooks
