### PR TITLE
fix(splunk): scope secret AppRegistry tags by region

### DIFF
--- a/modules/integrations/splunk_secrets/README.md
+++ b/modules/integrations/splunk_secrets/README.md
@@ -20,21 +20,20 @@ Forge integrates with Splunk Cloud and Splunk Observability across several modul
 - Secret names are consumed by other modules, so coordinate renames carefully.
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version  |
-| ------------------------------------------------------------------------ | -------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.9.1 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | ~> 5.90  |
-| <a name="requirement_time"></a> [time](#requirement_time)                | ~> 0.13  |
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.11 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.47 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.13 |
 
 ## Providers
 
-| Name                                                | Version |
-| --------------------------------------------------- | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws)    | 5.99.1  |
-| <a name="provider_time"></a> [time](#provider_time) | 0.13.1  |
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.57.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
 
 ## Modules
 
@@ -42,24 +41,29 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                                             | Type        |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_secretsmanager_secret.cicd_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret)                      | resource    |
-| [aws_secretsmanager_secret_version.cicd_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version)      | resource    |
-| [time_sleep.wait_30_seconds](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep)                                                 | resource    |
+| Name | Type |
+| ---- | ---- |
+| [aws_kms_alias.regional_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.regional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_secretsmanager_secret.cicd_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.cicd_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_tag.cicd_secret_replica_application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_tag) | resource |
+| [aws_servicecatalogappregistry_application.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicecatalogappregistry_application) | resource |
+| [aws_servicecatalogappregistry_application.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicecatalogappregistry_application) | resource |
+| [time_sleep.wait_60_seconds](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_secretsmanager_random_password.secret_seeds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_random_password) | data source |
 
 ## Inputs
 
-| Name                                                                  | Description                          | Type          | Default | Required |
-| --------------------------------------------------------------------- | ------------------------------------ | ------------- | ------- | :------: |
-| <a name="input_aws_profile"></a> [aws_profile](#input_aws_profile)    | AWS profile to use.                  | `string`      | n/a     |   yes    |
-| <a name="input_aws_region"></a> [aws_region](#input_aws_region)       | Default AWS region.                  | `string`      | n/a     |   yes    |
-| <a name="input_default_tags"></a> [default_tags](#input_default_tags) | A map of tags to apply to resources. | `map(string)` | n/a     |   yes    |
-| <a name="input_tags"></a> [tags](#input_tags)                         | A map of tags to apply to resources. | `map(string)` | n/a     |   yes    |
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile to use. | `string` | n/a | yes |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | Default AWS region. | `string` | `"us-east-1"` | no |
+| <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
+| <a name="input_replica_regions"></a> [replica\_regions](#input\_replica\_regions) | List of regions to replicate the secret | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
 
 ## Outputs
 
 No outputs.
-
 <!-- END_TF_DOCS -->

--- a/modules/integrations/splunk_secrets/README.md
+++ b/modules/integrations/splunk_secrets/README.md
@@ -47,8 +47,7 @@ No modules.
 | [aws_kms_key.regional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_secretsmanager_secret.cicd_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.cicd_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_tag.cicd_secret_replica_application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_tag) | resource |
-| [aws_servicecatalogappregistry_application.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicecatalogappregistry_application) | resource |
+| [aws_secretsmanager_tag.cicd_secret_application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_tag) | resource |
 | [aws_servicecatalogappregistry_application.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicecatalogappregistry_application) | resource |
 | [time_sleep.wait_60_seconds](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_secretsmanager_random_password.secret_seeds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_random_password) | data source |

--- a/modules/integrations/splunk_secrets/main.tf
+++ b/modules/integrations/splunk_secrets/main.tf
@@ -132,6 +132,21 @@ resource "aws_secretsmanager_secret" "cicd_secrets" {
 
 }
 
+# Replica blocks do not support tags, so manage each replica's regional
+# AppRegistry association through the regional Secrets Manager endpoint.
+resource "aws_secretsmanager_tag" "cicd_secret_replica_application" {
+  for_each = local.secret_replica_application_tags
+  provider = aws.by_region[each.value.region]
+
+  secret_id = replace(
+    aws_secretsmanager_secret.cicd_secrets[each.value.secret_name].arn,
+    ":${var.aws_region}:",
+    ":${each.value.region}:",
+  )
+  key   = "awsApplication"
+  value = local.application_tags_by_region[each.value.region]["awsApplication"]
+}
+
 # Force a delay between secret creation and seeding. We only need a few
 # seconds, but if we don't do this, we get into a bad state requiring manual
 # intervention and/or manual forced-deletion of secrets.

--- a/modules/integrations/splunk_secrets/main.tf
+++ b/modules/integrations/splunk_secrets/main.tf
@@ -95,8 +95,8 @@ resource "aws_kms_key" "regional" {
 
   description         = "Customer managed CMK for Splunk Secrets in ${each.key}"
   enable_key_rotation = true
-  tags                = local.all_security_tags
-  tags_all            = local.all_security_tags
+  tags                = local.all_security_tags_by_region[each.value]
+  tags_all            = local.all_security_tags_by_region[each.value]
 }
 
 resource "aws_kms_alias" "regional_alias" {
@@ -119,8 +119,8 @@ resource "aws_secretsmanager_secret" "cicd_secrets" {
   description             = each.value.description
   kms_key_id              = aws_kms_key.regional[var.aws_region].arn
   recovery_window_in_days = each.value.recovery_days
-  tags                    = local.all_security_tags
-  tags_all                = local.all_security_tags
+  tags                    = local.secret_security_tags
+  tags_all                = local.secret_security_tags
 
   dynamic "replica" {
     for_each = var.replica_regions

--- a/modules/integrations/splunk_secrets/main.tf
+++ b/modules/integrations/splunk_secrets/main.tf
@@ -119,8 +119,8 @@ resource "aws_secretsmanager_secret" "cicd_secrets" {
   description             = each.value.description
   kms_key_id              = aws_kms_key.regional[var.aws_region].arn
   recovery_window_in_days = each.value.recovery_days
-  tags                    = local.secret_security_tags
-  tags_all                = local.secret_security_tags
+  tags                    = local.all_security_tags
+  tags_all                = local.all_security_tags
 
   dynamic "replica" {
     for_each = var.replica_regions

--- a/modules/integrations/splunk_secrets/main.tf
+++ b/modules/integrations/splunk_secrets/main.tf
@@ -95,8 +95,14 @@ resource "aws_kms_key" "regional" {
 
   description         = "Customer managed CMK for Splunk Secrets in ${each.key}"
   enable_key_rotation = true
-  tags                = local.all_security_tags_by_region[each.value]
-  tags_all            = local.all_security_tags_by_region[each.value]
+  tags = merge(
+    local.all_security_tags,
+    each.value == var.aws_region ? aws_servicecatalogappregistry_application.this.application_tag : aws_servicecatalogappregistry_application.replica[each.value].application_tag,
+  )
+  tags_all = merge(
+    local.all_security_tags,
+    each.value == var.aws_region ? aws_servicecatalogappregistry_application.this.application_tag : aws_servicecatalogappregistry_application.replica[each.value].application_tag,
+  )
 }
 
 resource "aws_kms_alias" "regional_alias" {
@@ -119,8 +125,14 @@ resource "aws_secretsmanager_secret" "cicd_secrets" {
   description             = each.value.description
   kms_key_id              = aws_kms_key.regional[var.aws_region].arn
   recovery_window_in_days = each.value.recovery_days
-  tags                    = local.all_security_tags
-  tags_all                = local.all_security_tags
+  tags = merge(
+    local.all_security_tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
+  tags_all = merge(
+    local.all_security_tags,
+    aws_servicecatalogappregistry_application.this.application_tag,
+  )
 
   dynamic "replica" {
     for_each = var.replica_regions
@@ -144,7 +156,7 @@ resource "aws_secretsmanager_tag" "cicd_secret_replica_application" {
     ":${each.value.region}:",
   )
   key   = "awsApplication"
-  value = local.application_tags_by_region[each.value.region]["awsApplication"]
+  value = aws_servicecatalogappregistry_application.replica[each.value.region].application_tag["awsApplication"]
 }
 
 # Force a delay between secret creation and seeding. We only need a few

--- a/modules/integrations/splunk_secrets/main.tf
+++ b/modules/integrations/splunk_secrets/main.tf
@@ -97,11 +97,11 @@ resource "aws_kms_key" "regional" {
   enable_key_rotation = true
   tags = merge(
     local.all_security_tags,
-    each.value == var.aws_region ? aws_servicecatalogappregistry_application.this.application_tag : aws_servicecatalogappregistry_application.replica[each.value].application_tag,
+    aws_servicecatalogappregistry_application.this[each.value].application_tag,
   )
   tags_all = merge(
     local.all_security_tags,
-    each.value == var.aws_region ? aws_servicecatalogappregistry_application.this.application_tag : aws_servicecatalogappregistry_application.replica[each.value].application_tag,
+    aws_servicecatalogappregistry_application.this[each.value].application_tag,
   )
 }
 
@@ -125,14 +125,8 @@ resource "aws_secretsmanager_secret" "cicd_secrets" {
   description             = each.value.description
   kms_key_id              = aws_kms_key.regional[var.aws_region].arn
   recovery_window_in_days = each.value.recovery_days
-  tags = merge(
-    local.all_security_tags,
-    aws_servicecatalogappregistry_application.this.application_tag,
-  )
-  tags_all = merge(
-    local.all_security_tags,
-    aws_servicecatalogappregistry_application.this.application_tag,
-  )
+  tags                    = local.all_security_tags
+  tags_all                = local.all_security_tags
 
   dynamic "replica" {
     for_each = var.replica_regions
@@ -144,10 +138,16 @@ resource "aws_secretsmanager_secret" "cicd_secrets" {
 
 }
 
-# Replica blocks do not support tags, so manage each replica's regional
-# AppRegistry association through the regional Secrets Manager endpoint.
-resource "aws_secretsmanager_tag" "cicd_secret_replica_application" {
-  for_each = local.secret_replica_application_tags
+# Manage every secret's AppRegistry association through its regional
+# Secrets Manager endpoint, including the primary region.
+resource "aws_secretsmanager_tag" "cicd_secret_application" {
+  for_each = {
+    for replica in setproduct(keys(aws_secretsmanager_secret.cicd_secrets), local.all_regions) :
+    "${replica[0]}:${replica[1]}" => {
+      secret_name = replica[0]
+      region      = replica[1]
+    }
+  }
   provider = aws.by_region[each.value.region]
 
   secret_id = replace(
@@ -156,7 +156,7 @@ resource "aws_secretsmanager_tag" "cicd_secret_replica_application" {
     ":${each.value.region}:",
   )
   key   = "awsApplication"
-  value = aws_servicecatalogappregistry_application.replica[each.value.region].application_tag["awsApplication"]
+  value = aws_servicecatalogappregistry_application.this[each.value.region].application_tag["awsApplication"]
 }
 
 # Force a delay between secret creation and seeding. We only need a few

--- a/modules/integrations/splunk_secrets/service_catalog.tf
+++ b/modules/integrations/splunk_secrets/service_catalog.tf
@@ -1,10 +1,5 @@
 resource "aws_servicecatalogappregistry_application" "this" {
-  name = "integrations_splunk_secrets_${var.aws_region}"
-  tags = merge(var.default_tags, var.tags)
-}
-
-resource "aws_servicecatalogappregistry_application" "replica" {
-  for_each = setsubtract(local.all_regions, toset([var.aws_region]))
+  for_each = local.all_regions
   provider = aws.by_region[each.value]
 
   name = "integrations_splunk_secrets_${each.value}"

--- a/modules/integrations/splunk_secrets/service_catalog.tf
+++ b/modules/integrations/splunk_secrets/service_catalog.tf
@@ -2,3 +2,11 @@ resource "aws_servicecatalogappregistry_application" "this" {
   name = "integrations_splunk_secrets_${var.aws_region}"
   tags = merge(var.default_tags, var.tags)
 }
+
+resource "aws_servicecatalogappregistry_application" "replica" {
+  for_each = setsubtract(local.all_regions, toset([var.aws_region]))
+  provider = aws.by_region[each.value]
+
+  name = "integrations_splunk_secrets_${each.value}"
+  tags = merge(var.default_tags, var.tags)
+}

--- a/modules/integrations/splunk_secrets/tags.tf
+++ b/modules/integrations/splunk_secrets/tags.tf
@@ -1,8 +1,31 @@
 # Common tags we propagate project-wide.
 locals {
-  all_security_tags = merge(
+  application_tags_by_region = merge(
+    {
+      (var.aws_region) = aws_servicecatalogappregistry_application.this.application_tag
+    },
+    {
+      for region, application in aws_servicecatalogappregistry_application.replica :
+      region => application.application_tag
+    },
+  )
+
+  all_security_tags_by_region = {
+    for region in local.all_regions :
+    region => merge(
+      var.default_tags,
+      var.tags,
+      local.application_tags_by_region[region],
+    )
+  }
+
+  all_security_tags = local.all_security_tags_by_region[var.aws_region]
+
+  # Secrets Manager copies primary-secret tags to every replica, so a regional
+  # AppRegistry tag can only be applied safely when the secret is not replicated.
+  secret_security_tags = merge(
     var.default_tags,
     var.tags,
-    aws_servicecatalogappregistry_application.this.application_tag,
+    length(var.replica_regions) == 0 ? aws_servicecatalogappregistry_application.this.application_tag : {},
   )
 }

--- a/modules/integrations/splunk_secrets/tags.tf
+++ b/modules/integrations/splunk_secrets/tags.tf
@@ -20,12 +20,4 @@ locals {
   }
 
   all_security_tags = local.all_security_tags_by_region[var.aws_region]
-
-  # Secrets Manager copies primary-secret tags to every replica, so a regional
-  # AppRegistry tag can only be applied safely when the secret is not replicated.
-  secret_security_tags = merge(
-    var.default_tags,
-    var.tags,
-    length(var.replica_regions) == 0 ? aws_servicecatalogappregistry_application.this.application_tag : {},
-  )
 }

--- a/modules/integrations/splunk_secrets/tags.tf
+++ b/modules/integrations/splunk_secrets/tags.tf
@@ -20,4 +20,16 @@ locals {
   }
 
   all_security_tags = local.all_security_tags_by_region[var.aws_region]
+
+  secret_replica_application_tags = {
+    for replica in flatten([
+      for secret in local.secrets : [
+        for region in var.replica_regions : {
+          key         = "${secret.name}:${region}"
+          secret_name = secret.name
+          region      = region
+        }
+      ]
+    ]) : replica.key => replica
+  }
 }

--- a/modules/integrations/splunk_secrets/tags.tf
+++ b/modules/integrations/splunk_secrets/tags.tf
@@ -1,16 +1,4 @@
 # Common tags we propagate project-wide.
 locals {
   all_security_tags = merge(var.default_tags, var.tags)
-
-  secret_replica_application_tags = {
-    for replica in flatten([
-      for secret in local.secrets : [
-        for region in var.replica_regions : {
-          key         = "${secret.name}:${region}"
-          secret_name = secret.name
-          region      = region
-        }
-      ]
-    ]) : replica.key => replica
-  }
 }

--- a/modules/integrations/splunk_secrets/tags.tf
+++ b/modules/integrations/splunk_secrets/tags.tf
@@ -1,25 +1,6 @@
 # Common tags we propagate project-wide.
 locals {
-  application_tags_by_region = merge(
-    {
-      (var.aws_region) = aws_servicecatalogappregistry_application.this.application_tag
-    },
-    {
-      for region, application in aws_servicecatalogappregistry_application.replica :
-      region => application.application_tag
-    },
-  )
-
-  all_security_tags_by_region = {
-    for region in local.all_regions :
-    region => merge(
-      var.default_tags,
-      var.tags,
-      local.application_tags_by_region[region],
-    )
-  }
-
-  all_security_tags = local.all_security_tags_by_region[var.aws_region]
+  all_security_tags = merge(var.default_tags, var.tags)
 
   secret_replica_application_tags = {
     for replica in flatten([

--- a/modules/integrations/splunk_secrets/tests/integrations_splunk_secrets_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_secrets/tests/integrations_splunk_secrets_source_inventory.tftest.hcl
@@ -11,6 +11,7 @@ run "integrations_splunk_secrets_contract" {
       "resource \"aws_kms_key\" \"regional\"",
       "resource \"aws_kms_alias\" \"regional_alias\"",
       "resource \"aws_secretsmanager_secret\" \"cicd_secrets\"",
+      "resource \"aws_secretsmanager_tag\" \"cicd_secret_replica_application\"",
       "resource \"time_sleep\" \"wait_60_seconds\"",
       "resource \"aws_secretsmanager_secret_version\" \"cicd_secrets\"",
       "data \"aws_secretsmanager_random_password\" \"secret_seeds\"",

--- a/modules/integrations/splunk_secrets/tests/integrations_splunk_secrets_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_secrets/tests/integrations_splunk_secrets_source_inventory.tftest.hcl
@@ -11,7 +11,7 @@ run "integrations_splunk_secrets_contract" {
       "resource \"aws_kms_key\" \"regional\"",
       "resource \"aws_kms_alias\" \"regional_alias\"",
       "resource \"aws_secretsmanager_secret\" \"cicd_secrets\"",
-      "resource \"aws_secretsmanager_tag\" \"cicd_secret_replica_application\"",
+      "resource \"aws_secretsmanager_tag\" \"cicd_secret_application\"",
       "resource \"time_sleep\" \"wait_60_seconds\"",
       "resource \"aws_secretsmanager_secret_version\" \"cicd_secrets\"",
       "data \"aws_secretsmanager_random_password\" \"secret_seeds\"",


### PR DESCRIPTION
## Description

Fix regional AppRegistry associations in the `splunk_secrets` module.

- Create one `aws_servicecatalogappregistry_application.this` instance for every configured region.
- Apply each region's application tag directly to its regional KMS key.
- Keep common tags on `aws_secretsmanager_secret.cicd_secrets`.
- Use one `aws_secretsmanager_tag.cicd_secret_application` resource across every secret and every configured region, including the primary, so each secret receives the matching regional `awsApplication` value.

## State Migration

The existing primary AppRegistry application changes from the singleton address `aws_servicecatalogappregistry_application.this` to the keyed address `aws_servicecatalogappregistry_application.this["eu-west-1"]`. Move that state address before applying the module update to avoid recreating the existing primary application.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: __________

## Testing

- `tofu test -test-directory=tests -no-color` (`2 passed, 0 failed`)
- Full repository commit hooks, including OpenTofu formatting and validation, Terraform linting and validation, security scans, and Ansible linting
- Regenerated `modules/integrations/splunk_secrets/README.md`
