### PR TITLE
fix(eks): keep AppRegistry tag key static

### DIFF
--- a/modules/infra/eks/tags.tf
+++ b/modules/infra/eks/tags.tf
@@ -3,6 +3,8 @@ locals {
   all_security_tags = merge(
     var.default_tags,
     var.tags,
-    aws_servicecatalogappregistry_application.this.application_tag,
+    {
+      awsApplication = aws_servicecatalogappregistry_application.this.application_tag["awsApplication"]
+    },
   )
 }

--- a/modules/infra/eks/tests/infra_eks_source_inventory.tftest.hcl
+++ b/modules/infra/eks/tests/infra_eks_source_inventory.tftest.hcl
@@ -34,6 +34,7 @@ run "infra_eks_contract" {
       "output \"kubeconfig\"",
       "provider \"aws\"",
       "provider \"kubectl\"",
+      "awsApplication = aws_servicecatalogappregistry_application.this.application_tag[\"awsApplication\"]",
     ]
   }
 


### PR DESCRIPTION
## Description

Prevent EKS plans from failing when the upstream EKS module expands tags with `for_each`.

The AppRegistry resource exposes `application_tag` as a computed map, so its key set is unknown during the first plan. Project the provider-generated value through the static `awsApplication` key, allowing OpenTofu to identify downstream instances while leaving only the tag value unknown until apply.

Add a focused module contract test to keep the tag key static.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu test -no-color` in `modules/infra/eks`: 3 passed, 0 failed
- `tofu fmt -check`
- `git diff --check`
- Full pre-commit suite passed
- Minimal OpenTofu reproduction confirmed the original computed map and a `depends_on` variant fail, while the static-key projection plans successfully
