### PR TITLE
fix(splunk): preserve ACLs and harden Data Manager discovery

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -10,6 +10,7 @@ on:
       - renovatebot
     paths:
       - modules/**/lambda/**
+      - modules/**/*.py
       - modules/**/*.tf
       - modules/**/*.tftest.hcl
       - examples/**
@@ -35,6 +36,7 @@ on:
       - main
     paths:
       - modules/**/lambda/**
+      - modules/**/*.py
       - modules/**/*.tf
       - modules/**/*.tftest.hcl
       - examples/**

--- a/modules/integrations/splunk_cloud_conf_shared/props_billing_cur.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_billing_cur.tf
@@ -7,8 +7,11 @@ resource "splunk_configs_conf" "forgecicd_aws_billing_cur" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
@@ -48,8 +48,8 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_conf_shared/props_ec2.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_ec2.tf
@@ -10,8 +10,11 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs_forgecicd" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_conf_shared/props_k8s.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_k8s.tf
@@ -8,8 +8,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_runner" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -75,8 +78,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_runner_logs" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -140,8 +146,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_docker_creds" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -203,8 +212,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_dind_rootless" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -266,8 +278,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_work" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -329,8 +344,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_dind_externals" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -392,8 +410,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_dind" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -455,8 +476,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_listener" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -518,8 +542,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_manager" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -580,8 +607,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_log_worker" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -642,8 +672,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_log_hook" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_conf_shared/props_runner_logs.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_runner_logs.tf
@@ -8,8 +8,11 @@ resource "splunk_configs_conf" "forgecicd_runner_logs_s3" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_data_manager_common/README.md
+++ b/modules/integrations/splunk_cloud_data_manager_common/README.md
@@ -17,6 +17,7 @@ Data Manager needs a read-only AWS role to inventory and ingest logs or metadata
 
 - Keep the role trust aligned with Splunk Data Manager requirements.
 - When Splunk integration setup fails, confirm both the secret values and the external data-source scripts.
+- The external data helper requires Python 3.12 and uses only the Python standard library; `curl` and `jq` are not required.
 - This module is shared foundation for several Data Manager inputs.
 
 <!-- BEGIN_TF_DOCS -->

--- a/modules/integrations/splunk_cloud_data_manager_common/scripts/splunk_data_manager.py
+++ b/modules/integrations/splunk_cloud_data_manager_common/scripts/splunk_data_manager.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3.12
+"""Read Splunk Data Manager values for Terraform external data sources."""
+
+from __future__ import annotations
+
+import http.cookiejar
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable, Mapping, Sequence
+from typing import IO, Any
+
+REQUEST_TIMEOUT_SECONDS = 30
+LOGIN_COOKIE_NAMES = (
+    'splunkweb_uid',
+    'cval',
+    'splunkweb_csrf_token_8443',
+    'splunkd_8443',
+    'AWSELB',
+)
+AUTHENTICATED_COOKIE_NAMES = (
+    'splunkweb_csrf_token_8443',
+    'splunkd_8443',
+)
+REQUIRED_AWS_CONFIG_NAMES = ('iamExternalId', 'instanceIamRole')
+AJAX_HEADERS = {
+    'Sec-Fetch-Dest': 'empty',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Site': 'same-origin',
+    'X-Requested-With': 'XMLHttpRequest',
+}
+
+
+class ExternalDataError(RuntimeError):
+    """A safe-to-report external data source failure."""
+
+
+def _read_query(input_stream: IO[str]) -> dict[str, str]:
+    try:
+        query = json.load(input_stream)
+    except json.JSONDecodeError as error:
+        raise ExternalDataError('stdin must contain valid JSON') from error
+
+    if not isinstance(query, dict):
+        raise ExternalDataError('external data query must be a JSON object')
+    if not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in query.items()
+    ):
+        raise ExternalDataError('external data query values must be strings')
+    return query
+
+
+def _required(query: Mapping[str, str], *names: str) -> tuple[str, ...]:
+    missing = [name for name in names if not query.get(name)]
+    if missing:
+        raise ExternalDataError(
+            f'external data query is missing: {", ".join(missing)}'
+        )
+    return tuple(query[name] for name in names)
+
+
+def _cookie_values(cookies: Iterable[Any]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for cookie in cookies:
+        if cookie.name in LOGIN_COOKIE_NAMES:
+            values[cookie.name] = cookie.value
+    return values
+
+
+def _request_bytes(
+    opener: Any,
+    request: urllib.request.Request,
+) -> bytes:
+    with opener.open(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        return response.read()
+
+
+def authenticate(
+    query: Mapping[str, str],
+    *,
+    opener: Any | None = None,
+    cookie_jar: Any | None = None,
+) -> dict[str, str]:
+    """Authenticate to Splunk Cloud and return the legacy cookie result map."""
+    splunk_cloud, username, password = _required(
+        query,
+        'splunk_cloud',
+        'username',
+        'password',
+    )
+    splunk_cloud = splunk_cloud.rstrip('/')
+
+    if cookie_jar is None:
+        cookie_jar = http.cookiejar.CookieJar()
+    if opener is None:
+        opener = urllib.request.build_opener(
+            urllib.request.HTTPCookieProcessor(cookie_jar)
+        )
+
+    initial_login = urllib.request.Request(
+        f'{splunk_cloud}/en-US/account/login?loginType=splunk',
+        method='GET',
+    )
+    _request_bytes(opener, initial_login)
+
+    initial_cookies = _cookie_values(cookie_jar)
+    missing_initial = [
+        name
+        for name in ('splunkweb_uid', 'cval')
+        if not initial_cookies.get(name)
+    ]
+    if missing_initial:
+        raise ExternalDataError(
+            'Splunk initial login did not return required cookies: '
+            f'{", ".join(missing_initial)}'
+        )
+
+    login_form = urllib.parse.urlencode(
+        {
+            'cval': initial_cookies['cval'],
+            'username': username,
+            'password': password,
+        }
+    ).encode('utf-8')
+    authenticated_login = urllib.request.Request(
+        f'{splunk_cloud}/en-GB/account/login',
+        data=login_form,
+        headers={
+            **AJAX_HEADERS,
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Cookie': (
+                f'cval={initial_cookies["cval"]}; '
+                f'splunkweb_uid={initial_cookies["splunkweb_uid"]}'
+            ),
+        },
+        method='POST',
+    )
+    _request_bytes(opener, authenticated_login)
+
+    authenticated_cookies = _cookie_values(cookie_jar)
+    missing = [
+        name
+        for name in AUTHENTICATED_COOKIE_NAMES
+        if not authenticated_cookies.get(name)
+    ]
+    if missing:
+        raise ExternalDataError(
+            'Splunk authenticated login did not return required cookies: '
+            f'{", ".join(missing)}'
+        )
+
+    return {
+        'splunkweb_uid': initial_cookies['splunkweb_uid'],
+        'cval': initial_cookies['cval'],
+        'splunkweb_csrf_token_8443': authenticated_cookies[
+            'splunkweb_csrf_token_8443'
+        ],
+        'splunkd_8443': authenticated_cookies['splunkd_8443'],
+        'awselb': authenticated_cookies.get('AWSELB', ''),
+    }
+
+
+def fetch_config(
+    query: Mapping[str, str],
+    *,
+    opener: Any | None = None,
+) -> dict[str, str]:
+    """Return the legacy top-level ``aws`` configuration result map."""
+    splunk_cloud, csrf_token, splunkd_cookie = _required(
+        query,
+        'splunk_cloud',
+        'splunkweb_csrf_token_8443',
+        'splunkd_8443',
+    )
+    awselb_cookie = query.get('awselb', '')
+    splunk_cloud = splunk_cloud.rstrip('/')
+
+    if opener is None:
+        opener = urllib.request.build_opener()
+
+    cookie_values = [
+        f'splunkweb_csrf_token_8443={csrf_token}',
+        f'splunk_csrf_token={csrf_token}',
+        f'splunkd_8443={splunkd_cookie}',
+    ]
+    if awselb_cookie:
+        cookie_values.append(f'AWSELB={awselb_cookie}')
+    request = urllib.request.Request(
+        f'{splunk_cloud}/en-US/splunkd/__raw/servicesNS/nobody/'
+        'data_manager/cloudinput/globalconfig',
+        headers={
+            **AJAX_HEADERS,
+            'Accept': 'application/json, text/plain, */*',
+            'Cookie': '; '.join(cookie_values),
+            'X-Splunk-Form-Key': csrf_token,
+        },
+        method='GET',
+    )
+    response_body = _request_bytes(opener, request)
+
+    try:
+        response = json.loads(response_body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ExternalDataError(
+            'Splunk global configuration response was not valid JSON'
+        ) from error
+
+    aws_config = response.get('aws') if isinstance(response, dict) else None
+    if not isinstance(aws_config, dict):
+        raise ExternalDataError(
+            'Splunk global configuration response is missing an aws object'
+        )
+    missing = [
+        name
+        for name in REQUIRED_AWS_CONFIG_NAMES
+        if not isinstance(aws_config.get(name), str) or not aws_config[name]
+    ]
+    if missing:
+        raise ExternalDataError(
+            'Splunk aws configuration has missing or invalid required values: '
+            f'{", ".join(missing)}'
+        )
+    return {name: aws_config[name] for name in REQUIRED_AWS_CONFIG_NAMES}
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    input_stream: IO[str] | None = None,
+    output_stream: IO[str] | None = None,
+    error_stream: IO[str] | None = None,
+) -> int:
+    """Run one Terraform external data source operation."""
+    if argv is None:
+        argv = sys.argv[1:]
+    if input_stream is None:
+        input_stream = sys.stdin
+    if output_stream is None:
+        output_stream = sys.stdout
+    if error_stream is None:
+        error_stream = sys.stderr
+
+    if len(argv) != 1 or argv[0] not in {'authenticate', 'config'}:
+        print(
+            f'Usage: {sys.argv[0]} authenticate|config',
+            file=error_stream,
+        )
+        return 2
+
+    try:
+        query = _read_query(input_stream)
+        if argv[0] == 'authenticate':
+            result = authenticate(query)
+        else:
+            result = fetch_config(query)
+    except (ExternalDataError, urllib.error.URLError) as error:
+        print(f'error: {error}', file=error_stream)
+        return 1
+
+    json.dump(result, output_stream, separators=(',', ':'), sort_keys=True)
+    output_stream.write('\n')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/modules/integrations/splunk_cloud_data_manager_common/splunk.tf
+++ b/modules/integrations/splunk_cloud_data_manager_common/splunk.tf
@@ -5,52 +5,31 @@ locals {
 
 data "external" "splunk_data" {
   program = [
-    "bash", "-c",
-    <<-EOF
-      splunk_cloud_url="${var.splunk_cloud}/en-US/account/login?loginType=splunk"
-
-      # Perform the login and save cookies
-      curl -c /tmp/cookies.txt "$splunk_cloud_url" > /dev/null 2>&1
-
-      # Extract the required values
-      splunkweb_uid=$(grep splunkweb_uid cookies.txt | awk '{print $7}')
-      cval=$(grep cval /tmp/cookies.txt | awk '{print $7}')
-
-      # Perform the second login and save cookies
-      curl '${var.splunk_cloud}/en-GB/account/login' \
-        -b "cval=$cval; splunkweb_uid=$splunkweb_uid" \
-        -c /tmp/cookies2.txt \
-        -H 'Sec-Fetch-Dest: empty' \
-        -H 'Sec-Fetch-Mode: cors' \
-        -H 'Sec-Fetch-Site: same-origin' \
-        -H 'X-Requested-With: XMLHttpRequest' \
-        --data-raw "cval=$cval&username=${local.splunk_cloud_username}&password=${local.splunk_cloud_password}" > /dev/null 2>&1
-
-      splunkweb_csrf_token_8443=$(grep splunkweb_csrf_token_8443 /tmp/cookies2.txt | awk '{print $7}')
-      splunkd_8443=$(grep splunkd_8443 /tmp/cookies2.txt | awk '{print $7}')
-      awselb=$(grep AWSELB /tmp/cookies2.txt | awk '{print $7}')
-
-      # Output the values in JSON format
-      jq -n --arg splunkweb_uid "$splunkweb_uid" --arg cval "$cval" --arg splunkweb_csrf_token_8443 "$splunkweb_csrf_token_8443" --arg splunkd_8443 "$splunkd_8443" --arg awselb "$awselb" '{"splunkweb_uid": $splunkweb_uid, "cval": $cval, "splunkweb_csrf_token_8443": $splunkweb_csrf_token_8443, "splunkd_8443": $splunkd_8443, "awselb": $awselb}'
-    EOF
+    "python3.12",
+    "${path.module}/scripts/splunk_data_manager.py",
+    "authenticate",
   ]
+
+  query = {
+    splunk_cloud = var.splunk_cloud
+    username     = local.splunk_cloud_username
+    password     = local.splunk_cloud_password
+  }
 }
 
 data "external" "config" {
   program = [
-    "bash", "-c",
-    <<-EOF
-      curl '${var.splunk_cloud}/en-US/splunkd/__raw/servicesNS/nobody/data_manager/cloudinput/globalconfig' \
-        -H 'Accept: application/json, text/plain, */*' \
-        -b "splunkweb_csrf_token_8443=${data.external.splunk_data.result["splunkweb_csrf_token_8443"]}; splunk_csrf_token=${data.external.splunk_data.result["splunkweb_csrf_token_8443"]}; splunkd_8443=${data.external.splunk_data.result["splunkd_8443"]}; AWSELB=${data.external.splunk_data.result["awselb"]}" \
-        -H 'Sec-Fetch-Dest: empty' \
-        -H 'Sec-Fetch-Mode: cors' \
-        -H 'Sec-Fetch-Site: same-origin' \
-        -H 'X-Requested-With: XMLHttpRequest' \
-        -H "X-Splunk-Form-Key: ${data.external.splunk_data.result["splunkweb_csrf_token_8443"]}" \
-        -o /tmp/config.json > /dev/null 2>&1
-      cat /tmp/config.json | jq '.aws'
-    EOF
+    "python3.12",
+    "${path.module}/scripts/splunk_data_manager.py",
+    "config",
   ]
+
+  query = {
+    splunk_cloud              = var.splunk_cloud
+    splunkweb_csrf_token_8443 = data.external.splunk_data.result["splunkweb_csrf_token_8443"]
+    splunkd_8443              = data.external.splunk_data.result["splunkd_8443"]
+    awselb                    = data.external.splunk_data.result["awselb"]
+  }
+
   depends_on = [data.external.splunk_data]
 }

--- a/modules/integrations/splunk_cloud_data_manager_common/tests/behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_data_manager_common/tests/behavior.tftest.hcl
@@ -80,6 +80,25 @@ run "splunk_data_manager_common_role_contract" {
 
   assert {
     condition = (
+      data.external.splunk_data.program[0] == "python3.12"
+      && data.external.splunk_data.program[1] == "${path.module}/scripts/splunk_data_manager.py"
+      && data.external.splunk_data.program[2] == "authenticate"
+      && data.external.splunk_data.query.splunk_cloud == "https://splunk.example.com"
+      && nonsensitive(data.external.splunk_data.query.username) == "mock-splunk-secret"
+      && nonsensitive(data.external.splunk_data.query.password) == "mock-splunk-secret"
+      && data.external.config.program[0] == "python3.12"
+      && data.external.config.program[1] == "${path.module}/scripts/splunk_data_manager.py"
+      && data.external.config.program[2] == "config"
+      && data.external.config.query.splunk_cloud == "https://splunk.example.com"
+      && data.external.config.query.splunkweb_csrf_token_8443 == "csrf"
+      && data.external.config.query.splunkd_8443 == "splunkd"
+      && data.external.config.query.awselb == "awselb"
+    )
+    error_message = "Splunk Data Manager discovery must invoke both Python helper subcommands and pass credentials and cookies through external data queries."
+  }
+
+  assert {
+    condition = (
       aws_iam_role.splunk_dm_read_only.name == "SplunkDMReadOnly"
       && jsondecode(aws_iam_role.splunk_dm_read_only.assume_role_policy).Statement[0].Principal.AWS[0] == "arn:aws:iam::999999999999:role/splunk-data-manager"
       && jsondecode(aws_iam_role.splunk_dm_read_only.assume_role_policy).Statement[0].Condition.StringEquals["sts:ExternalId"] == "external-id-123"

--- a/modules/integrations/splunk_cloud_data_manager_common/tests/source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_cloud_data_manager_common/tests/source_inventory.tftest.hcl
@@ -16,6 +16,15 @@ run "integrations_splunk_cloud_data_manager_common_contract" {
       "data \"aws_secretsmanager_secret_version\" \"secrets\"",
       "data \"external\" \"splunk_data\"",
       "data \"external\" \"config\"",
+      "\"python3.12\"",
+      "\"$${path.module}/scripts/splunk_data_manager.py\"",
+      "\"authenticate\"",
+      "\"config\"",
+      "username     = local.splunk_cloud_username",
+      "password     = local.splunk_cloud_password",
+      "splunkweb_csrf_token_8443 = data.external.splunk_data.result[\"splunkweb_csrf_token_8443\"]",
+      "splunkd_8443              = data.external.splunk_data.result[\"splunkd_8443\"]",
+      "awselb                    = data.external.splunk_data.result[\"awselb\"]",
       "provider \"aws\"",
     ]
   }

--- a/tests/iac/splunk_data_manager_common_script_test.py
+++ b/tests/iac/splunk_data_manager_common_script_test.py
@@ -1,0 +1,513 @@
+"""Hermetic tests for the Splunk Data Manager external-data helper."""
+
+from __future__ import annotations
+
+import http.cookiejar
+import importlib.util
+import io
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.contract
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / (
+    'modules/integrations/splunk_cloud_data_manager_common'
+)
+SCRIPT_PATH = MODULE_PATH / 'scripts/splunk_data_manager.py'
+TERRAFORM_PATH = MODULE_PATH / 'splunk.tf'
+
+
+def load_helper() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        'splunk_data_manager_external',
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        return False
+
+
+class RecordingOpener:
+    def __init__(self, responses, callbacks=None):
+        self.responses = list(responses)
+        self.callbacks = list(callbacks or [])
+        self.requests = []
+        self.timeouts = []
+
+    def open(self, request, timeout):
+        self.requests.append(request)
+        self.timeouts.append(timeout)
+        index = len(self.requests) - 1
+        if index < len(self.callbacks):
+            self.callbacks[index]()
+        response = self.responses[index]
+        if isinstance(response, BaseException):
+            raise response
+        return FakeResponse(response)
+
+
+def add_cookies(cookie_jar, **cookies):
+    cookie_jar.extend(
+        SimpleNamespace(name=name, value=value)
+        for name, value in cookies.items()
+    )
+
+
+def add_real_cookies(
+    cookie_jar: http.cookiejar.CookieJar,
+    **cookies: str,
+) -> None:
+    for name, value in cookies.items():
+        cookie_jar.set_cookie(
+            http.cookiejar.Cookie(
+                version=0,
+                name=name,
+                value=value,
+                port=None,
+                port_specified=False,
+                domain='splunk.example.com',
+                domain_specified=True,
+                domain_initial_dot=False,
+                path='/',
+                path_specified=True,
+                secure=True,
+                expires=None,
+                discard=True,
+                comment=None,
+                comment_url=None,
+                rest={},
+                rfc2109=False,
+            )
+        )
+
+
+def authentication_query() -> dict[str, str]:
+    return {
+        'splunk_cloud': 'https://splunk.example.com/',
+        'username': 'test-user',
+        'password': 'test-password',
+    }
+
+
+def config_query(*, awselb: str = 'awselb-value') -> dict[str, str]:
+    return {
+        'splunk_cloud': 'https://splunk.example.com',
+        'splunkweb_csrf_token_8443': 'csrf-value',
+        'splunkd_8443': 'splunkd-value',
+        'awselb': awselb,
+    }
+
+
+def valid_config_response() -> bytes:
+    return json.dumps(
+        {
+            'aws': {
+                'iamExternalId': 'external-id-123',
+                'instanceIamRole': (
+                    'arn:aws:iam::999999999999:role/splunk-dm'
+                ),
+                'unusedNested': {'retries': 3},
+            },
+            'ignored': 'value',
+        }
+    ).encode('utf-8')
+
+
+def test_authenticate_preserves_the_external_cookie_contract() -> None:
+    helper = load_helper()
+    cookie_jar = []
+    opener = RecordingOpener(
+        [b'initial login', b'authenticated'],
+        callbacks=[
+            lambda: add_cookies(
+                cookie_jar,
+                splunkweb_uid='uid-value',
+                cval='cval-value',
+            ),
+            lambda: add_cookies(
+                cookie_jar,
+                splunkweb_csrf_token_8443='csrf-value',
+                splunkd_8443='splunkd-value',
+                AWSELB='awselb-value',
+            ),
+        ],
+    )
+
+    with patch('builtins.open', side_effect=AssertionError('no file access')):
+        result = helper.authenticate(
+            authentication_query(),
+            opener=opener,
+            cookie_jar=cookie_jar,
+        )
+
+    assert result == {
+        'splunkweb_uid': 'uid-value',
+        'cval': 'cval-value',
+        'splunkweb_csrf_token_8443': 'csrf-value',
+        'splunkd_8443': 'splunkd-value',
+        'awselb': 'awselb-value',
+    }
+    initial_request, authenticated_request = opener.requests
+    assert initial_request.full_url == (
+        'https://splunk.example.com/en-US/account/login?loginType=splunk'
+    )
+    assert initial_request.get_method() == 'GET'
+    assert authenticated_request.full_url == (
+        'https://splunk.example.com/en-GB/account/login'
+    )
+    assert authenticated_request.get_method() == 'POST'
+    assert authenticated_request.get_header('Cookie') == (
+        'cval=cval-value; splunkweb_uid=uid-value'
+    )
+    assert urllib.parse.parse_qs(
+        authenticated_request.data.decode('utf-8')
+    ) == {
+        'cval': ['cval-value'],
+        'username': ['test-user'],
+        'password': ['test-password'],
+    }
+    authenticated_headers = {
+        name.lower(): value
+        for name, value in authenticated_request.header_items()
+    }
+    assert authenticated_headers['sec-fetch-dest'] == 'empty'
+    assert authenticated_headers['sec-fetch-mode'] == 'cors'
+    assert authenticated_headers['sec-fetch-site'] == 'same-origin'
+    assert authenticated_headers['x-requested-with'] == 'XMLHttpRequest'
+    assert authenticated_headers['content-type'] == (
+        'application/x-www-form-urlencoded'
+    )
+    assert opener.timeouts == [30, 30]
+
+
+def test_authenticate_builds_an_in_memory_cookie_aware_opener(
+    monkeypatch,
+) -> None:
+    helper = load_helper()
+    captured = {}
+
+    def fake_build_opener(handler):
+        assert isinstance(handler, helper.urllib.request.HTTPCookieProcessor)
+        captured['cookie_jar'] = handler.cookiejar
+        return RecordingOpener(
+            [b'initial login', b'authenticated'],
+            callbacks=[
+                lambda: add_real_cookies(
+                    handler.cookiejar,
+                    splunkweb_uid='uid-value',
+                    cval='cval-value',
+                ),
+                lambda: add_real_cookies(
+                    handler.cookiejar,
+                    splunkweb_csrf_token_8443='csrf-value',
+                    splunkd_8443='splunkd-value',
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(
+        helper.urllib.request,
+        'build_opener',
+        fake_build_opener,
+    )
+
+    result = helper.authenticate(authentication_query())
+
+    assert isinstance(captured['cookie_jar'], http.cookiejar.CookieJar)
+    assert result['splunkweb_csrf_token_8443'] == 'csrf-value'
+    assert result['awselb'] == ''
+
+
+def test_authenticate_preserves_initial_cookies_when_login_clears_them() -> None:
+    helper = load_helper()
+    cookie_jar = []
+
+    def replace_initial_cookies() -> None:
+        cookie_jar.clear()
+        add_cookies(
+            cookie_jar,
+            splunkweb_csrf_token_8443='csrf-value',
+            splunkd_8443='splunkd-value',
+        )
+
+    opener = RecordingOpener(
+        [b'initial login', b'authenticated'],
+        callbacks=[
+            lambda: add_cookies(
+                cookie_jar,
+                splunkweb_uid='initial-uid',
+                cval='initial-cval',
+            ),
+            replace_initial_cookies,
+        ],
+    )
+
+    result = helper.authenticate(
+        authentication_query(),
+        opener=opener,
+        cookie_jar=cookie_jar,
+    )
+
+    assert result['splunkweb_uid'] == 'initial-uid'
+    assert result['cval'] == 'initial-cval'
+    assert result['splunkweb_csrf_token_8443'] == 'csrf-value'
+
+
+@pytest.mark.parametrize(
+    ('cookies', 'missing_name'),
+    [
+        ({'cval': 'cval-value'}, 'splunkweb_uid'),
+        ({'splunkweb_uid': 'uid-value'}, 'cval'),
+    ],
+)
+def test_authenticate_rejects_incomplete_initial_cookies(
+    cookies: dict[str, str],
+    missing_name: str,
+) -> None:
+    helper = load_helper()
+    cookie_jar = []
+    opener = RecordingOpener(
+        [b'initial login'],
+        callbacks=[lambda: add_cookies(cookie_jar, **cookies)],
+    )
+
+    with pytest.raises(helper.ExternalDataError, match=missing_name):
+        helper.authenticate(
+            authentication_query(),
+            opener=opener,
+            cookie_jar=cookie_jar,
+        )
+
+
+@pytest.mark.parametrize(
+    ('cookies', 'missing_name'),
+    [
+        ({'splunkd_8443': 'splunkd-value'}, 'splunkweb_csrf_token_8443'),
+        (
+            {'splunkweb_csrf_token_8443': 'csrf-value'},
+            'splunkd_8443',
+        ),
+    ],
+)
+def test_authenticate_rejects_incomplete_authenticated_cookies(
+    cookies: dict[str, str],
+    missing_name: str,
+) -> None:
+    helper = load_helper()
+    cookie_jar = []
+    opener = RecordingOpener(
+        [b'initial login', b'authenticated'],
+        callbacks=[
+            lambda: add_cookies(
+                cookie_jar,
+                splunkweb_uid='uid-value',
+                cval='cval-value',
+            ),
+            lambda: add_cookies(cookie_jar, **cookies),
+        ],
+    )
+
+    with pytest.raises(helper.ExternalDataError, match=missing_name):
+        helper.authenticate(
+            authentication_query(),
+            opener=opener,
+            cookie_jar=cookie_jar,
+        )
+
+
+def test_fetch_config_returns_only_the_required_aws_values() -> None:
+    helper = load_helper()
+    opener = RecordingOpener([valid_config_response()])
+
+    result = helper.fetch_config(config_query(), opener=opener)
+
+    assert result == {
+        'iamExternalId': 'external-id-123',
+        'instanceIamRole': 'arn:aws:iam::999999999999:role/splunk-dm',
+    }
+    request = opener.requests[0]
+    assert request.full_url.endswith(
+        '/en-US/splunkd/__raw/servicesNS/nobody/'
+        'data_manager/cloudinput/globalconfig'
+    )
+    assert request.get_method() == 'GET'
+    assert request.get_header('Cookie') == (
+        'splunkweb_csrf_token_8443=csrf-value; '
+        'splunk_csrf_token=csrf-value; '
+        'splunkd_8443=splunkd-value; '
+        'AWSELB=awselb-value'
+    )
+    assert request.get_header('X-splunk-form-key') == 'csrf-value'
+    config_headers = {
+        name.lower(): value for name, value in request.header_items()
+    }
+    assert config_headers['accept'] == 'application/json, text/plain, */*'
+    assert config_headers['sec-fetch-dest'] == 'empty'
+    assert config_headers['sec-fetch-mode'] == 'cors'
+    assert config_headers['sec-fetch-site'] == 'same-origin'
+    assert config_headers['x-requested-with'] == 'XMLHttpRequest'
+    assert opener.timeouts == [30]
+
+
+def test_fetch_config_omits_an_empty_optional_awselb_cookie() -> None:
+    helper = load_helper()
+    opener = RecordingOpener([valid_config_response()])
+
+    helper.fetch_config(config_query(awselb=''), opener=opener)
+
+    assert opener.requests[0].get_header('Cookie') == (
+        'splunkweb_csrf_token_8443=csrf-value; '
+        'splunk_csrf_token=csrf-value; '
+        'splunkd_8443=splunkd-value'
+    )
+
+
+@pytest.mark.parametrize('body', [b'', b'  \n', b'not-json'])
+def test_fetch_config_rejects_a_non_json_response(body: bytes) -> None:
+    helper = load_helper()
+
+    with pytest.raises(
+        helper.ExternalDataError,
+        match='global configuration response was not valid JSON',
+    ):
+        helper.fetch_config(
+            config_query(),
+            opener=RecordingOpener([body]),
+        )
+
+
+@pytest.mark.parametrize(
+    ('body', 'message'),
+    [
+        (b'[]', 'missing an aws object'),
+        (b'{"not_aws": {}}', 'missing an aws object'),
+    ],
+)
+def test_fetch_config_rejects_an_invalid_external_result(
+    body: bytes,
+    message: str,
+) -> None:
+    helper = load_helper()
+
+    with pytest.raises(helper.ExternalDataError, match=message):
+        helper.fetch_config(
+            config_query(),
+            opener=RecordingOpener([body]),
+        )
+
+
+@pytest.mark.parametrize(
+    ('aws_config', 'missing_names'),
+    [
+        ({}, 'iamExternalId, instanceIamRole'),
+        ({'iamExternalId': 'id'}, 'instanceIamRole'),
+        ({'instanceIamRole': 'role'}, 'iamExternalId'),
+        (
+            {'iamExternalId': 'id', 'instanceIamRole': 3},
+            'instanceIamRole',
+        ),
+        (
+            {'iamExternalId': '', 'instanceIamRole': ''},
+            'iamExternalId, instanceIamRole',
+        ),
+    ],
+)
+def test_fetch_config_requires_non_empty_iam_values(
+    aws_config: dict[str, object],
+    missing_names: str,
+) -> None:
+    helper = load_helper()
+    body = json.dumps({'aws': aws_config}).encode('utf-8')
+
+    with pytest.raises(
+        helper.ExternalDataError,
+        match=f'missing or invalid required values: {missing_names}',
+    ):
+        helper.fetch_config(
+            config_query(),
+            opener=RecordingOpener([body]),
+        )
+
+
+def test_main_writes_compact_external_json(monkeypatch) -> None:
+    helper = load_helper()
+    output = io.StringIO()
+    monkeypatch.setattr(
+        helper,
+        'fetch_config',
+        lambda query: {'instanceIamRole': 'role', 'iamExternalId': 'id'},
+    )
+
+    return_code = helper.main(
+        ['config'],
+        input_stream=io.StringIO(json.dumps(config_query())),
+        output_stream=output,
+        error_stream=io.StringIO(),
+    )
+
+    assert return_code == 0
+    assert output.getvalue() == (
+        '{"iamExternalId":"id","instanceIamRole":"role"}\n'
+    )
+
+
+def test_main_reports_an_empty_config_response_without_secrets(
+    monkeypatch,
+) -> None:
+    helper = load_helper()
+    output = io.StringIO()
+    error = io.StringIO()
+    query = config_query()
+    monkeypatch.setattr(
+        helper.urllib.request,
+        'build_opener',
+        lambda: RecordingOpener([b'']),
+    )
+
+    return_code = helper.main(
+        ['config'],
+        input_stream=io.StringIO(json.dumps(query)),
+        output_stream=output,
+        error_stream=error,
+    )
+
+    assert return_code == 1
+    assert output.getvalue() == ''
+    assert error.getvalue() == (
+        'error: Splunk global configuration response was not valid JSON\n'
+    )
+    assert all(value not in error.getvalue() for value in query.values())
+
+
+def test_terraform_uses_python_and_stdin_queries_for_both_sources() -> None:
+    terraform_source = TERRAFORM_PATH.read_text(encoding='utf-8')
+
+    assert terraform_source.count('scripts/splunk_data_manager.py') == 2
+    assert terraform_source.count('"python3.12"') == 2
+    assert '"authenticate"' in terraform_source
+    assert '"config"' in terraform_source
+    assert 'username     = local.splunk_cloud_username' in terraform_source
+    assert 'password     = local.splunk_cloud_password' in terraform_source
+    assert '"bash", "-c"' not in terraform_source
+    assert '/tmp/cookies' not in terraform_source
+    assert 'curl ' not in terraform_source
+    assert 'jq ' not in terraform_source


### PR DESCRIPTION
## Description

- Propagate configured `app`, `owner`, and `sharing` ACL values to the managed billing, EC2, Kubernetes, and runner-log Splunk properties.
- Replace the common Splunk Data Manager inline Bash external programs with a Python 3.12 helper that keeps cookies in memory, validates authentication and global configuration responses, treats `AWSELB` as optional, and returns only the required IAM values.
- Add focused Python unit tests, OpenTofu wiring contracts, runtime documentation, and Python workflow path coverage.

The legacy discovery helper wrote and read inconsistent cookie paths, suppressed `curl` failures, and allowed `jq` to exit successfully with empty output. That caused plans to fail later with `unexpected end of JSON input` instead of reporting the Splunk response problem directly.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [x] Refactor
- [ ] Other: _________

## Testing

- `22 passed` — focused Splunk Data Manager common helper tests
- `113 passed` — full offline IaC test suite
- `26 passed` — quality-gate test suite
- `3 passed` — Splunk Data Manager common OpenTofu module tests
- Scoped pre-commit suite passed, including formatting, validation, TFLint, Gitleaks, Bandit, pip-audit, and Ansible lint
