### PR TITLE
fix(splunk-conf): ignore trackPipelineLatency drift

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/props_billing_cur.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_billing_cur.tf
@@ -53,6 +53,7 @@ resource "splunk_configs_conf" "forgecicd_aws_billing_cur" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }

--- a/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
@@ -94,6 +94,7 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }

--- a/modules/integrations/splunk_cloud_conf_shared/props_ec2.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_ec2.tf
@@ -56,6 +56,7 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs_forgecicd" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -121,6 +122,7 @@ resource "splunk_configs_conf" "forgecicd_metadata" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }

--- a/modules/integrations/splunk_cloud_conf_shared/props_k8s.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_k8s.tf
@@ -54,6 +54,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_runner" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -120,6 +121,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_runner_logs" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -184,6 +186,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_docker_creds" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -246,6 +249,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_dind_rootless" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -308,6 +312,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_work" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -370,6 +375,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_dind_externals" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -432,6 +438,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_dind" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -494,6 +501,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_listener" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -556,6 +564,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_manager" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -617,6 +626,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_log_worker" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }
@@ -678,6 +688,7 @@ resource "splunk_configs_conf" "forgecicd_kube_container_log_hook" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }

--- a/modules/integrations/splunk_cloud_conf_shared/props_runner_logs.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_runner_logs.tf
@@ -53,6 +53,7 @@ resource "splunk_configs_conf" "forgecicd_runner_logs_s3" {
       variables["priority"],
       variables["sourcetype"],
       variables["termFrequencyWeightedDist"],
+      variables["trackPipelineLatency"],
       variables["unarchive_cmd_start_mode"],
     ]
   }


### PR DESCRIPTION
## Description

Add `trackPipelineLatency` to the lifecycle `ignore_changes` lists for all 16 managed Splunk `props` resources covering billing CUR, CloudWatch logs, EC2 metadata, Kubernetes containers, and runner logs.

This prevents Splunk-managed changes to that property from producing recurring Terraform drift while keeping the declared props configuration managed.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `tofu fmt -check` on all five changed Terraform files
- `git diff --check`
- `tofu -chdir=modules/integrations/splunk_cloud_conf_shared validate -no-color`
- `tofu -chdir=modules/integrations/splunk_cloud_conf_shared test -filter=tests/behavior.tftest.hcl -no-color` (9 passed)
- `tflint --chdir=modules/integrations/splunk_cloud_conf_shared --disable-rule=terraform_required_providers --no-color`
- Repository pre-commit hooks during commit
