### PR TITLE
fix(splunk): restore Data Manager delete flow

### DIFF
--- a/modules/integrations/splunk_cloud_data_manager/data_input/scripts/splunk_integration.py
+++ b/modules/integrations/splunk_cloud_data_manager/data_input/scripts/splunk_integration.py
@@ -34,6 +34,10 @@ S3_DATASETS = frozenset(
 
 NOAH_TOKEN_PENDING = 'Noah stack token creation in progress'
 
+DELETE_READINESS_MAX_ATTEMPTS = 10
+DELETE_READINESS_MAX_RETRY_DELAY_SECONDS = 30
+DELETE_READINESS_INITIAL_RETRY_DELAY_SECONDS = 2
+
 DATASET_HEC_CATEGORIES = {
     'cwl-api-gateway': 'aws-cwl',
     'cwl-cloudhsm': 'aws-cwl',
@@ -527,9 +531,41 @@ def get_integration(
     }
 
 
+def wait_for_delete_readiness(
+    client,
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+    logger: Logger | None = None,
+) -> None:
+    """Retry transient Splunk delete-readiness failures."""
+    log = logger or (lambda _message: None)
+    delay = DELETE_READINESS_INITIAL_RETRY_DELAY_SECONDS
+    for attempt in range(1, DELETE_READINESS_MAX_ATTEMPTS + 1):
+        try:
+            client.check_delete_readiness()
+            return
+        except SplunkHttpError as error:
+            retryable = error.status in (0, 429) or 500 <= error.status < 600
+            if not retryable or attempt == DELETE_READINESS_MAX_ATTEMPTS:
+                raise
+
+            log(
+                'Splunk delete readiness returned retryable status '
+                f'{error.status} on attempt '
+                f'{attempt}/{DELETE_READINESS_MAX_ATTEMPTS}; '
+                f'retrying in {delay} seconds.'
+            )
+            sleep(delay)
+            delay = min(
+                delay * 2,
+                DELETE_READINESS_MAX_RETRY_DELAY_SECONDS,
+            )
+
+
 def delete_integration(
     client,
     *,
+    sleep: Callable[[float], None] = time.sleep,
     logger: Logger | None = None,
 ) -> None:
     """Delete an input and clean up push-input HEC tokens."""
@@ -542,15 +578,23 @@ def delete_integration(
             return
         raise
 
-    client.check_delete_readiness()
+    # The legacy flow treated this pre-transition probe as advisory.
+    try:
+        client.check_delete_readiness()
+    except SplunkHttpError as error:
+        log(
+            'Initial Splunk delete readiness returned status '
+            f'{error.status}; continuing with MarkedForDelete.'
+        )
+
     client.put_input(build_delete_payload(input_document))
-    client.check_delete_readiness()
+    wait_for_delete_readiness(client, sleep=sleep, logger=log)
 
     if not input_uses_s3(input_document):
         for category in PUSH_HEC_CLEANUP_CATEGORIES:
             client.delete_hec_token(category)
 
-    client.check_delete_readiness()
+    wait_for_delete_readiness(client, sleep=sleep, logger=log)
     client.delete_input()
 
 

--- a/tests/iac/splunk_data_manager_scripts_test.py
+++ b/tests/iac/splunk_data_manager_scripts_test.py
@@ -172,6 +172,7 @@ class FakeClient:
         input_responses=(),
         template: bytes = VALID_TEMPLATE,
         hec_responses: dict[str, list[dict[str, object]]] | None = None,
+        delete_readiness_responses=(),
         put_error: BaseException | None = None,
     ):
         self.input_responses = deque(input_responses)
@@ -180,6 +181,9 @@ class FakeClient:
             category: deque(responses)
             for category, responses in (hec_responses or {}).items()
         }
+        self.delete_readiness_responses = deque(
+            delete_readiness_responses
+        )
         self.put_error = put_error
         self.calls: list[tuple[str, object]] = []
 
@@ -234,6 +238,14 @@ class FakeClient:
 
     def check_delete_readiness(self) -> None:
         self.calls.append(('check_delete_readiness', None))
+        if self.delete_readiness_responses:
+            response = (
+                self.delete_readiness_responses.popleft()
+                if len(self.delete_readiness_responses) > 1
+                else self.delete_readiness_responses[0]
+            )
+            if isinstance(response, BaseException):
+                raise response
 
     def delete_input(self) -> None:
         self.calls.append(('delete_input', None))
@@ -569,6 +581,200 @@ def test_delete_accepts_an_already_missing_input() -> None:
     assert client.calls == [('get_input', None)]
 
 
+@pytest.mark.parametrize(
+    'status',
+    (0, 403, 500),
+)
+def test_delete_treats_initial_readiness_failure_as_advisory(
+    status: int,
+) -> None:
+    document = push_response()
+    client = FakeClient(
+        input_responses=[document],
+        delete_readiness_responses=[
+            splunk_integration.SplunkHttpError(status, 'not ready'),
+            None,
+            None,
+        ],
+    )
+    messages: list[str] = []
+
+    splunk_integration.delete_integration(
+        client,
+        sleep=lambda _seconds: None,
+        logger=messages.append,
+    )
+
+    assert messages == [
+        'Initial Splunk delete readiness returned status '
+        f'{status}; continuing with MarkedForDelete.'
+    ]
+    assert client.calls[0:3] == [
+        ('get_input', None),
+        ('check_delete_readiness', None),
+        (
+            'put_input',
+            splunk_integration.build_delete_payload(document),
+        ),
+    ]
+    assert client.calls[-1] == ('delete_input', None)
+
+
+def test_delete_stops_after_failed_mark_for_delete() -> None:
+    document = push_response()
+    client = FakeClient(
+        input_responses=[document],
+        delete_readiness_responses=[
+            splunk_integration.SplunkHttpError(500, 'not ready'),
+        ],
+        put_error=splunk_integration.SplunkHttpError(500, 'PUT failed'),
+    )
+
+    with pytest.raises(
+        splunk_integration.SplunkHttpError,
+        match='PUT failed',
+    ):
+        splunk_integration.delete_integration(client)
+
+    assert client.calls == [
+        ('get_input', None),
+        ('check_delete_readiness', None),
+        (
+            'put_input',
+            splunk_integration.build_delete_payload(document),
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    'status',
+    (0, 429, 500, 502, 503, 504, 599),
+)
+def test_wait_for_delete_readiness_retries_transient_status(
+    status: int,
+) -> None:
+    client = FakeClient(
+        delete_readiness_responses=[
+            splunk_integration.SplunkHttpError(status, 'not ready'),
+            None,
+        ],
+    )
+    sleeps: list[float] = []
+    messages: list[str] = []
+
+    splunk_integration.wait_for_delete_readiness(
+        client,
+        sleep=sleeps.append,
+        logger=messages.append,
+    )
+
+    assert sleeps == [2]
+    assert messages == [
+        'Splunk delete readiness returned retryable status '
+        f'{status} on attempt 1/10; retrying in 2 seconds.'
+    ]
+    assert client.calls == [
+        ('check_delete_readiness', None),
+        ('check_delete_readiness', None),
+    ]
+
+
+def test_delete_continues_after_transient_readiness_failure() -> None:
+    document = push_response()
+    client = FakeClient(
+        input_responses=[document],
+        delete_readiness_responses=[
+            None,
+            splunk_integration.SplunkHttpError(500, 'not ready'),
+            None,
+        ],
+    )
+    sleeps: list[float] = []
+    messages: list[str] = []
+
+    splunk_integration.delete_integration(
+        client,
+        sleep=sleeps.append,
+        logger=messages.append,
+    )
+
+    assert sleeps == [2]
+    assert messages == [
+        'Splunk delete readiness returned retryable status 500 on attempt '
+        '1/10; retrying in 2 seconds.',
+    ]
+    assert sum(
+        operation == 'check_delete_readiness'
+        for operation, _value in client.calls
+    ) == 4
+    assert client.calls[-1] == ('delete_input', None)
+
+
+def test_delete_fails_after_readiness_retry_budget_is_exhausted() -> None:
+    client = FakeClient(
+        input_responses=[push_response()],
+        delete_readiness_responses=[
+            None,
+            splunk_integration.SplunkHttpError(500, 'not ready')
+        ],
+    )
+    sleeps: list[float] = []
+
+    with pytest.raises(
+        splunk_integration.SplunkHttpError,
+        match='not ready',
+    ):
+        splunk_integration.delete_integration(
+            client,
+            sleep=sleeps.append,
+        )
+
+    assert sleeps == [2, 4, 8, 16, 30, 30, 30, 30, 30]
+    assert client.calls == [
+        ('get_input', None),
+        ('check_delete_readiness', None),
+        (
+            'put_input',
+            splunk_integration.build_delete_payload(push_response()),
+        ),
+        *[
+            ('check_delete_readiness', None)
+            for _attempt in range(10)
+        ],
+    ]
+
+
+def test_delete_does_not_retry_non_retryable_readiness_failure() -> None:
+    client = FakeClient(
+        input_responses=[push_response()],
+        delete_readiness_responses=[
+            None,
+            splunk_integration.SplunkHttpError(403, 'forbidden')
+        ],
+    )
+    sleeps: list[float] = []
+
+    with pytest.raises(
+        splunk_integration.SplunkHttpError,
+        match='forbidden',
+    ):
+        splunk_integration.delete_integration(
+            client,
+            sleep=sleeps.append,
+        )
+
+    assert sleeps == []
+    assert client.calls == [
+        ('get_input', None),
+        ('check_delete_readiness', None),
+        (
+            'put_input',
+            splunk_integration.build_delete_payload(push_response()),
+        ),
+        ('check_delete_readiness', None),
+    ]
+
+
 class FakeResponse:
     def __init__(self, status: int, body: bytes):
         self.status = status
@@ -860,6 +1066,57 @@ def test_client_tolerates_already_deleted_resources() -> None:
         request.get_method()
         for request in opener.requests[2:]
     ] == ['DELETE', 'DELETE']
+
+
+def test_client_preserves_delete_endpoint_contract() -> None:
+    opener = FakeOpener(
+        [
+            FakeResponse(200, b'login'),
+            FakeResponse(200, b'authenticated'),
+            FakeResponse(200, b'ready'),
+            FakeResponse(200, b'deleted token'),
+            FakeResponse(200, b'deleted input'),
+        ]
+    )
+    client = splunk_integration.SplunkWebClient(
+        runtime_config(push_request()),
+        cookies=authenticated_cookie_jar(),
+        opener=opener,
+    )
+
+    client.login()
+    client.check_delete_readiness()
+    client.delete_hec_token('cloudtrail')
+    client.delete_input()
+
+    readiness_request, hec_request, input_request = opener.requests[2:]
+    assert readiness_request.get_method() == 'GET'
+    assert readiness_request.full_url.endswith(
+        '/en-GB/splunkd/__raw/servicesNS/nobody/'
+        'data_manager/cloudinput/inputs/input-id/'
+        'validate/checkdeletereadiness'
+    )
+    assert request_headers(readiness_request)['content-type'] == (
+        'application/json'
+    )
+    assert readiness_request.data is None
+
+    assert hec_request.get_method() == 'DELETE'
+    assert hec_request.full_url.endswith(
+        '/en-US/splunkd/__raw/servicesNS/nobody/'
+        'data_manager/cloudinput/inputs/input-id/'
+        'hectoken?dataset=cloudtrail'
+    )
+    assert request_headers(hec_request)['content-type'] == 'text/plain'
+    assert hec_request.data is None
+
+    assert input_request.get_method() == 'DELETE'
+    assert input_request.full_url.endswith(
+        '/en-US/splunkd/__raw/servicesNS/nobody/'
+        'data_manager/cloudinput/inputs/input-id'
+    )
+    assert request_headers(input_request)['content-type'] == 'text/plain'
+    assert input_request.data is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Restore the Splunk Data Manager deletion transition that became a fatal gate
during the Bash-to-Python migration, while keeping mutation requests strict.

The v4.10.0 Bash implementation called the initial `checkdeletereadiness`
endpoint without `curl --fail` and without `set -e`. An HTTP 500 therefore did
not prevent the following `PUT` that changed the input to `MarkedForDelete`.
The Python client preserved the request method, path, headers, and body, but
made every non-2xx response fatal before that state transition.

Both attempts of the affected run received HTTP 500 at the first readiness
probe for all three inputs, with no `PUT` or `DELETE` following. Attempt 2
repeated the result against the same inputs more than an hour later, so retrying
only before the state transition is not sufficient.

This change:

- keeps the initial readiness request as an advisory probe;
- keeps the `MarkedForDelete` PUT strict;
- retries transport, HTTP 429, and HTTP 5xx failures at the two post-transition
  readiness checkpoints for up to ten attempts with capped exponential
  backoff;
- keeps HEC-token and final input DELETE requests strict; and
- locks the existing readiness, HEC-token delete, and final input-delete API
  contracts in tests.

Evidence:

- v4.10.0 Bash implementation:
  https://github.com/cisco-open/forge/blob/v4.10.0/modules/integrations/splunk_cloud_data_manager/data_input/scripts/delete_splunk_integration.sh
- Attempt 1, job 93771659351:
  https://github.com/cisco-sbg-emu/cloudsec_srea_product_forge-examples-iac-aws/actions/runs/31485266988/job/93771659351
- Attempt 2, job 93796515468:
  https://github.com/cisco-sbg-emu/cloudsec_srea_product_forge-examples-iac-aws/actions/runs/31485266988/job/93796515468

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `uv run --project .. --locked --only-group lambda-tests pytest -q iac/splunk_data_manager_scripts_test.py` (68 passed)
- `uv run --project .. --locked --only-group lambda-tests pytest -q iac` (128 passed)
- `pre-commit run --show-diff-on-failure --color=always --files modules/integrations/splunk_cloud_data_manager/data_input/scripts/splunk_integration.py tests/iac/splunk_data_manager_scripts_test.py` (passed)
- No live destroy has used this change yet.
