### PR TITLE
fix(service-catalog): support cluster-scoped application names

### DIFF
--- a/modules/infra/eks/service_catalog.tf
+++ b/modules/infra/eks/service_catalog.tf
@@ -1,4 +1,4 @@
 resource "aws_servicecatalogappregistry_application" "this" {
-  name = "infra_eks_${var.aws_region}"
+  name = "infra_eks_${var.cluster_name}_${var.aws_region}"
   tags = merge(var.default_tags, var.tags)
 }

--- a/modules/infra/eks/tests/infra_eks_source_inventory.tftest.hcl
+++ b/modules/infra/eks/tests/infra_eks_source_inventory.tftest.hcl
@@ -15,6 +15,7 @@ run "infra_eks_contract" {
       "resource \"aws_eks_addon\" \"aws_ebs_csi_driver\"",
       "resource \"aws_eks_addon\" \"eks_pod_identity_agent\"",
       "resource \"aws_eks_addon\" \"coredns\"",
+      "name = \"infra_eks_$${var.cluster_name}_$${var.aws_region}\"",
       "resource \"null_resource\" \"patch_calico_installation\"",
       "resource \"null_resource\" \"wait_for_cluster\"",
       "resource \"null_resource\" \"karpenter\"",

--- a/modules/integrations/splunk_aws_billing/lambda/common.py
+++ b/modules/integrations/splunk_aws_billing/lambda/common.py
@@ -202,7 +202,7 @@ MODULE_APPLICATION_ARN = re.compile(
     r'(?P<account_id>\d+):'
     r'group/'
     r'(?P<forgecicd_module_group>helpers|infra|integrations)_'
-    r'(?P<forgecicd_module>[a-z0-9_]+)_'
+    r'(?P<forgecicd_module>[a-z0-9_-]+)_'
     r'(?P=aws_region)'
     r'/resources'
 )

--- a/modules/integrations/splunk_otel_eks/service_catalog.tf
+++ b/modules/integrations/splunk_otel_eks/service_catalog.tf
@@ -1,4 +1,4 @@
 resource "aws_servicecatalogappregistry_application" "this" {
-  name = "integrations_splunk_otel_eks_${var.aws_region}"
+  name = "integrations_splunk_otel_eks_${var.cluster_name}_${var.aws_region}"
   tags = merge(var.default_tags, var.tags)
 }

--- a/modules/integrations/splunk_otel_eks/tests/splunk_otel_eks_behavior.tftest.hcl
+++ b/modules/integrations/splunk_otel_eks/tests/splunk_otel_eks_behavior.tftest.hcl
@@ -122,4 +122,9 @@ run "splunk_otel_eks_contract" {
     )
     error_message = "Splunk OTel Helm release must keep chart identity and configured cluster, platform index, and Prometheus autodiscovery values."
   }
+
+  assert {
+    condition     = aws_servicecatalogappregistry_application.this.name == "integrations_splunk_otel_eks_forge-euw1-dev_us-east-1"
+    error_message = "Splunk OTel EKS AppRegistry application names must include the cluster and AWS region."
+  }
 }

--- a/modules/integrations/teleport/service_catalog.tf
+++ b/modules/integrations/teleport/service_catalog.tf
@@ -1,4 +1,4 @@
 resource "aws_servicecatalogappregistry_application" "this" {
-  name = "integrations_teleport_${var.aws_region}"
+  name = "integrations_teleport_${var.teleport_config.cluster_name}_${var.aws_region}"
   tags = merge(var.default_tags, var.tags)
 }

--- a/modules/integrations/teleport/tests/teleport_behavior.tftest.hcl
+++ b/modules/integrations/teleport/tests/teleport_behavior.tftest.hcl
@@ -96,4 +96,9 @@ run "teleport_parent_contract" {
     )
     error_message = "Teleport outputs must expose role ARN, cluster/account identity, and tenant group mapping."
   }
+
+  assert {
+    condition     = aws_servicecatalogappregistry_application.this.name == "integrations_teleport_forge-euw1-dev_us-east-1"
+    error_message = "Teleport AppRegistry application names must include the cluster and AWS region."
+  }
 }

--- a/tests/lambdas/splunk_aws_billing_test.py
+++ b/tests/lambdas/splunk_aws_billing_test.py
@@ -15,6 +15,7 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
 from conftest import requires_aws
 
 pytestmark = requires_aws
@@ -329,6 +330,45 @@ def test_extract_arn_parts_for_module_application(monkeypatch, aws):
         'account_id': '123456789012',
         'forgecicd_module_group': 'integrations',
         'forgecicd_module': 'splunk_aws_billing',
+        'forgecicd_scope': 'module',
+    }
+
+
+@pytest.mark.parametrize(
+    ('application_name', 'module_name'),
+    [
+        (
+            'integrations_teleport_forge-euw1-dev_us-west-2',
+            'teleport_forge-euw1-dev',
+        ),
+        (
+            'integrations_splunk_otel_eks_forge-euw1-dev_us-west-2',
+            'splunk_otel_eks_forge-euw1-dev',
+        ),
+        (
+            'infra_eks_forge-euw1-dev_us-west-2',
+            'eks_forge-euw1-dev',
+        ),
+    ],
+)
+def test_extract_arn_parts_for_uniquely_named_module_application(
+    monkeypatch,
+    aws,
+    application_name,
+    module_name,
+):
+    common = _load_billing_module(monkeypatch, 'common')
+
+    parts = common.extract_arn_parts(
+        'arn:aws:resource-groups:us-west-2:123456789012:'
+        f'group/{application_name}/resources'
+    )
+
+    assert parts == {
+        'aws_region': 'us-west-2',
+        'account_id': '123456789012',
+        'forgecicd_module_group': application_name.split('_', 1)[0],
+        'forgecicd_module': module_name,
         'forgecicd_scope': 'module',
     }
 


### PR DESCRIPTION
## Description

Scope AppRegistry application names by cluster and AWS region for:

- Teleport
- Splunk OTel EKS
- EKS infrastructure

Update the Splunk AWS Billing Lambda's module application ARN parser to accept the hyphens used by these deployment-unique names while retaining the existing ARN-region consistency check.

Region-only AppRegistry names collided when the same module was deployed for multiple clusters in one region, and the billing parser's module-name pattern did not accept hyphenated cluster names.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- Repository pre-commit formatting, linting, static analysis, and security hooks passed.
- `tofu fmt -check -recursive` passed for the three affected modules.
- Splunk OTel EKS OpenTofu validation passed during the full hook attempt.
- Focused regex validation passed for all three cluster-qualified application names and rejection of a mismatched region.
- The focused pytest file collected successfully but its 19 tests were skipped locally because the available Python environments do not include the complete `boto3`/`moto` test dependency group.
- Teleport and EKS OpenTofu initialization/validation could not complete locally because provider/module downloads exhausted the machine's available disk space; the download-dependent validation hooks were skipped for the second commit.
