### PR TITLE
fix(splunk): select newest managed metric stream

### DIFF
--- a/modules/integrations/splunk_o11y_aws_integration/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration/README.md
@@ -19,7 +19,8 @@ Forge uses Splunk Observability for AWS metrics while Splunk Cloud handles logs.
 - CloudFormation failures should be debugged in both Terraform output and the CloudFormation events.
 - Use the common integration module for IAM role setup when needed.
 - Metric Stream tag management requires the AWS CLI and `cloudwatch:ListMetricStreams`, `cloudwatch:TagResource`, and `cloudwatch:UntagResource` permissions for the configured AWS profile.
-- The tag helper finds exactly one stream in the configured region whose name starts with `splunk-metric-stream-`. It waits up to 15 minutes for a newly configured stream and fails rather than choosing arbitrarily if multiple streams match.
+- The tag helper finds streams in the configured region whose names start with `splunk-metric-stream-`. It waits up to 15 minutes for a newly configured stream and selects the newest match by its AWS creation date.
+- Discovery assumes one current Splunk integration per account and region. Apply and remove each resolve the newest match, so tag cleanup on an older stream is not guaranteed after a later integration appears; stale-stream deletion remains owned by the Splunk integration lifecycle.
 - Tag drift outside Terraform is not detected unless the stack, template, helper script, or desired tag map changes and replaces the helper.
 
 <!-- BEGIN_TF_DOCS -->

--- a/modules/integrations/splunk_o11y_aws_integration/scripts/manage_cloudwatch_metric_stream_tags.sh
+++ b/modules/integrations/splunk_o11y_aws_integration/scripts/manage_cloudwatch_metric_stream_tags.sh
@@ -18,7 +18,7 @@ resolve_metric_stream_arn() {
 
     if ! matching_output="$(aws cloudwatch list-metric-streams \
         --region "$AWS_REGION" \
-        --query "Entries[?starts_with(Name, '$STREAM_NAME_PREFIX')].Arn" \
+        --query "max_by(Entries[?starts_with(Name, '$STREAM_NAME_PREFIX')], &CreationDate).Arn" \
         --output text)"; then
         return 2
     fi
@@ -34,7 +34,7 @@ resolve_metric_stream_arn() {
     fi
 
     if [ "${#matching_arns[@]}" -ne 1 ]; then
-        echo "Expected exactly one CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX'; found ${#matching_arns[@]}." >&2
+        echo "Expected one newest CloudWatch Metric Stream with prefix '$STREAM_NAME_PREFIX'; query returned ${#matching_arns[@]}." >&2
         printf '  %s\n' "${matching_arns[@]}" >&2
         return 2
     fi

--- a/tests/iac/splunk_metric_stream_tags_script_test.py
+++ b/tests/iac/splunk_metric_stream_tags_script_test.py
@@ -45,6 +45,8 @@ if operation == 'list-metric-streams':
     if scenario == 'missing':
         print('None')
     elif scenario == 'multiple':
+        print(f'{arn}-newest')
+    elif scenario == 'malformed-multiple':
         print(f'{arn}\\t{arn}-second')
     elif scenario == 'list-error':
         print('ListMetricStreams failed', file=sys.stderr)
@@ -140,7 +142,10 @@ def test_apply_tags_the_single_matching_stream(tmp_path: Path) -> None:
         '--region',
         'us-east-1',
         '--query',
-        "Entries[?starts_with(Name, 'splunk-metric-stream-')].Arn",
+        (
+            'max_by(Entries[?starts_with(Name, '
+            "'splunk-metric-stream-')], &CreationDate).Arn"
+        ),
         '--output',
         'text',
     ]
@@ -178,17 +183,38 @@ def test_remove_untags_the_single_matching_stream(tmp_path: Path) -> None:
     assert METRIC_STREAM_ARN in result.stdout
 
 
-@pytest.mark.parametrize('mode', ['apply', 'remove'])
-def test_ambiguous_stream_matches_fail_safely(
+@pytest.mark.parametrize(
+    ('mode', 'operation'),
+    [('apply', 'tag-resource'), ('remove', 'untag-resource')],
+)
+def test_multiple_stream_matches_select_the_newest(
     tmp_path: Path,
     mode: str,
+    operation: str,
 ) -> None:
     result, calls = run_script(tmp_path, mode, scenario='multiple')
 
+    assert result.returncode == 0
+    assert [call[1] for call in calls] == [
+        'list-metric-streams',
+        operation,
+    ]
+    assert calls[1][calls[1].index('--resource-arn') + 1] == (
+        f'{METRIC_STREAM_ARN}-newest'
+    )
+
+
+@pytest.mark.parametrize('mode', ['apply', 'remove'])
+def test_unexpected_multiple_query_results_fail_safely(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    result, calls = run_script(tmp_path, mode, scenario='malformed-multiple')
+
     assert result.returncode == 2
     assert [call[1] for call in calls] == ['list-metric-streams']
-    assert 'Expected exactly one CloudWatch Metric Stream' in result.stderr
-    assert 'found 2' in result.stderr
+    assert 'Expected one newest CloudWatch Metric Stream' in result.stderr
+    assert 'query returned 2' in result.stderr
 
 
 def test_apply_retries_until_the_stream_is_available(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

Select the newest Splunk-managed CloudWatch Metric Stream by its AWS creation date when multiple streams share the `splunk-metric-stream-` prefix.

Splunk creates the Metric Stream asynchronously outside the CloudFormation stack. Re-provisioning can therefore leave an older stream in the account, while the tag helper's exact-one-match assumption aborts before tagging the current stream. The selector now uses the documented `CreationDate` returned by `ListMetricStreams` and keeps the existing retry behavior when no stream is available.

Discovery assumes one current Splunk integration per account and region. This change does not broaden the helper's ownership or delete stale Splunk-managed resources. Because apply and remove each resolve the newest match, tag cleanup on an older stream is not guaranteed after a later integration appears; stale-stream cleanup remains part of the Splunk integration lifecycle.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- From `tests/`: `uv run --project .. --locked --only-group lambda-tests pytest -q iac/splunk_metric_stream_tags_script_test.py` (19 passed)
- From `tests/`: `uv run --project .. --locked --only-group lambda-tests pytest -q iac` (115 passed)
- From `modules/integrations/splunk_o11y_aws_integration/`: `tofu test -no-color` (3 passed)
- Scoped pre-commit hooks for the three changed files (passed)
- Read-only selector validation against the affected AWS account selected the stream created after the current stack
