### PR TITLE
fix(renovate): update Lambda layers safely

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
     "stabilityDays": 0,
     "separateMinorPatch": true,
     "separateMajorMinor": true,
-    "useBaseBranchConfig": "merge",
+    "useBaseBranchConfig": "none",
     "ignorePaths": [
         "**/.terraform/**"
     ],
@@ -88,7 +88,8 @@
             "depNameTemplate": "KLayers {{{layerPackage}}} for Python {{{pythonMajor}}}.{{{pythonMinor}}}{{{architecture}}}",
             "packageNameTemplate": "p{{{pythonMajor}}}.{{{pythonMinor}}}{{{architecture}}}/layers/{{#if lookupRegion}}{{{lookupRegion}}}{{else}}us-east-1{{/if}}/{{{layerPackage}}}",
             "datasourceTemplate": "custom.klayers",
-            "versioningTemplate": "regex:^(?<patch>\\d+)$"
+            "versioningTemplate": "regex:^(?<patch>\\d+)$",
+            "autoReplaceStringTemplate": "{{{replace '\\d+$' newValue replaceString}}}"
         },
         {
             "customType": "regex",
@@ -103,7 +104,8 @@
             "depNameTemplate": "AWS SDK for pandas {{{layerName}}}",
             "packageNameTemplate": "arn:{{#if partition}}{{{partition}}}{{else}}aws{{/if}}:lambda:{{#if lookupRegion}}{{{lookupRegion}}}{{else}}us-east-1{{/if}}:{{{publisherAccount}}}:layer:{{{layerName}}}",
             "datasourceTemplate": "custom.aws-sdk-pandas-layers",
-            "versioningTemplate": "regex:^(?<patch>\\d+)$"
+            "versioningTemplate": "regex:^(?<patch>\\d+)$",
+            "autoReplaceStringTemplate": "{{{replace '\\d+$' newValue replaceString}}}"
         }
       ],
     "packageRules": [

--- a/tests/quality/automation_gates_test.py
+++ b/tests/quality/automation_gates_test.py
@@ -84,10 +84,10 @@ def test_renovate_groups_runner_updates_by_semver_level() -> None:
     assert runner_rule['separateMinorPatch'] is True
 
 
-def test_renovate_merges_config_from_selected_base_branch() -> None:
+def test_renovate_does_not_merge_config_from_selected_base_branch() -> None:
     config = json.loads(read('renovate.json'))
 
-    assert config['useBaseBranchConfig'] == 'merge'
+    assert config['useBaseBranchConfig'] == 'none'
 
 
 def test_renovate_pre_commit_hooks_have_single_update_owner() -> None:
@@ -332,6 +332,22 @@ def test_renovate_manages_supported_lambda_layer_arns() -> None:
     assert all(
         manager['versioningTemplate'] == r'regex:^(?<patch>\d+)$'
         for manager in managers.values()
+    )
+    suffix_only_replacement = r"{{{replace '\d+$' newValue replaceString}}}"
+    assert all(
+        manager['autoReplaceStringTemplate'] == suffix_only_replacement
+        for manager in managers.values()
+    )
+    suffix_pattern = suffix_only_replacement.removeprefix(
+        "{{{replace '",
+    ).removesuffix("' newValue replaceString}}}")
+    pyjwt_arn = (
+        'arn:aws:lambda:${data.aws_region.current.region}:'
+        '770693421928:layer:Klayers-p312-PyJWT:1'
+    )
+    assert re.sub(suffix_pattern, '4', pyjwt_arn) == (
+        'arn:aws:lambda:${data.aws_region.current.region}:'
+        '770693421928:layer:Klayers-p312-PyJWT:4'
     )
     pandas_datasource = config['customDatasources']['aws-sdk-pandas-layers']
     assert pandas_datasource['format'] == 'plain'


### PR DESCRIPTION
## Description

Fix Renovate Lambda layer updates after a Mend run exposed two interacting configuration issues:

- stop merging the selected base branch configuration into an identical repository configuration, which caused each of the 21 Lambda layer dependencies to be extracted twice
- restrict KLayers and AWS SDK for pandas replacements to the terminal numeric layer revision, preventing values such as `1` from changing earlier digits in an ARN
- add regression coverage for both the base-branch behavior and suffix-only PyJWT ARN replacement

This keeps grouped Lambda layer update branches free of duplicate records and malformed ARN replacements.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `renovate-config-validator renovate.json`
- `pre-commit run check-renovate --files renovate.json`
- `uv run --locked --only-group lambda-tests pytest -q tests/quality` (31 passed)
- commit-time full pre-commit suite
