### PR TITLE
chore(deps): manage Lambda layer revisions with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -195,20 +195,7 @@
             ]
         },
         {
-            "description": "GitHub Actions - pin to commit SHA for security",
-            "matchManagers": [
-                "github-actions"
-            ],
-            "groupName": "GitHub Actions dependencies",
-            "groupSlug": "github-actions-dependencies",
-            "addLabels": [
-                "dependencies",
-                "github-actions",
-                "ci-cd"
-            ]
-        },
-        {
-            "description": "Pin executable GitHub Action and container references",
+            "description": "Group and SHA-pin executable GitHub workflow dependencies by update type",
             "matchManagers": [
                 "github-actions"
             ],
@@ -218,7 +205,16 @@
                 "docker",
                 "service"
             ],
-            "pinDigests": true
+            "pinDigests": true,
+            "groupName": "GitHub Actions {{{updateType}}} dependencies",
+            "groupSlug": "github-actions-{{{updateType}}}-dependencies",
+            "separateMajorMinor": false,
+            "separateMinorPatch": false,
+            "addLabels": [
+                "dependencies",
+                "github-actions",
+                "ci-cd"
+            ]
         },
         {
             "description": "Pre-commit hook dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
         {
             "customType": "regex",
             "fileMatch": [
-                "^*\\.tf$"
+                "^.*\\.tf$"
             ],
             "matchStrings": [
                 "required_version\\s=\\s\">= (?<currentValue>.*?)\""
@@ -73,19 +73,6 @@
           "fileMatch": ["Dockerfile$"],
           "matchStrings": ["# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) registryUrl=(?<registryUrl>\\S+)( extractVersion=(?<extractVersion>.+?))?( versioning=(?<versioning>.*?))?\\n.*?VERSION=\"(?<currentValue>.*)?\"\\s"],
           "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-        },
-        {
-            "customType": "regex",
-            "description": "Update SHA-pinned pre-commit hook refs from frozen tag comments",
-            "fileMatch": [
-                "(^|/)\\.pre-commit-config\\.ya?ml$"
-            ],
-            "matchStrings": [
-                "(?<lineStart>^|\\r\\n|\\r|\\n)(?<indentation>[ \\t]*)- repo: (?<repoUrl>https?://github\\.com/(?<packageName>[^\\s]+?)(?:\\.git)?)\\s+rev: (?<currentDigest>[a-f0-9]{40})\\s+# frozen: (?<currentValue>\\S+)"
-            ],
-            "datasourceTemplate": "github-tags",
-            "versioningTemplate": "semver-coerced",
-            "autoReplaceStringTemplate": "{{{lineStart}}}{{{indentation}}}- repo: {{{repoUrl}}}\n{{{indentation}}}  rev: {{{newDigest}}}  # frozen: {{{newValue}}}"
         },
         {
             "customType": "regex",
@@ -212,7 +199,6 @@
             "matchManagers": [
                 "github-actions"
             ],
-            "pinDigests": true,
             "groupName": "GitHub Actions dependencies",
             "groupSlug": "github-actions-dependencies",
             "addLabels": [
@@ -220,6 +206,19 @@
                 "github-actions",
                 "ci-cd"
             ]
+        },
+        {
+            "description": "Pin executable GitHub Action and container references",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchDepTypes": [
+                "action",
+                "container",
+                "docker",
+                "service"
+            ],
+            "pinDigests": true
         },
         {
             "description": "Pre-commit hook dependencies",
@@ -234,19 +233,14 @@
             ]
         },
         {
-            "description": "SHA-pinned pre-commit hooks",
+            "description": "Ignore digest-only refreshes for frozen pre-commit hooks",
             "matchManagers": [
-                "custom.regex"
-            ],
-            "matchFileNames": [
-                ".pre-commit-config.yaml"
-            ],
-            "groupName": "Pre-commit dependencies",
-            "groupSlug": "pre-commit-dependencies",
-            "addLabels": [
-                "dependencies",
                 "pre-commit"
-            ]
+            ],
+            "matchUpdateTypes": [
+                "digest"
+            ],
+            "enabled": false
         },
         {
             "description": "Python dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,7 @@
     "stabilityDays": 0,
     "separateMinorPatch": true,
     "separateMajorMinor": true,
+    "useBaseBranchConfig": "merge",
     "ignorePaths": [
         "**/.terraform/**"
     ],

--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,21 @@
     "lockFileMaintenance": {
         "enabled": true
     },
+    "customDatasources": {
+        "klayers": {
+            "defaultRegistryUrlTemplate": "https://api.klayers.cloud/api/v2/{{{packageName}}}",
+            "transformTemplates": [
+                "{ \"releases\": $map($, function($layer) { { \"version\": $split($layer.arn, \":\")[-1], \"isDeprecated\": $layer.deployStatus = \"deprecated\" } }), \"homepage\": \"https://klayers.cloud\", \"sourceUrl\": \"https://github.com/keithrozario/Klayers\" }"
+            ]
+        },
+        "aws-sdk-pandas-layers": {
+            "defaultRegistryUrlTemplate": "https://aws-sdk-pandas.readthedocs.io/en/stable/_sources/layers.rst.txt",
+            "format": "plain",
+            "transformTemplates": [
+                "{ \"releases\": [releases[$contains(version, \"{{{packageName}}}:\")].{ \"version\": $trim($substringBefore($substringAfter(version, \"{{{packageName}}}:\"), \"|\")) }], \"homepage\": \"https://aws-sdk-pandas.readthedocs.io/en/stable/layers.html\", \"sourceUrl\": \"https://github.com/aws/aws-sdk-pandas\" }"
+            ]
+        }
+    },
     "customManagers": [
         {
             "customType": "regex",
@@ -71,6 +86,36 @@
             "datasourceTemplate": "github-tags",
             "versioningTemplate": "semver-coerced",
             "autoReplaceStringTemplate": "{{{lineStart}}}{{{indentation}}}- repo: {{{repoUrl}}}\n{{{indentation}}}  rev: {{{newDigest}}}  # frozen: {{{newValue}}}"
+        },
+        {
+            "customType": "regex",
+            "description": "Update KLayers Lambda layer revisions; use us-east-1 as the catalog for interpolated regions",
+            "fileMatch": [
+                "^.*\\.tf$"
+            ],
+            "matchStrings": [
+                "arn:aws:lambda:(?<lookupRegion>[a-z]{2}(?:-gov)?-[a-z]+-\\d):770693421928:layer:Klayers-p(?<pythonMajor>\\d)(?<pythonMinor>\\d{1,2})(?<architecture>-arm64)?-(?<layerPackage>[A-Za-z0-9._-]+):(?<currentValue>\\d+)",
+                "arn:aws:lambda:\\$\\{[^}]+\\}:770693421928:layer:Klayers-p(?<pythonMajor>\\d)(?<pythonMinor>\\d{1,2})(?<architecture>-arm64)?-(?<layerPackage>[A-Za-z0-9._-]+):(?<currentValue>\\d+)"
+            ],
+            "depNameTemplate": "KLayers {{{layerPackage}}} for Python {{{pythonMajor}}}.{{{pythonMinor}}}{{{architecture}}}",
+            "packageNameTemplate": "p{{{pythonMajor}}}.{{{pythonMinor}}}{{{architecture}}}/layers/{{#if lookupRegion}}{{{lookupRegion}}}{{else}}us-east-1{{/if}}/{{{layerPackage}}}",
+            "datasourceTemplate": "custom.klayers",
+            "versioningTemplate": "regex:^(?<patch>\\d+)$"
+        },
+        {
+            "customType": "regex",
+            "description": "Update AWS SDK for pandas Lambda layer revisions; use us-east-1 as the catalog for interpolated regions",
+            "fileMatch": [
+                "^.*\\.tf$"
+            ],
+            "matchStrings": [
+                "arn:(?<partition>aws(?:-[a-z]+)*):lambda:(?<lookupRegion>[a-z]{2}(?:-gov)?-[a-z]+-\\d):(?<publisherAccount>\\d{12}):layer:(?<layerName>AWSSDKPandas-Python\\d+(?:-Arm64)?):(?<currentValue>\\d+)",
+                "arn:aws:lambda:\\$\\{[^}]+\\}:(?<publisherAccount>\\d{12}):layer:(?<layerName>AWSSDKPandas-Python\\d+(?:-Arm64)?):(?<currentValue>\\d+)"
+            ],
+            "depNameTemplate": "AWS SDK for pandas {{{layerName}}}",
+            "packageNameTemplate": "arn:{{#if partition}}{{{partition}}}{{else}}aws{{/if}}:lambda:{{#if lookupRegion}}{{{lookupRegion}}}{{else}}us-east-1{{/if}}:{{{publisherAccount}}}:layer:{{{layerName}}}",
+            "datasourceTemplate": "custom.aws-sdk-pandas-layers",
+            "versioningTemplate": "regex:^(?<patch>\\d+)$"
         }
       ],
     "packageRules": [
@@ -82,6 +127,10 @@
             "matchUpdateTypes": [
                 "patch",
                 "minor"
+            ],
+            "matchDatasources": [
+                "!custom.klayers",
+                "!custom.aws-sdk-pandas-layers"
             ],
             "vulnerabilityAlerts": {
                 "enabled": true
@@ -99,6 +148,10 @@
                 "patch",
                 "pin",
                 "digest"
+            ],
+            "matchDatasources": [
+                "!custom.klayers",
+                "!custom.aws-sdk-pandas-layers"
             ],
             "addLabels": [
                 "simple-review"
@@ -300,6 +353,10 @@
             "matchUpdateTypes": [
                 "patch"
             ],
+            "matchDatasources": [
+                "!custom.klayers",
+                "!custom.aws-sdk-pandas-layers"
+            ],
             "vulnerabilityAlerts": {
                 "enabled": true
             },
@@ -318,8 +375,23 @@
             ],
             "groupName": "terraform-aws-github-runner version",
             "groupSlug": "terraform-aws-github-runner",
-            "separateMajorMinor": false,
-            "separateMinorPatch": false
+            "separateMajorMinor": true,
+            "separateMinorPatch": true
+        },
+        {
+            "description": "Group AWS Lambda layer revision updates without automerge",
+            "matchDatasources": [
+                "custom.klayers",
+                "custom.aws-sdk-pandas-layers"
+            ],
+            "groupName": "AWS Lambda layers",
+            "groupSlug": "aws-lambda-layers",
+            "minimumReleaseAge": null,
+            "automerge": false,
+            "addLabels": [
+                "dependencies",
+                "lambda-layers"
+            ]
         }
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -377,6 +377,7 @@
             ],
             "groupName": "AWS Lambda layers",
             "groupSlug": "aws-lambda-layers",
+            "prPriority": 20,
             "minimumReleaseAge": null,
             "automerge": false,
             "addLabels": [

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -132,30 +132,39 @@ def test_renovate_pre_commit_hooks_have_single_update_owner() -> None:
     assert all(frozen_revision.match(line) for line in revision_lines)
 
 
-def test_renovate_only_pins_executable_github_action_dependencies() -> None:
+def test_renovate_groups_and_pins_executable_github_action_dependencies() -> None:
     config = json.loads(read('renovate.json'))
-    github_actions_rules = [
-        rule
-        for rule in config['packageRules']
-        if rule.get('matchManagers') == ['github-actions']
-    ]
-    group_rule = next(
-        rule
-        for rule in github_actions_rules
-        if rule.get('groupSlug') == 'github-actions-dependencies'
-    )
-    pin_rule = next(
-        rule for rule in github_actions_rules if rule.get('pinDigests') is True
-    )
-
-    assert 'pinDigests' not in group_rule
-    assert set(pin_rule['matchDepTypes']) == {
+    executable_dep_types = {
         'action',
         'container',
         'docker',
         'service',
     }
-    assert 'uses-with' not in pin_rule['matchDepTypes']
+    github_actions_rules = [
+        rule
+        for rule in config['packageRules']
+        if rule.get('matchManagers') == ['github-actions']
+    ]
+    executable_group_rules = [
+        rule
+        for rule in github_actions_rules
+        if rule.get('matchDepTypes')
+    ]
+    assert len(executable_group_rules) == 1
+    assert github_actions_rules == executable_group_rules
+    group_rule = executable_group_rules[0]
+
+    assert set(group_rule['matchDepTypes']) == executable_dep_types
+    assert group_rule['pinDigests'] is True
+    assert group_rule['groupName'] == (
+        'GitHub Actions {{{updateType}}} dependencies'
+    )
+    assert group_rule['groupSlug'] == (
+        'github-actions-{{{updateType}}}-dependencies'
+    )
+    assert group_rule['separateMajorMinor'] is False
+    assert group_rule['separateMinorPatch'] is False
+    assert 'uses-with' not in group_rule['matchDepTypes']
 
 
 def test_renovate_manages_supported_lambda_layer_arns() -> None:

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -347,6 +347,7 @@ def test_renovate_manages_supported_lambda_layer_arns() -> None:
     assert set(layer_rule['matchDatasources']) == set(managers)
     assert layer_rule['automerge'] is False
     assert layer_rule['minimumReleaseAge'] is None
+    assert layer_rule['prPriority'] == 20
 
     inherited_patch_policy = {
         'security',

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -84,6 +84,12 @@ def test_renovate_groups_runner_updates_by_semver_level() -> None:
     assert runner_rule['separateMinorPatch'] is True
 
 
+def test_renovate_merges_config_from_selected_base_branch() -> None:
+    config = json.loads(read('renovate.json'))
+
+    assert config['useBaseBranchConfig'] == 'merge'
+
+
 def test_renovate_pre_commit_hooks_have_single_update_owner() -> None:
     config = json.loads(read('renovate.json'))
     pre_commit_path = '.pre-commit-config.yaml'

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -84,6 +84,80 @@ def test_renovate_groups_runner_updates_by_semver_level() -> None:
     assert runner_rule['separateMinorPatch'] is True
 
 
+def test_renovate_pre_commit_hooks_have_single_update_owner() -> None:
+    config = json.loads(read('renovate.json'))
+    pre_commit_path = '.pre-commit-config.yaml'
+
+    assert config['pre-commit']['enabled'] is True
+
+    overlapping_custom_managers = [
+        manager.get('description', '<unnamed>')
+        for manager in config['customManagers']
+        if any(
+            re.search(file_pattern, pre_commit_path)
+            for file_pattern in manager.get('fileMatch', [])
+        )
+    ]
+    assert overlapping_custom_managers == []
+
+    group_rules = [
+        rule
+        for rule in config['packageRules']
+        if rule.get('groupSlug') == 'pre-commit-dependencies'
+    ]
+    assert len(group_rules) == 1
+    assert group_rules[0]['matchManagers'] == ['pre-commit']
+    assert 'pinDigests' not in group_rules[0]
+
+    digest_rule = next(
+        rule
+        for rule in config['packageRules']
+        if rule.get('description') == (
+            'Ignore digest-only refreshes for frozen pre-commit hooks'
+        )
+    )
+    assert digest_rule['matchManagers'] == ['pre-commit']
+    assert digest_rule['matchUpdateTypes'] == ['digest']
+    assert digest_rule['enabled'] is False
+
+    frozen_revision = re.compile(
+        r'^\s*rev: [a-f0-9]{40}\s+# frozen: \S+$',
+    )
+    revision_lines = [
+        line
+        for line in read(pre_commit_path).splitlines()
+        if line.lstrip().startswith('rev:')
+    ]
+    assert revision_lines
+    assert all(frozen_revision.match(line) for line in revision_lines)
+
+
+def test_renovate_only_pins_executable_github_action_dependencies() -> None:
+    config = json.loads(read('renovate.json'))
+    github_actions_rules = [
+        rule
+        for rule in config['packageRules']
+        if rule.get('matchManagers') == ['github-actions']
+    ]
+    group_rule = next(
+        rule
+        for rule in github_actions_rules
+        if rule.get('groupSlug') == 'github-actions-dependencies'
+    )
+    pin_rule = next(
+        rule for rule in github_actions_rules if rule.get('pinDigests') is True
+    )
+
+    assert 'pinDigests' not in group_rule
+    assert set(pin_rule['matchDepTypes']) == {
+        'action',
+        'container',
+        'docker',
+        'service',
+    }
+    assert 'uses-with' not in pin_rule['matchDepTypes']
+
+
 def test_renovate_manages_supported_lambda_layer_arns() -> None:
     config = json.loads(read('renovate.json'))
     managers = {

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import re
 import tomllib
 from pathlib import Path
@@ -67,6 +68,225 @@ def dependency_group_names(group_name: str) -> set[str]:
         )[0].lower()
         for dependency in dependencies
     }
+
+
+def test_renovate_groups_runner_updates_by_semver_level() -> None:
+    config = json.loads(read('renovate.json'))
+    runner_rule = next(
+        rule
+        for rule in config['packageRules']
+        if rule.get('groupSlug') == 'terraform-aws-github-runner'
+    )
+
+    assert config['separateMajorMinor'] is True
+    assert config['separateMinorPatch'] is True
+    assert runner_rule['separateMajorMinor'] is True
+    assert runner_rule['separateMinorPatch'] is True
+
+
+def test_renovate_manages_supported_lambda_layer_arns() -> None:
+    config = json.loads(read('renovate.json'))
+    managers = {
+        manager.get('datasourceTemplate'): manager
+        for manager in config['customManagers']
+        if manager.get('datasourceTemplate') in {
+            'custom.klayers',
+            'custom.aws-sdk-pandas-layers',
+        }
+    }
+
+    assert set(managers) == {
+        'custom.klayers',
+        'custom.aws-sdk-pandas-layers',
+    }
+    assert all(
+        manager['fileMatch'] == [r'^.*\.tf$']
+        for manager in managers.values()
+    )
+
+    compiled_patterns = {
+        datasource: [
+            re.compile(
+                re.sub(
+                    r'\(\?<([A-Za-z][A-Za-z0-9_]*)>',
+                    r'(?P<\1>',
+                    pattern,
+                ),
+            )
+            for pattern in manager['matchStrings']
+        ]
+        for datasource, manager in managers.items()
+    }
+
+    supported_arn_pattern = re.compile(
+        r'arn:aws(?:-[a-z]+)*:lambda:'
+        r'(?:\$\{[^}]+\}|[a-z0-9-]+):'
+        r'(?:'
+        r'770693421928:layer:Klayers-[A-Za-z0-9._-]+'
+        r'|\d{12}:layer:AWSSDKPandas-[A-Za-z0-9._-]+'
+        r'):\d+',
+    )
+    source_arns = []
+    source_texts = {}
+    for path in sorted((REPO_ROOT / 'modules').rglob('*.tf')):
+        if '.terraform' in path.parts:
+            continue
+        source_texts[path] = path.read_text(encoding='utf-8')
+        source_arns.extend(
+            (path, match)
+            for match in supported_arn_pattern.finditer(source_texts[path])
+        )
+
+    matched_datasources = []
+    matched_packages = []
+    manager_match_count = sum(
+        len(list(pattern.finditer(source_text)))
+        for source_text in source_texts.values()
+        for patterns in compiled_patterns.values()
+        for pattern in patterns
+    )
+    for path, arn_match in source_arns:
+        matches = [
+            (datasource, match)
+            for datasource, patterns in compiled_patterns.items()
+            for pattern in patterns
+            for match in pattern.finditer(source_texts[path])
+            if match.start() <= arn_match.start() <= arn_match.end()
+            if arn_match.end() <= match.end()
+        ]
+        assert len(matches) == 1, arn_match.group()
+        datasource, match = matches[0]
+        matched_datasources.append(datasource)
+        groups = match.groupdict()
+        package = groups.get('layerPackage') or groups.get('layerName')
+        matched_packages.append(package)
+
+    assert len(source_arns) == 21
+    assert manager_match_count == len(source_arns)
+    assert matched_datasources.count('custom.klayers') == 18
+    assert matched_datasources.count('custom.aws-sdk-pandas-layers') == 3
+    assert set(matched_packages) == {
+        'AWSSDKPandas-Python312',
+        'PyJWT',
+        'cryptography',
+        'requests',
+    }
+
+    klayers_literal = (
+        'arn:aws:lambda:eu-west-1:770693421928:'
+        'layer:Klayers-p312-arm64-requests:4'
+    )
+    klayers_match = compiled_patterns['custom.klayers'][0].fullmatch(
+        klayers_literal,
+    )
+    assert klayers_match is not None
+    assert klayers_match.groupdict() == {
+        'lookupRegion': 'eu-west-1',
+        'pythonMajor': '3',
+        'pythonMinor': '12',
+        'architecture': '-arm64',
+        'layerPackage': 'requests',
+        'currentValue': '4',
+    }
+
+    klayers_dynamic = (
+        '"arn:aws:lambda:${var.aws_region}:770693421928:'
+        'layer:Klayers-p312-requests:4"'
+    )
+    klayers_dynamic_match = compiled_patterns[
+        'custom.klayers'
+    ][1].search(klayers_dynamic)
+    assert klayers_dynamic_match is not None
+    assert klayers_dynamic_match.group('layerPackage') == 'requests'
+    assert 'lookupRegion' not in klayers_dynamic_match.groupdict()
+
+    assert all(
+        'lambdaLayerRegion' not in pattern
+        for manager in managers.values()
+        for pattern in manager['matchStrings']
+    )
+    assert all(
+        '{{else}}us-east-1{{/if}}' in manager['packageNameTemplate']
+        for manager in managers.values()
+    )
+    assert all(
+        'lambdaLayerRegion' not in source_text
+        for source_text in source_texts.values()
+    )
+
+    pandas_literal = (
+        'arn:aws-cn:lambda:cn-north-1:123456789012:'
+        'layer:AWSSDKPandas-Python312-Arm64:8'
+    )
+    pandas_match = compiled_patterns[
+        'custom.aws-sdk-pandas-layers'
+    ][0].fullmatch(pandas_literal)
+    assert pandas_match is not None
+    assert pandas_match.groupdict() == {
+        'partition': 'aws-cn',
+        'lookupRegion': 'cn-north-1',
+        'publisherAccount': '123456789012',
+        'layerName': 'AWSSDKPandas-Python312-Arm64',
+        'currentValue': '8',
+    }
+
+    unsupported_arn = (
+        'arn:aws:lambda:eu-west-1:123456789012:'
+        'layer:private-application-layer:7'
+    )
+    assert not any(
+        pattern.fullmatch(unsupported_arn)
+        for patterns in compiled_patterns.values()
+        for pattern in patterns
+    )
+
+    assert all(
+        manager['versioningTemplate'] == r'regex:^(?<patch>\d+)$'
+        for manager in managers.values()
+    )
+    pandas_datasource = config['customDatasources']['aws-sdk-pandas-layers']
+    assert pandas_datasource['format'] == 'plain'
+    assert '/stable/_sources/layers.rst.txt' in (
+        pandas_datasource['defaultRegistryUrlTemplate']
+    )
+
+    layer_rule = next(
+        rule
+        for rule in config['packageRules']
+        if rule.get('groupSlug') == 'aws-lambda-layers'
+    )
+    assert set(layer_rule['matchDatasources']) == set(managers)
+    assert layer_rule['automerge'] is False
+    assert layer_rule['minimumReleaseAge'] is None
+
+    inherited_patch_policy = {
+        'security',
+        'critical',
+        'simple-review',
+        'auto-merge',
+    }
+    for rule in config['packageRules']:
+        if 'patch' not in rule.get('matchUpdateTypes', []):
+            continue
+        if rule.get('matchDepTypes'):
+            continue
+        changes_layer_policy = any(
+            (
+                rule.get('automerge') is True,
+                bool(
+                    inherited_patch_policy.intersection(
+                        rule.get('addLabels', []),
+                    ),
+                ),
+                'prPriority' in rule,
+                'prCreation' in rule,
+            ),
+        )
+        if not changes_layer_policy:
+            continue
+        assert {
+            f'!{datasource}' for datasource in managers
+        }.issubset(rule.get('matchDatasources', []))
 
 
 def test_python_ssm_clients_use_explicit_retry_config() -> None:


### PR DESCRIPTION
## Description

- Separate grouped `terraform-aws-github-runner` updates into major, minor, and patch pull requests.
- Add custom Renovate datasources and regex managers for KLayers and AWS SDK for pandas Lambda layers.
- Detect all 21 existing layer references without adding annotations to Terraform files. Literal ARNs use their embedded region; interpolated ARNs use `us-east-1` as the configured catalog region.
- Group layer revision updates into a review-only pull request, prevent the existing patch/security rules from auto-merging them, and prioritize the group ahead of the rate-limited dependency queue.
- Prevent Renovate update collisions by using the native pre-commit manager as the sole owner of frozen hook refs and ignoring same-tag digest-only refreshes. Patch, minor, and major hook upgrades remain enabled and update both the SHA and frozen version comment.
- Group and SHA-pin only executable GitHub workflow references, split their branches by update type, and exclude `uses-with` tool-version inputs such as `astral-sh/uv`.
- Correct the OpenTofu custom-manager file matcher and add regression tests for ownership, digest pinning, layer extraction, catalog selection, grouping, priority, and review policy.

> [!IMPORTANT]
> For region-interpolated ARNs, Renovate resolves revisions from the `us-east-1` catalogs. Layer revisions and publisher accounts can differ between deployment regions, so reviewers must verify the proposed revision for non-`us-east-1` deployments before merging a generated layer update.

## Type of Change

- [x] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `renovate-config-validator renovate.json`
- `pre-commit run check-renovate --files renovate.json`
- `UV_CACHE_DIR=/private/tmp/forge-uv-cache uv run pytest tests/quality/automation_gates_test.py -k renovate` (`5 passed`)
- Renovate `44.11.4` authenticated `--dry-run=full --enabled-managers=github-actions,pre-commit` against the `renovatebot` base: no upgrade collisions or branch update failures
- Renovate branch plan: Action version updates use `renovate/github-actions-minor-dependencies` with new commit SHAs, container refreshes use `renovate/github-actions-digest-dependencies`, and all seven `astral-sh/uv` inputs remain separate `uses-with` dependencies
- Local Renovate layer lookup: detected 21 layer dependencies and grouped the available revisions into `renovate/patch-aws-lambda-layers`
- Commit-time pre-commit suite: all applicable hooks passed, including Renovate JSON schema validation and Terraform/OpenTofu validation
- Hosted Renovate pull-request creation will occur on a subsequent Mend run
