### PR TITLE
fix(splunk): preserve configuration ACLs

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/props_billing_cur.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_billing_cur.tf
@@ -7,8 +7,11 @@ resource "splunk_configs_conf" "forgecicd_aws_billing_cur" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
@@ -48,8 +48,11 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_cloudwatchlogs.tf
@@ -48,11 +48,10 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs" {
   }
 
   acl {
-    app     = var.splunk_conf.acl.app
-    owner   = var.splunk_conf.acl.owner
-    sharing = var.splunk_conf.acl.sharing
-    read    = var.splunk_conf.acl.read
-    write   = var.splunk_conf.acl.write
+    app   = var.splunk_conf.acl.app
+    owner = var.splunk_conf.acl.owner
+    read  = var.splunk_conf.acl.read
+    write = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_conf_shared/props_ec2.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_ec2.tf
@@ -10,8 +10,11 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs_forgecicd" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_conf_shared/props_k8s.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_k8s.tf
@@ -8,8 +8,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_runner" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -75,8 +78,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_runner_logs" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -140,8 +146,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_docker_creds" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -203,8 +212,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_dind_rootless" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -266,8 +278,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_work" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -329,8 +344,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_init_dind_externals" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -392,8 +410,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_dind" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -455,8 +476,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_listener" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -518,8 +542,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_manager" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -580,8 +607,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_log_worker" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {
@@ -642,8 +672,11 @@ resource "splunk_configs_conf" "forgecicd_kube_container_log_hook" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {

--- a/modules/integrations/splunk_cloud_conf_shared/props_runner_logs.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_runner_logs.tf
@@ -8,8 +8,11 @@ resource "splunk_configs_conf" "forgecicd_runner_logs_s3" {
   }
 
   acl {
-    read  = var.splunk_conf.acl.read
-    write = var.splunk_conf.acl.write
+    app     = var.splunk_conf.acl.app
+    owner   = var.splunk_conf.acl.owner
+    sharing = var.splunk_conf.acl.sharing
+    read    = var.splunk_conf.acl.read
+    write   = var.splunk_conf.acl.write
   }
 
   lifecycle {


### PR DESCRIPTION
## Description

- Pass the configured `app` and `owner` values alongside `read` and `write` in the CloudWatch Logs properties ACL block, while intentionally leaving `sharing` unset.
- Pass the complete configured ACL, including `sharing`, for billing CUR, EC2, Kubernetes, and runner logs.

The affected properties resources previously forwarded only the ACL permission lists. This change supplies their configured Splunk app and owner, and propagates the sharing mode for every affected resource except CloudWatch Logs.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: _________

## Testing

- `tofu test -no-color`: 11 passed for `splunk_cloud_conf_shared`
- Scoped pre-commit suite passed, including OpenTofu/Terraform formatting and validation, TFLint, Gitleaks, Bandit, pip-audit, and Ansible lint
