### PR TITLE
fix: remove service catalog from github_webhook_relay_destination

### DIFF
--- a/modules/integrations/github_webhook_relay_destination/service_catalog.tf
+++ b/modules/integrations/github_webhook_relay_destination/service_catalog.tf
@@ -1,4 +1,0 @@
-resource "aws_servicecatalogappregistry_application" "this" {
-  name = "integrations_github_webhook_relay_destination_${var.aws_region}"
-  tags = merge(var.default_tags, var.tags)
-}

--- a/modules/integrations/github_webhook_relay_destination/tags.tf
+++ b/modules/integrations/github_webhook_relay_destination/tags.tf
@@ -2,7 +2,6 @@
 locals {
   all_security_tags = merge(
     var.default_tags,
-    var.tags,
-    aws_servicecatalogappregistry_application.this.application_tag,
+    var.tags
   )
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Remove service catalog from github_webhook_relay_destination because it is already created in github_webhook_relay_destination_receivers

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: \_\_\_\_\_\_\_\_\_\_\_

## Testing

<!-- Describe testing done if needed -->
