### PR TITLE
feat(splunk): tag managed metric stream

### DIFF
--- a/.github/workflows/iac-policy.yml
+++ b/.github/workflows/iac-policy.yml
@@ -10,6 +10,7 @@ on:
       - renovatebot
     paths:
       - modules/**/*.tf
+      - modules/**/*.sh
       - modules/**/*.tftest.hcl
       - modules/**/*.tofutest.hcl
       - examples/**/*.tf
@@ -25,6 +26,7 @@ on:
       - main
     paths:
       - modules/**/*.tf
+      - modules/**/*.sh
       - modules/**/*.tftest.hcl
       - modules/**/*.tofutest.hcl
       - examples/**/*.tf

--- a/modules/integrations/splunk_o11y_aws_integration/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration/README.md
@@ -20,7 +20,7 @@ Forge uses Splunk Observability for AWS metrics while Splunk Cloud handles logs.
 - Use the common integration module for IAM role setup when needed.
 - Metric Stream tag management requires the AWS CLI and `cloudwatch:ListMetricStreams`, `cloudwatch:TagResource`, and `cloudwatch:UntagResource` permissions for the configured AWS profile.
 - The tag helper finds exactly one stream in the configured region whose name starts with `splunk-metric-stream-`. It waits up to 15 minutes for a newly configured stream and fails rather than choosing arbitrarily if multiple streams match.
-- Tag drift outside Terraform is not detected unless the stack, template, or desired tag map changes and replaces the helper.
+- Tag drift outside Terraform is not detected unless the stack, template, helper script, or desired tag map changes and replaces the helper.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/modules/integrations/splunk_o11y_aws_integration/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration/README.md
@@ -11,12 +11,16 @@ Forge uses Splunk Observability for AWS metrics while Splunk Cloud handles logs.
 - A CloudFormation stack created from the configured template URL.
 - Secret lookups for Splunk access material.
 - Region, ingest URL, and tagging inputs for the integration.
+- Application of the common Forge tags to the regional Splunk-managed CloudWatch Metric Stream.
 
 ## Operational Notes
 
 - This module depends on a valid Splunk-provided template URL.
 - CloudFormation failures should be debugged in both Terraform output and the CloudFormation events.
 - Use the common integration module for IAM role setup when needed.
+- Metric Stream tag management requires the AWS CLI and `cloudwatch:ListMetricStreams`, `cloudwatch:TagResource`, and `cloudwatch:UntagResource` permissions for the configured AWS profile.
+- The tag helper finds exactly one stream in the configured region whose name starts with `splunk-metric-stream-`. It waits up to 15 minutes for a newly configured stream and fails rather than choosing arbitrarily if multiple streams match.
+- Tag drift outside Terraform is not detected unless the stack, template, or desired tag map changes and replaces the helper.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -31,6 +35,7 @@ Forge uses Splunk Observability for AWS metrics while Splunk Cloud handles logs.
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 6.57.1 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -42,6 +47,7 @@ No modules.
 | ---- | ---- |
 | [aws_cloudformation_stack.splunk_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack) | resource |
 | [aws_servicecatalogappregistry_application.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicecatalogappregistry_application) | resource |
+| [terraform_data.cloudwatch_metric_stream_tags](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_secretsmanager_secret.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret_version.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 

--- a/modules/integrations/splunk_o11y_aws_integration/metric_stream_tags.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/metric_stream_tags.tf
@@ -10,18 +10,19 @@ resource "terraform_data" "cloudwatch_metric_stream_tags" {
     tags = local.all_security_tags
   }
 
-  # local-exec provisioners do not run for an in-place terraform_data
-  # update, so stack, template, and tag changes must replace this resource.
+  # local-exec provisioners do not run for an in-place terraform_data update,
+  # so stack, template, script, and tag changes must replace this resource.
   triggers_replace = [
     aws_cloudformation_stack.splunk_integration.id,
     var.template_url,
+    filesha256("${path.module}/scripts/manage_cloudwatch_metric_stream_tags.sh"),
     sha256(jsonencode(local.all_security_tags)),
   ]
 
   # Apply all desired tags. Splunk creates its managed Metric Stream
   # asynchronously after the CloudFormation prerequisites are available.
   provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
+    working_dir = path.module
 
     environment = {
       AWS_PAGER          = ""
@@ -38,78 +39,7 @@ resource "terraform_data" "cloudwatch_metric_stream_tags" {
       ])
     }
 
-    command = <<-EOT
-      set -euo pipefail
-
-      resolve_metric_stream_arn() {
-        local matching_output
-        local candidate_arn
-        local -a matching_arns=()
-
-        if ! matching_output="$(aws cloudwatch list-metric-streams \
-          --region "$AWS_REGION" \
-          --query "Entries[?starts_with(Name, '$STREAM_NAME_PREFIX')].Arn" \
-          --output text)"; then
-          return 2
-        fi
-
-        while IFS= read -r candidate_arn; do
-          if [ -n "$candidate_arn" ] && [ "$candidate_arn" != "None" ]; then
-            matching_arns+=("$candidate_arn")
-          fi
-        done < <(printf '%s\n' "$matching_output" | tr '\t' '\n')
-
-        if [ "$${#matching_arns[@]}" -eq 0 ]; then
-          return 1
-        fi
-
-        if [ "$${#matching_arns[@]}" -ne 1 ]; then
-          echo "Expected exactly one CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX'; found $${#matching_arns[@]}." >&2
-          printf '  %s\n' "$${matching_arns[@]}" >&2
-          return 2
-        fi
-
-        printf '%s\n' "$${matching_arns[0]}"
-      }
-
-      if [ "$TAG_COUNT" -eq 0 ]; then
-        echo "No CloudWatch Metric Stream tags to apply."
-        exit 0
-      fi
-
-      for ((attempt = 1; attempt <= 60; attempt++)); do
-        resource_arn=""
-
-        if resource_arn="$(resolve_metric_stream_arn)"; then
-          echo "Applying $TAG_COUNT tag(s) to CloudWatch Metric Stream: $resource_arn"
-
-          if output="$(aws cloudwatch tag-resource \
-            --region "$AWS_REGION" \
-            --resource-arn "$resource_arn" \
-            --tags "$TAGS_JSON" 2>&1)"; then
-            exit 0
-          fi
-
-          if [[ "$output" != *"ResourceNotFoundException"* ]]; then
-            echo "$output" >&2
-            exit 1
-          fi
-        else
-          resolve_status="$?"
-          if [ "$resolve_status" -ne 1 ]; then
-            exit "$resolve_status"
-          fi
-        fi
-
-        if [ "$attempt" -eq 60 ]; then
-          echo "CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX' was not available after 15 minutes." >&2
-          exit 1
-        fi
-
-        echo "CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX' is not available yet; retrying in 15 seconds."
-        sleep 15
-      done
-    EOT
+    command = "./scripts/manage_cloudwatch_metric_stream_tags.sh apply"
   }
 
   # Remove all keys managed by the previous instance of this helper.
@@ -118,10 +48,11 @@ resource "terraform_data" "cloudwatch_metric_stream_tags" {
   # - a tag is deleted from local.all_security_tags;
   # - a tag value changes;
   # - the CloudFormation stack or template changes;
+  # - the helper script changes;
   # - terraform destroy is executed.
   provisioner "local-exec" {
     when        = destroy
-    interpreter = ["/bin/bash", "-c"]
+    working_dir = path.module
 
     environment = {
       AWS_PAGER          = ""
@@ -134,77 +65,7 @@ resource "terraform_data" "cloudwatch_metric_stream_tags" {
       )
     }
 
-    command = <<-EOT
-      set -euo pipefail
-
-      resolve_metric_stream_arn() {
-        local matching_output
-        local candidate_arn
-        local -a matching_arns=()
-
-        if ! matching_output="$(aws cloudwatch list-metric-streams \
-          --region "$AWS_REGION" \
-          --query "Entries[?starts_with(Name, '$STREAM_NAME_PREFIX')].Arn" \
-          --output text)"; then
-          return 2
-        fi
-
-        while IFS= read -r candidate_arn; do
-          if [ -n "$candidate_arn" ] && [ "$candidate_arn" != "None" ]; then
-            matching_arns+=("$candidate_arn")
-          fi
-        done < <(printf '%s\n' "$matching_output" | tr '\t' '\n')
-
-        if [ "$${#matching_arns[@]}" -eq 0 ]; then
-          return 1
-        fi
-
-        if [ "$${#matching_arns[@]}" -ne 1 ]; then
-          echo "Expected exactly one CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX'; found $${#matching_arns[@]}." >&2
-          printf '  %s\n' "$${matching_arns[@]}" >&2
-          return 2
-        fi
-
-        printf '%s\n' "$${matching_arns[0]}"
-      }
-
-      if [ "$TAG_COUNT" -eq 0 ]; then
-        echo "No CloudWatch Metric Stream tags to remove."
-        exit 0
-      fi
-
-      resource_arn=""
-
-      if resource_arn="$(resolve_metric_stream_arn)"; then
-        :
-      else
-        resolve_status="$?"
-
-        if [ "$resolve_status" -eq 1 ]; then
-          echo "CloudWatch Metric Stream no longer exists; no tags remain to remove."
-          exit 0
-        fi
-
-        exit "$resolve_status"
-      fi
-
-      echo "Removing previously managed tags from CloudWatch Metric Stream: $resource_arn"
-
-      if output="$(aws cloudwatch untag-resource \
-        --region "$AWS_REGION" \
-        --resource-arn "$resource_arn" \
-        --tag-keys "$TAG_KEYS_JSON" 2>&1)"; then
-        exit 0
-      fi
-
-      if [[ "$output" == *"ResourceNotFoundException"* ]]; then
-        echo "CloudWatch Metric Stream no longer exists; no tags remain to remove."
-        exit 0
-      fi
-
-      echo "$output" >&2
-      exit 1
-    EOT
+    command = "./scripts/manage_cloudwatch_metric_stream_tags.sh remove"
   }
 
   depends_on = [

--- a/modules/integrations/splunk_o11y_aws_integration/metric_stream_tags.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/metric_stream_tags.tf
@@ -1,0 +1,213 @@
+resource "terraform_data" "cloudwatch_metric_stream_tags" {
+  input = {
+    aws_profile        = var.aws_profile
+    region             = var.aws_region
+    stack_id           = aws_cloudformation_stack.splunk_integration.id
+    stream_name_prefix = "splunk-metric-stream-"
+
+    # Stored in Terraform state so the destroy provisioner knows which
+    # keys were managed by the previous configuration.
+    tags = local.all_security_tags
+  }
+
+  # local-exec provisioners do not run for an in-place terraform_data
+  # update, so stack, template, and tag changes must replace this resource.
+  triggers_replace = [
+    aws_cloudformation_stack.splunk_integration.id,
+    var.template_url,
+    sha256(jsonencode(local.all_security_tags)),
+  ]
+
+  # Apply all desired tags. Splunk creates its managed Metric Stream
+  # asynchronously after the CloudFormation prerequisites are available.
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+
+    environment = {
+      AWS_PAGER          = ""
+      AWS_PROFILE        = self.input.aws_profile
+      AWS_REGION         = self.input.region
+      STREAM_NAME_PREFIX = self.input.stream_name_prefix
+      TAG_COUNT          = tostring(length(self.input.tags))
+
+      TAGS_JSON = jsonencode([
+        for key in sort(keys(self.input.tags)) : {
+          Key   = key
+          Value = self.input.tags[key]
+        }
+      ])
+    }
+
+    command = <<-EOT
+      set -euo pipefail
+
+      resolve_metric_stream_arn() {
+        local matching_output
+        local candidate_arn
+        local -a matching_arns=()
+
+        if ! matching_output="$(aws cloudwatch list-metric-streams \
+          --region "$AWS_REGION" \
+          --query "Entries[?starts_with(Name, '$STREAM_NAME_PREFIX')].Arn" \
+          --output text)"; then
+          return 2
+        fi
+
+        while IFS= read -r candidate_arn; do
+          if [ -n "$candidate_arn" ] && [ "$candidate_arn" != "None" ]; then
+            matching_arns+=("$candidate_arn")
+          fi
+        done < <(printf '%s\n' "$matching_output" | tr '\t' '\n')
+
+        if [ "$${#matching_arns[@]}" -eq 0 ]; then
+          return 1
+        fi
+
+        if [ "$${#matching_arns[@]}" -ne 1 ]; then
+          echo "Expected exactly one CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX'; found $${#matching_arns[@]}." >&2
+          printf '  %s\n' "$${matching_arns[@]}" >&2
+          return 2
+        fi
+
+        printf '%s\n' "$${matching_arns[0]}"
+      }
+
+      if [ "$TAG_COUNT" -eq 0 ]; then
+        echo "No CloudWatch Metric Stream tags to apply."
+        exit 0
+      fi
+
+      for ((attempt = 1; attempt <= 60; attempt++)); do
+        resource_arn=""
+
+        if resource_arn="$(resolve_metric_stream_arn)"; then
+          echo "Applying $TAG_COUNT tag(s) to CloudWatch Metric Stream: $resource_arn"
+
+          if output="$(aws cloudwatch tag-resource \
+            --region "$AWS_REGION" \
+            --resource-arn "$resource_arn" \
+            --tags "$TAGS_JSON" 2>&1)"; then
+            exit 0
+          fi
+
+          if [[ "$output" != *"ResourceNotFoundException"* ]]; then
+            echo "$output" >&2
+            exit 1
+          fi
+        else
+          resolve_status="$?"
+          if [ "$resolve_status" -ne 1 ]; then
+            exit "$resolve_status"
+          fi
+        fi
+
+        if [ "$attempt" -eq 60 ]; then
+          echo "CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX' was not available after 15 minutes." >&2
+          exit 1
+        fi
+
+        echo "CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX' is not available yet; retrying in 15 seconds."
+        sleep 15
+      done
+    EOT
+  }
+
+  # Remove all keys managed by the previous instance of this helper.
+  #
+  # This runs when:
+  # - a tag is deleted from local.all_security_tags;
+  # - a tag value changes;
+  # - the CloudFormation stack or template changes;
+  # - terraform destroy is executed.
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+
+    environment = {
+      AWS_PAGER          = ""
+      AWS_PROFILE        = self.input.aws_profile
+      AWS_REGION         = self.input.region
+      STREAM_NAME_PREFIX = self.input.stream_name_prefix
+      TAG_COUNT          = tostring(length(self.input.tags))
+      TAG_KEYS_JSON = jsonencode(
+        sort(keys(self.input.tags))
+      )
+    }
+
+    command = <<-EOT
+      set -euo pipefail
+
+      resolve_metric_stream_arn() {
+        local matching_output
+        local candidate_arn
+        local -a matching_arns=()
+
+        if ! matching_output="$(aws cloudwatch list-metric-streams \
+          --region "$AWS_REGION" \
+          --query "Entries[?starts_with(Name, '$STREAM_NAME_PREFIX')].Arn" \
+          --output text)"; then
+          return 2
+        fi
+
+        while IFS= read -r candidate_arn; do
+          if [ -n "$candidate_arn" ] && [ "$candidate_arn" != "None" ]; then
+            matching_arns+=("$candidate_arn")
+          fi
+        done < <(printf '%s\n' "$matching_output" | tr '\t' '\n')
+
+        if [ "$${#matching_arns[@]}" -eq 0 ]; then
+          return 1
+        fi
+
+        if [ "$${#matching_arns[@]}" -ne 1 ]; then
+          echo "Expected exactly one CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX'; found $${#matching_arns[@]}." >&2
+          printf '  %s\n' "$${matching_arns[@]}" >&2
+          return 2
+        fi
+
+        printf '%s\n' "$${matching_arns[0]}"
+      }
+
+      if [ "$TAG_COUNT" -eq 0 ]; then
+        echo "No CloudWatch Metric Stream tags to remove."
+        exit 0
+      fi
+
+      resource_arn=""
+
+      if resource_arn="$(resolve_metric_stream_arn)"; then
+        :
+      else
+        resolve_status="$?"
+
+        if [ "$resolve_status" -eq 1 ]; then
+          echo "CloudWatch Metric Stream no longer exists; no tags remain to remove."
+          exit 0
+        fi
+
+        exit "$resolve_status"
+      fi
+
+      echo "Removing previously managed tags from CloudWatch Metric Stream: $resource_arn"
+
+      if output="$(aws cloudwatch untag-resource \
+        --region "$AWS_REGION" \
+        --resource-arn "$resource_arn" \
+        --tag-keys "$TAG_KEYS_JSON" 2>&1)"; then
+        exit 0
+      fi
+
+      if [[ "$output" == *"ResourceNotFoundException"* ]]; then
+        echo "CloudWatch Metric Stream no longer exists; no tags remain to remove."
+        exit 0
+      fi
+
+      echo "$output" >&2
+      exit 1
+    EOT
+  }
+
+  depends_on = [
+    aws_cloudformation_stack.splunk_integration,
+  ]
+}

--- a/modules/integrations/splunk_o11y_aws_integration/scripts/manage_cloudwatch_metric_stream_tags.sh
+++ b/modules/integrations/splunk_o11y_aws_integration/scripts/manage_cloudwatch_metric_stream_tags.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 apply|remove" >&2
+}
+
+require_common_environment() {
+    : "${AWS_REGION:?AWS_REGION must be set}"
+    : "${STREAM_NAME_PREFIX:?STREAM_NAME_PREFIX must be set}"
+    : "${TAG_COUNT:?TAG_COUNT must be set}"
+}
+
+resolve_metric_stream_arn() {
+    local matching_output
+    local candidate_arn
+    local -a matching_arns=()
+
+    if ! matching_output="$(aws cloudwatch list-metric-streams \
+        --region "$AWS_REGION" \
+        --query "Entries[?starts_with(Name, '$STREAM_NAME_PREFIX')].Arn" \
+        --output text)"; then
+        return 2
+    fi
+
+    while IFS= read -r candidate_arn; do
+        if [ -n "$candidate_arn" ] && [ "$candidate_arn" != "None" ]; then
+            matching_arns+=("$candidate_arn")
+        fi
+    done < <(printf '%s\n' "$matching_output" | tr '\t' '\n')
+
+    if [ "${#matching_arns[@]}" -eq 0 ]; then
+        return 1
+    fi
+
+    if [ "${#matching_arns[@]}" -ne 1 ]; then
+        echo "Expected exactly one CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX'; found ${#matching_arns[@]}." >&2
+        printf '  %s\n' "${matching_arns[@]}" >&2
+        return 2
+    fi
+
+    printf '%s\n' "${matching_arns[0]}"
+}
+
+apply_tags() {
+    local attempt
+    local output
+    local resolve_status
+    local resource_arn
+    local max_attempts=60
+    local retry_seconds=15
+
+    if [ "$TAG_COUNT" -eq 0 ]; then
+        echo "No CloudWatch Metric Stream tags to apply."
+        return 0
+    fi
+
+    : "${TAGS_JSON:?TAGS_JSON must be set when applying tags}"
+
+    for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+        resource_arn=""
+
+        if resource_arn="$(resolve_metric_stream_arn)"; then
+            echo "Applying $TAG_COUNT tag(s) to CloudWatch Metric Stream: $resource_arn"
+
+            if output="$(aws cloudwatch tag-resource \
+                --region "$AWS_REGION" \
+                --resource-arn "$resource_arn" \
+                --tags "$TAGS_JSON" 2>&1)"; then
+                return 0
+            fi
+
+            if [[ "$output" != *"ResourceNotFoundException"* ]]; then
+                echo "$output" >&2
+                return 1
+            fi
+        else
+            resolve_status="$?"
+            if [ "$resolve_status" -ne 1 ]; then
+                return "$resolve_status"
+            fi
+        fi
+
+        if [ "$attempt" -eq "$max_attempts" ]; then
+            echo "CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX' was not available after $max_attempts attempts." >&2
+            return 1
+        fi
+
+        echo "CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX' is not available yet; retrying in $retry_seconds seconds."
+        sleep "$retry_seconds"
+    done
+}
+
+remove_tags() {
+    local output
+    local resolve_status
+    local resource_arn
+
+    if [ "$TAG_COUNT" -eq 0 ]; then
+        echo "No CloudWatch Metric Stream tags to remove."
+        return 0
+    fi
+
+    : "${TAG_KEYS_JSON:?TAG_KEYS_JSON must be set when removing tags}"
+    resource_arn=""
+
+    if resource_arn="$(resolve_metric_stream_arn)"; then
+        :
+    else
+        resolve_status="$?"
+
+        if [ "$resolve_status" -eq 1 ]; then
+            echo "CloudWatch Metric Stream no longer exists; no tags remain to remove."
+            return 0
+        fi
+
+        return "$resolve_status"
+    fi
+
+    echo "Removing previously managed tags from CloudWatch Metric Stream: $resource_arn"
+
+    if output="$(aws cloudwatch untag-resource \
+        --region "$AWS_REGION" \
+        --resource-arn "$resource_arn" \
+        --tag-keys "$TAG_KEYS_JSON" 2>&1)"; then
+        return 0
+    fi
+
+    if [[ "$output" == *"ResourceNotFoundException"* ]]; then
+        echo "CloudWatch Metric Stream no longer exists; no tags remain to remove."
+        return 0
+    fi
+
+    echo "$output" >&2
+    return 1
+}
+
+main() {
+    if [ "$#" -ne 1 ]; then
+        usage
+        return 2
+    fi
+
+    case "$1" in
+    apply | remove) ;;
+    *)
+        usage
+        return 2
+        ;;
+    esac
+
+    require_common_environment
+
+    case "$1" in
+    apply)
+        apply_tags
+        ;;
+    remove)
+        remove_tags
+        ;;
+    esac
+}
+
+main "$@"

--- a/modules/integrations/splunk_o11y_aws_integration/tests/integrations_splunk_o11y_aws_integration_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_aws_integration/tests/integrations_splunk_o11y_aws_integration_source_inventory.tftest.hcl
@@ -14,13 +14,11 @@ run "integrations_splunk_o11y_aws_integration_contract" {
       "data \"aws_secretsmanager_secret_version\" \"secrets\"",
       "provider \"aws\"",
       "AWS_PROFILE",
-      "aws cloudwatch list-metric-streams",
-      "aws cloudwatch tag-resource",
-      "aws cloudwatch untag-resource",
-      "starts_with(Name, '$STREAM_NAME_PREFIX')",
-      "Expected exactly one CloudWatch Metric Stream",
+      "working_dir = path.module",
+      "./scripts/manage_cloudwatch_metric_stream_tags.sh apply",
+      "./scripts/manage_cloudwatch_metric_stream_tags.sh remove",
+      "filesha256(\"$${path.module}/scripts/manage_cloudwatch_metric_stream_tags.sh\")",
       "sha256(jsonencode(local.all_security_tags))",
-      "ResourceNotFoundException",
     ]
   }
 

--- a/modules/integrations/splunk_o11y_aws_integration/tests/integrations_splunk_o11y_aws_integration_source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_aws_integration/tests/integrations_splunk_o11y_aws_integration_source_inventory.tftest.hcl
@@ -9,9 +9,18 @@ run "integrations_splunk_o11y_aws_integration_contract" {
     module_path = "."
     expected_literals = [
       "resource \"aws_cloudformation_stack\" \"splunk_integration\"",
+      "resource \"terraform_data\" \"cloudwatch_metric_stream_tags\"",
       "data \"aws_secretsmanager_secret\" \"secrets\"",
       "data \"aws_secretsmanager_secret_version\" \"secrets\"",
       "provider \"aws\"",
+      "AWS_PROFILE",
+      "aws cloudwatch list-metric-streams",
+      "aws cloudwatch tag-resource",
+      "aws cloudwatch untag-resource",
+      "starts_with(Name, '$STREAM_NAME_PREFIX')",
+      "Expected exactly one CloudWatch Metric Stream",
+      "sha256(jsonencode(local.all_security_tags))",
+      "ResourceNotFoundException",
     ]
   }
 

--- a/modules/integrations/splunk_o11y_aws_integration/tests/splunk_o11y_aws_integration_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_aws_integration/tests/splunk_o11y_aws_integration_behavior.tftest.hcl
@@ -78,11 +78,12 @@ run "splunk_o11y_cloudformation_stack_contract" {
 
   assert {
     condition = (
-      length(terraform_data.cloudwatch_metric_stream_tags.triggers_replace) == 3
+      length(terraform_data.cloudwatch_metric_stream_tags.triggers_replace) == 4
       && terraform_data.cloudwatch_metric_stream_tags.triggers_replace[0] == terraform_data.cloudwatch_metric_stream_tags.input.stack_id
       && terraform_data.cloudwatch_metric_stream_tags.triggers_replace[1] == "https://example.com/splunk-integration.yaml"
-      && terraform_data.cloudwatch_metric_stream_tags.triggers_replace[2] == sha256(jsonencode(terraform_data.cloudwatch_metric_stream_tags.input.tags))
+      && terraform_data.cloudwatch_metric_stream_tags.triggers_replace[2] == filesha256("${path.module}/scripts/manage_cloudwatch_metric_stream_tags.sh")
+      && terraform_data.cloudwatch_metric_stream_tags.triggers_replace[3] == sha256(jsonencode(terraform_data.cloudwatch_metric_stream_tags.input.tags))
     )
-    error_message = "Metric Stream tag management must replace on stack, template, or desired-tag changes."
+    error_message = "Metric Stream tag management must replace on stack, template, script, or desired-tag changes."
   }
 }

--- a/modules/integrations/splunk_o11y_aws_integration/tests/splunk_o11y_aws_integration_behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_aws_integration/tests/splunk_o11y_aws_integration_behavior.tftest.hcl
@@ -11,6 +11,20 @@ mock_provider "aws" {
       secret_string = "mock-splunk-access-token"
     }
   }
+
+  mock_resource "aws_servicecatalogappregistry_application" {
+    defaults = {
+      application_tag = {
+        awsApplication = "arn:aws:resource-groups:us-east-1:123456789012:group/splunk-o11y"
+      }
+    }
+  }
+
+  mock_resource "aws_cloudformation_stack" {
+    defaults = {
+      id = "arn:aws:cloudformation:us-east-1:123456789012:stack/splunk-integration/mock-stack-id"
+    }
+  }
 }
 
 variables {
@@ -47,5 +61,28 @@ run "splunk_o11y_cloudformation_stack_contract" {
       && aws_cloudformation_stack.splunk_integration.tags.Env == "test"
     )
     error_message = "Splunk o11y AWS integration stack must keep IAM capabilities and merged Forge tags."
+  }
+
+  assert {
+    condition = (
+      terraform_data.cloudwatch_metric_stream_tags.input.aws_profile == "test"
+      && terraform_data.cloudwatch_metric_stream_tags.input.region == "us-east-1"
+      && terraform_data.cloudwatch_metric_stream_tags.input.stack_id == "arn:aws:cloudformation:us-east-1:123456789012:stack/splunk-integration/mock-stack-id"
+      && terraform_data.cloudwatch_metric_stream_tags.input.stream_name_prefix == "splunk-metric-stream-"
+      && terraform_data.cloudwatch_metric_stream_tags.input.tags.Product == "Forge"
+      && terraform_data.cloudwatch_metric_stream_tags.input.tags.Env == "test"
+      && terraform_data.cloudwatch_metric_stream_tags.input.tags.awsApplication == "arn:aws:resource-groups:us-east-1:123456789012:group/splunk-o11y"
+    )
+    error_message = "Metric Stream tag management must retain the stack identity, configured profile and region, discovery prefix, and merged Forge tags."
+  }
+
+  assert {
+    condition = (
+      length(terraform_data.cloudwatch_metric_stream_tags.triggers_replace) == 3
+      && terraform_data.cloudwatch_metric_stream_tags.triggers_replace[0] == terraform_data.cloudwatch_metric_stream_tags.input.stack_id
+      && terraform_data.cloudwatch_metric_stream_tags.triggers_replace[1] == "https://example.com/splunk-integration.yaml"
+      && terraform_data.cloudwatch_metric_stream_tags.triggers_replace[2] == sha256(jsonencode(terraform_data.cloudwatch_metric_stream_tags.input.tags))
+    )
+    error_message = "Metric Stream tag management must replace on stack, template, or desired-tag changes."
   }
 }

--- a/tests/iac/README.md
+++ b/tests/iac/README.md
@@ -3,15 +3,16 @@
 ## What This Is
 
 `tests/iac` contains Python contract tests that inspect Terraform and Lambda
-source files without initializing providers or contacting AWS.
+source files and exercise infrastructure helper scripts with fake CLIs. They do
+not initialize providers or contact AWS.
 
 ## Why It Is Used
 
-These tests pin Forge contracts that cross the HCL/Python boundary: Lambda
-environment variables, event-source wiring, queue and bucket assumptions, and
-other module-to-handler interfaces. They catch changes where Terraform stops
-providing something the handler requires, or where a handler starts requiring
-something Terraform does not set.
+These tests pin Forge contracts that cross source boundaries: Lambda environment
+variables, event-source wiring, queue and bucket assumptions, module-to-handler
+interfaces, and local provisioning-script behavior. They catch changes where
+Terraform stops providing something a helper requires or a helper no longer
+handles its lifecycle edge cases safely.
 
 ## CI Execution
 

--- a/tests/iac/splunk_metric_stream_tags_script_test.py
+++ b/tests/iac/splunk_metric_stream_tags_script_test.py
@@ -1,0 +1,304 @@
+"""Hermetic tests for the Splunk Metric Stream tag helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.contract
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / (
+    'modules/integrations/splunk_o11y_aws_integration'
+)
+SCRIPT_RELATIVE_PATH = Path('scripts/manage_cloudwatch_metric_stream_tags.sh')
+TERRAFORM_PATH = MODULE_PATH / 'metric_stream_tags.tf'
+METRIC_STREAM_ARN = (
+    'arn:aws:cloudwatch:us-east-1:123456789012:'
+    'metric-stream/splunk-metric-stream-test'
+)
+
+FAKE_AWS = '''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+scenario = os.environ['FAKE_AWS_SCENARIO']
+log_path = Path(os.environ['FAKE_AWS_LOG'])
+state_path = Path(os.environ['FAKE_AWS_STATE'])
+arn = os.environ['FAKE_METRIC_STREAM_ARN']
+
+with log_path.open('a', encoding='utf-8') as log:
+    log.write(json.dumps(sys.argv[1:]) + '\\n')
+
+if sys.argv[1] != 'cloudwatch':
+    raise SystemExit(99)
+
+operation = sys.argv[2]
+
+if operation == 'list-metric-streams':
+    if scenario == 'missing':
+        print('None')
+    elif scenario == 'multiple':
+        print(f'{arn}\\t{arn}-second')
+    elif scenario == 'list-error':
+        print('ListMetricStreams failed', file=sys.stderr)
+        raise SystemExit(9)
+    else:
+        print(arn)
+elif operation == 'tag-resource':
+    if scenario == 'tag-race' and not state_path.exists():
+        state_path.write_text('retried', encoding='utf-8')
+        print('ResourceNotFoundException', file=sys.stderr)
+        raise SystemExit(1)
+    if scenario == 'tag-error':
+        print('AccessDeniedException', file=sys.stderr)
+        raise SystemExit(1)
+elif operation == 'untag-resource':
+    if scenario == 'untag-missing':
+        print('ResourceNotFoundException', file=sys.stderr)
+        raise SystemExit(1)
+    if scenario == 'untag-error':
+        print('AccessDeniedException', file=sys.stderr)
+        raise SystemExit(1)
+else:
+    raise SystemExit(98)
+'''
+
+
+def run_script(
+    tmp_path: Path,
+    mode: str,
+    scenario: str = 'success',
+    tag_count: int = 1,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    fake_aws = bin_dir / 'aws'
+    fake_aws.write_text(FAKE_AWS, encoding='utf-8')
+    fake_aws.chmod(0o755)
+    fake_sleep = bin_dir / 'sleep'
+    fake_sleep.write_text('#!/usr/bin/env bash\nexit 0\n', encoding='utf-8')
+    fake_sleep.chmod(0o755)
+
+    log_path = tmp_path / 'aws-calls.jsonl'
+    env = os.environ.copy()
+    env.update(
+        {
+            'AWS_PAGER': '',
+            'AWS_PROFILE': 'test',
+            'AWS_REGION': 'us-east-1',
+            'FAKE_AWS_LOG': str(log_path),
+            'FAKE_AWS_SCENARIO': scenario,
+            'FAKE_AWS_STATE': str(tmp_path / 'aws-state'),
+            'FAKE_METRIC_STREAM_ARN': METRIC_STREAM_ARN,
+            'PATH': f'{bin_dir}:{env["PATH"]}',
+            'STREAM_NAME_PREFIX': 'splunk-metric-stream-',
+            'TAG_COUNT': str(tag_count),
+            'TAGS_JSON': '[{"Key":"Env","Value":"test"}]',
+            'TAG_KEYS_JSON': '["Env"]',
+        }
+    )
+    if extra_env:
+        env.update(extra_env)
+
+    result = subprocess.run(
+        [f'./{SCRIPT_RELATIVE_PATH.as_posix()}', mode],
+        check=False,
+        cwd=MODULE_PATH,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    calls = []
+    if log_path.exists():
+        calls = [
+            json.loads(line)
+            for line in log_path.read_text(encoding='utf-8').splitlines()
+        ]
+    return result, calls
+
+
+def test_apply_tags_the_single_matching_stream(tmp_path: Path) -> None:
+    result, calls = run_script(tmp_path, 'apply')
+
+    assert result.returncode == 0
+    assert [call[1] for call in calls] == [
+        'list-metric-streams',
+        'tag-resource',
+    ]
+    assert calls[0] == [
+        'cloudwatch',
+        'list-metric-streams',
+        '--region',
+        'us-east-1',
+        '--query',
+        "Entries[?starts_with(Name, 'splunk-metric-stream-')].Arn",
+        '--output',
+        'text',
+    ]
+    assert calls[1] == [
+        'cloudwatch',
+        'tag-resource',
+        '--region',
+        'us-east-1',
+        '--resource-arn',
+        METRIC_STREAM_ARN,
+        '--tags',
+        '[{"Key":"Env","Value":"test"}]',
+    ]
+    assert METRIC_STREAM_ARN in result.stdout
+
+
+def test_remove_untags_the_single_matching_stream(tmp_path: Path) -> None:
+    result, calls = run_script(tmp_path, 'remove')
+
+    assert result.returncode == 0
+    assert [call[1] for call in calls] == [
+        'list-metric-streams',
+        'untag-resource',
+    ]
+    assert calls[1] == [
+        'cloudwatch',
+        'untag-resource',
+        '--region',
+        'us-east-1',
+        '--resource-arn',
+        METRIC_STREAM_ARN,
+        '--tag-keys',
+        '["Env"]',
+    ]
+    assert METRIC_STREAM_ARN in result.stdout
+
+
+@pytest.mark.parametrize('mode', ['apply', 'remove'])
+def test_ambiguous_stream_matches_fail_safely(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    result, calls = run_script(tmp_path, mode, scenario='multiple')
+
+    assert result.returncode == 2
+    assert [call[1] for call in calls] == ['list-metric-streams']
+    assert 'Expected exactly one CloudWatch Metric Stream' in result.stderr
+    assert 'found 2' in result.stderr
+
+
+def test_apply_retries_until_the_stream_is_available(tmp_path: Path) -> None:
+    result, calls = run_script(tmp_path, 'apply', scenario='missing')
+
+    assert result.returncode == 1
+    assert [call[1] for call in calls] == ['list-metric-streams'] * 60
+    assert 'was not available after 60 attempts' in result.stderr
+
+
+def test_apply_retries_a_tag_resource_not_found_race(tmp_path: Path) -> None:
+    result, calls = run_script(tmp_path, 'apply', scenario='tag-race')
+
+    assert result.returncode == 0
+    assert [call[1] for call in calls] == [
+        'list-metric-streams',
+        'tag-resource',
+        'list-metric-streams',
+        'tag-resource',
+    ]
+
+
+def test_remove_accepts_an_already_missing_stream(tmp_path: Path) -> None:
+    result, calls = run_script(tmp_path, 'remove', scenario='missing')
+
+    assert result.returncode == 0
+    assert [call[1] for call in calls] == ['list-metric-streams']
+    assert 'no tags remain to remove' in result.stdout
+
+
+def test_remove_accepts_resource_not_found_from_untag(tmp_path: Path) -> None:
+    result, calls = run_script(tmp_path, 'remove', scenario='untag-missing')
+
+    assert result.returncode == 0
+    assert [call[1] for call in calls] == [
+        'list-metric-streams',
+        'untag-resource',
+    ]
+    assert 'no tags remain to remove' in result.stdout
+
+
+def test_remove_ignores_apply_retry_controls(tmp_path: Path) -> None:
+    result, calls = run_script(
+        tmp_path,
+        'remove',
+        extra_env={
+            'METRIC_STREAM_MAX_ATTEMPTS': 'invalid',
+            'METRIC_STREAM_RETRY_SECONDS': 'invalid',
+        },
+    )
+
+    assert result.returncode == 0
+    assert [call[1] for call in calls] == [
+        'list-metric-streams',
+        'untag-resource',
+    ]
+
+
+@pytest.mark.parametrize(
+    ('mode', 'scenario'),
+    [('apply', 'tag-error'), ('remove', 'untag-error')],
+)
+def test_tag_permission_failures_are_not_ignored(
+    tmp_path: Path,
+    mode: str,
+    scenario: str,
+) -> None:
+    result, calls = run_script(tmp_path, mode, scenario=scenario)
+
+    assert result.returncode == 1
+    assert len(calls) == 2
+    assert 'AccessDeniedException' in result.stderr
+
+
+@pytest.mark.parametrize('mode', ['apply', 'remove'])
+def test_list_metric_stream_failures_are_not_ignored(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    result, calls = run_script(tmp_path, mode, scenario='list-error')
+
+    assert result.returncode == 2
+    assert [call[1] for call in calls] == ['list-metric-streams']
+    assert 'ListMetricStreams failed' in result.stderr
+
+
+@pytest.mark.parametrize('mode', ['apply', 'remove'])
+def test_zero_tags_do_not_call_aws(tmp_path: Path, mode: str) -> None:
+    result, calls = run_script(tmp_path, mode, tag_count=0)
+
+    assert result.returncode == 0
+    assert calls == []
+    assert f'No CloudWatch Metric Stream tags to {mode}' in result.stdout
+
+
+def test_invalid_mode_is_rejected_without_calling_aws(tmp_path: Path) -> None:
+    result, calls = run_script(tmp_path, 'invalid')
+
+    assert result.returncode == 2
+    assert calls == []
+    assert 'Usage:' in result.stderr
+
+
+def test_terraform_runs_both_modes_from_the_module_directory() -> None:
+    terraform_source = TERRAFORM_PATH.read_text(encoding='utf-8')
+
+    assert terraform_source.count('working_dir = path.module') == 2
+    assert './scripts/manage_cloudwatch_metric_stream_tags.sh apply' in (
+        terraform_source
+    )
+    assert './scripts/manage_cloudwatch_metric_stream_tags.sh remove' in (
+        terraform_source
+    )

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -346,6 +346,7 @@ def test_test_suites_have_named_ci_jobs() -> None:
         'pytest -q iac',
         'tofu -chdir="${module}" test -no-color',
         'conftest verify --policy policy/opa',
+        'modules/**/*.sh',
         'tests/iac/**',
         'tests/tofu/**',
     ]:


### PR DESCRIPTION
## Description

Apply the merged Forge security tags to the regional Splunk-managed CloudWatch Metric Stream.

The module now:

- discovers exactly one stream in the configured AWS region whose name starts with `splunk-metric-stream-`;
- waits up to 15 minutes for Splunk's asynchronous stream creation;
- fails safely if multiple streams match instead of tagging an arbitrary resource;
- reapplies tags when the CloudFormation stack, template, helper script, or desired tags change;
- removes previously managed tag keys during replacement and destroy;
- keeps the shared apply/remove behavior in a tested module-local Bash script;
- uses the configured AWS profile and requires no new module input.

The deployment identity needs `cloudwatch:ListMetricStreams`, `cloudwatch:TagResource`, and `cloudwatch:UntagResource`.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: _________

## Testing

- `tofu validate -no-color`
- `tofu test -no-color` — 3 passed
- `.venv/bin/pytest -q tests/iac` — 41 passed
- ShellCheck, shfmt, and bashate through repository pre-commit hooks
- Checkov — 0 failed checks
- Full repository pre-commit suite during commit
