### PR TITLE
fix(observability): remove alert chart plot options

### DIFF
--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
@@ -119,15 +119,10 @@ resource "signalfx_single_value_chart" "firehose_freshness" {
 resource "signalfx_time_chart" "delivery_health_alerts" {
   name             = "Runner-log delivery alerts"
   description      = "Detector events for Firehose delivery failures, stale delivery, and runner-log DLQ occupancy."
-  program_text     = "A = alerts(detector_id='${var.detector_id}').publish(label='A')"
+  program_text     = "A = alerts(detector_id='${var.detector_id}').publish(label='Runner-log delivery alerts')"
   plot_type        = "LineChart"
   show_event_lines = true
   time_range       = 3600
-
-  viz_options {
-    display_name = "Delivery alerts"
-    label        = "A"
-  }
 }
 
 resource "signalfx_time_chart" "sqs_state" {

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/main.tf
@@ -119,7 +119,7 @@ resource "signalfx_single_value_chart" "firehose_freshness" {
 resource "signalfx_time_chart" "delivery_health_alerts" {
   name             = "Runner-log delivery alerts"
   description      = "Detector events for Firehose delivery failures, stale delivery, and runner-log DLQ occupancy."
-  program_text     = "A = alerts(detector_id='${var.detector_id}').publish(label='Runner-log delivery alerts')"
+  program_text     = "A = alerts(detector_id='${var.detector_id}').publish(label='A')"
   plot_type        = "LineChart"
   show_event_lines = true
   time_range       = 3600

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
@@ -112,7 +112,8 @@ run "creates_runner_logs_ingestion_dashboard" {
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataFreshness")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataAckLatency")
       && strcontains(signalfx_time_chart.delivery_health_alerts.program_text, "alerts(detector_id='runner-log-delivery-detector-id')")
-      && strcontains(signalfx_time_chart.delivery_health_alerts.program_text, ".publish(label='A')")
+      && strcontains(signalfx_time_chart.delivery_health_alerts.program_text, ".publish(label='Runner-log delivery alerts')")
+      && length(signalfx_time_chart.delivery_health_alerts.viz_options) == 0
       && signalfx_time_chart.delivery_health_alerts.show_event_lines
       && signalfx_time_chart.delivery_health_alerts.time_range == 3600
     )

--- a/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_conf_shared/dashboards/runner_logs_ingestion/tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl
@@ -112,6 +112,7 @@ run "creates_runner_logs_ingestion_dashboard" {
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataFreshness")
       && strcontains(signalfx_time_chart.firehose_latency.program_text, "DeliveryToSplunk.DataAckLatency")
       && strcontains(signalfx_time_chart.delivery_health_alerts.program_text, "alerts(detector_id='runner-log-delivery-detector-id')")
+      && strcontains(signalfx_time_chart.delivery_health_alerts.program_text, ".publish(label='A')")
       && signalfx_time_chart.delivery_health_alerts.show_event_lines
       && signalfx_time_chart.delivery_health_alerts.time_range == 3600
     )


### PR DESCRIPTION
## Description

Remove plot visualization options from the runner-log delivery alert timeline.

The chart is backed only by `alerts(...)`, which publishes an event stream rather than a plotted data stream. Its `viz_options` referenced plot label `A`, so Splunk Observability rejected the chart with HTTP 400 because no plotted publish block had that label.

Removing the plot options matches the other Forge alert-timeline charts and allows the shared observability configuration to create the chart. Behavior assertions preserve the descriptive event label and require the alert-only chart to have no plot options.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `tofu test -filter=tests/runner_logs_ingestion_dashboard_behavior.tftest.hcl` — 1 passed, 0 failed
- Repository pre-commit hooks — passed
