### PR TITLE
fix(helpers): remove License Manager service-linked role

### DIFF
--- a/docs/configurations/deployments/helpers.md
+++ b/docs/configurations/deployments/helpers.md
@@ -28,7 +28,7 @@ ______________________________________________________________________
 | `modules/helpers/ecr`                  | `environments/prod/regions/eu-west-1/ecr`                  | Forge owns ECR repositories for runner or helper images.             |
 | `modules/helpers/forge_subscription`   | `environments/prod/forge_subscription`                     | Tenant accounts need Forge-managed IAM, Packer, S3, or ECR access.   |
 | `modules/helpers/opt_in_regions`       | `environments/prod/opt_in_regions`                         | You need to enable AWS opt-in regions before regional deploys.       |
-| `modules/helpers/service_linked_roles` | `environments/prod/service_linked_roles`                   | Spot or related AWS services need service-linked roles.              |
+| `modules/helpers/service_linked_roles` | `environments/prod/service_linked_roles`                   | The account needs the EC2 Spot service-linked role.                  |
 | `modules/helpers/storage`              | `environments/prod/storage`                                | Forge owns operational S3 buckets for logs, artifacts, or templates. |
 
 ______________________________________________________________________
@@ -89,7 +89,7 @@ ______________________________________________________________________
 
 ## Common Adoption Order
 
-1. `service_linked_roles` when Spot or other AWS services need bootstrap roles.
+1. `service_linked_roles` when the account needs the EC2 Spot service-linked role.
 1. `opt_in_regions` before deploying into opt-in regions.
 1. `storage` before `aws_config_recording` so the long-term bucket is available as its delivery dependency.
 1. `aws_config_recording` before allocating Dedicated Hosts so their full history is captured.

--- a/docs/getting-started/configure-helpers.md
+++ b/docs/getting-started/configure-helpers.md
@@ -12,17 +12,17 @@ examples/templates/helpers
 
 ## Helper Modules
 
-| Helper                 | Use when                                                            | Skip when                                    |
-| ---------------------- | ------------------------------------------------------------------- | -------------------------------------------- |
-| `opt_in_regions`       | The AWS region is disabled by default.                              | The region is already enabled.               |
-| `service_linked_roles` | EC2 Spot or another AWS service role is missing.                    | Your account bootstrap already creates them. |
-| `ami_policy`           | You enforce AMI use through account policy.                         | AMI policy is handled elsewhere.             |
-| `ami_sharing`          | Runner AMIs are produced in one account and consumed in another.    | AMIs are local to the runner account.        |
-| `ecr`                  | Forge owns ECR repos for runner or helper images.                   | Your container platform owns ECR/GHCR.       |
-| `storage`              | Forge owns buckets for artifacts, logs, templates, or integrations. | Buckets are provided by another platform.    |
-| `cloud_formation`      | An integration needs CloudFormation admin/execution roles.          | No integration needs those roles.            |
-| `forge_subscription`   | Tenants need Forge-managed IAM, S3, Packer, ECR, or Secrets access. | Tenant access is managed elsewhere.          |
-| `cloud_custodian`      | You want scheduled cleanup and policy sweeps.                       | Another job owns cleanup.                    |
+| Helper                 | Use when                                                            | Skip when                                  |
+| ---------------------- | ------------------------------------------------------------------- | ------------------------------------------ |
+| `opt_in_regions`       | The AWS region is disabled by default.                              | The region is already enabled.             |
+| `service_linked_roles` | The EC2 Spot service-linked role is missing.                        | Your account bootstrap already creates it. |
+| `ami_policy`           | You enforce AMI use through account policy.                         | AMI policy is handled elsewhere.           |
+| `ami_sharing`          | Runner AMIs are produced in one account and consumed in another.    | AMIs are local to the runner account.      |
+| `ecr`                  | Forge owns ECR repos for runner or helper images.                   | Your container platform owns ECR/GHCR.     |
+| `storage`              | Forge owns buckets for artifacts, logs, templates, or integrations. | Buckets are provided by another platform.  |
+| `cloud_formation`      | An integration needs CloudFormation admin/execution roles.          | No integration needs those roles.          |
+| `forge_subscription`   | Tenants need Forge-managed IAM, S3, Packer, ECR, or Secrets access. | Tenant access is managed elsewhere.        |
+| `cloud_custodian`      | You want scheduled cleanup and policy sweeps.                       | Another job owns cleanup.                  |
 
 ## Files To Change First
 

--- a/docs/getting-started/platform-engineer.md
+++ b/docs/getting-started/platform-engineer.md
@@ -56,8 +56,7 @@ ______________________________________________________________________
    - `modules/helpers/ecr` for operational ECR repositories.
    - `modules/helpers/storage` for operational S3 buckets.
    - `modules/helpers/opt_in_regions` for AWS opt-in regions.
-   - `modules/helpers/service_linked_roles` for EC2 Spot and AWS service-linked
-     roles.
+   - `modules/helpers/service_linked_roles` for the EC2 Spot service-linked role.
    - `modules/helpers/cloud_formation` for CloudFormation-backed integrations.
    - `modules/helpers/aws_config_recording` for Dedicated Host and instance
      configuration history.

--- a/docs/reference/module-catalog.md
+++ b/docs/reference/module-catalog.md
@@ -40,7 +40,7 @@ EC2-only deployments can skip `examples/deployments/infra`.
 | `modules/helpers/ecr`                  | ECR repositories for runner and CI helper containers.        | Optional  | `examples/deployments/helpers` | Push/pull smoke for configured repositories.    |
 | `modules/helpers/forge_subscription`   | Tenant-side access for ForgeMT jobs and artifacts.           | Optional  | `examples/deployments/helpers` | Tenant role can access intended S3/ECR/secrets. |
 | `modules/helpers/opt_in_regions`       | Enables AWS opt-in regions.                                  | Sometimes | `examples/deployments/helpers` | AWS account region status is enabled.           |
-| `modules/helpers/service_linked_roles` | Creates service-linked roles such as EC2 Spot roles.         | Sometimes | `examples/deployments/helpers` | Role exists before EC2 runner launch.           |
+| `modules/helpers/service_linked_roles` | Creates the EC2 Spot service-linked role.                    | Sometimes | `examples/deployments/helpers` | Role exists before EC2 runner launch.           |
 | `modules/helpers/storage`              | S3 buckets for artifacts, templates, logs, and integrations. | Optional  | `examples/deployments/helpers` | Bucket policy, encryption, and access checks.   |
 
 Helpers are not runtime platform modules. Deploy them only when ForgeMT owns

--- a/docs/reference/module-dependencies.md
+++ b/docs/reference/module-dependencies.md
@@ -8,16 +8,16 @@ ______________________________________________________________________
 
 ## Practical Rollout Order
 
-| Step | Deploy root or module group                                        | Required?                       | Apply when                                                                 |
-| ---- | ------------------------------------------------------------------ | ------------------------------- | -------------------------------------------------------------------------- |
-| 1    | State backend, AWS profiles or roles, tags, and account guardrails | Yes                             | Before any Terragrunt stack.                                               |
-| 2    | `examples/deployments/helpers`: `opt_in_regions`                   | Only for opt-in regions         | Before deploying resources into regions that are disabled by default.      |
-| 3    | `examples/deployments/helpers`: `service_linked_roles`             | Usually for EC2 Spot            | Before EC2 runners if the account lacks required AWS service-linked roles. |
-| 4    | Runner AMI build and optional AMI sharing                          | Needed for EC2 runners          | Before tenant EC2 runner specs reference the AMI.                          |
-| 5    | `examples/deployments/infra`: EKS                                  | Only for ARC/Kubernetes runners | Before tenant `arc_runner_specs`.                                          |
-| 6    | `examples/deployments/platform`: one tenant                        | Yes for Forge runners           | The first real Forge runtime deployment.                                   |
-| 7    | `examples/deployments/helpers`: remaining helpers                  | Optional                        | When Forge owns ECR, buckets, tenant subscription roles, or cleanup jobs.  |
-| 8    | `examples/deployments/integrations`                                | Optional                        | After the platform path works.                                             |
+| Step | Deploy root or module group                                        | Required?                       | Apply when                                                                |
+| ---- | ------------------------------------------------------------------ | ------------------------------- | ------------------------------------------------------------------------- |
+| 1    | State backend, AWS profiles or roles, tags, and account guardrails | Yes                             | Before any Terragrunt stack.                                              |
+| 2    | `examples/deployments/helpers`: `opt_in_regions`                   | Only for opt-in regions         | Before deploying resources into regions that are disabled by default.     |
+| 3    | `examples/deployments/helpers`: `service_linked_roles`             | Usually for EC2 Spot            | Before EC2 runners if the account lacks the EC2 Spot service-linked role. |
+| 4    | Runner AMI build and optional AMI sharing                          | Needed for EC2 runners          | Before tenant EC2 runner specs reference the AMI.                         |
+| 5    | `examples/deployments/infra`: EKS                                  | Only for ARC/Kubernetes runners | Before tenant `arc_runner_specs`.                                         |
+| 6    | `examples/deployments/platform`: one tenant                        | Yes for Forge runners           | The first real Forge runtime deployment.                                  |
+| 7    | `examples/deployments/helpers`: remaining helpers                  | Optional                        | When Forge owns ECR, buckets, tenant subscription roles, or cleanup jobs. |
+| 8    | `examples/deployments/integrations`                                | Optional                        | After the platform path works.                                            |
 
 Do not block a first tenant on Splunk, Teleport, billing, dashboards, or helper
 modules your company already provides.
@@ -49,7 +49,7 @@ ______________________________________________________________________
 | `modules/helpers/storage`              | Before AWS Config recording    | Supplies the long-term S3 delivery bucket used by the example. |
 | `modules/helpers/aws_config_recording` | Before recorded resources      | Captures configuration history from resource creation.         |
 | `modules/helpers/opt_in_regions`       | Yes, for opt-in regions        | Regional resources cannot deploy until the region is enabled.  |
-| `modules/helpers/service_linked_roles` | Usually, for EC2 Spot          | Some accounts need AWS service-linked roles created first.     |
+| `modules/helpers/service_linked_roles` | Usually, for EC2 Spot          | Some accounts need the EC2 Spot service-linked role first.     |
 | `modules/helpers/ami_policy`           | Optional                       | Account policy support for AMI usage.                          |
 | `modules/helpers/ami_sharing`          | Yes, if tenant AMIs are shared | Tenant runner specs must be able to find the AMI.              |
 | `modules/helpers/ecr`                  | Optional                       | Only if Forge owns runner/helper image repositories.           |

--- a/docs/reference/module-layout.md
+++ b/docs/reference/module-layout.md
@@ -57,7 +57,7 @@ ______________________________________________________________________
 | `modules/helpers/ecr`                  | Creates ECR repositories for runner, sidecar, Lambda, or operational images.                |
 | `modules/helpers/forge_subscription`   | Creates tenant-side roles and access policies for Forge runner jobs.                        |
 | `modules/helpers/opt_in_regions`       | Enables AWS opt-in regions.                                                                 |
-| `modules/helpers/service_linked_roles` | Creates AWS service-linked roles used by services such as EC2 Spot.                         |
+| `modules/helpers/service_linked_roles` | Creates the EC2 Spot service-linked role.                                                   |
 | `modules/helpers/storage`              | Creates S3 buckets for artifacts, templates, logs, and operational data.                    |
 
 Helpers are useful, but they are not the runner runtime. Deploy them when your

--- a/examples/deployments/helpers/terragrunt/_global_settings/dedicated_mac_hosts.hcl
+++ b/examples/deployments/helpers/terragrunt/_global_settings/dedicated_mac_hosts.hcl
@@ -29,12 +29,6 @@ locals {
   }
 }
 
-dependencies {
-  paths = [
-    find_in_parent_folders("service_linked_roles")
-  ]
-}
-
 inputs = {
   aws_profile = local.default_aws_profile
   aws_region  = local.region

--- a/modules/helpers/service_linked_roles/README.md
+++ b/modules/helpers/service_linked_roles/README.md
@@ -1,22 +1,20 @@
 # Service-Linked Roles
 
-This module creates AWS service-linked roles that Forge expects to exist in runner accounts.
+This module creates the EC2 Spot service-linked role that Forge expects to exist in runner accounts.
 
 ## Why This Module Exists
 
-EC2 runner pools can use Spot capacity and other AWS services that depend on account-level service-linked roles. Creating those roles up front avoids first-use failures during runner scale-up.
+EC2 runner pools can use Spot capacity, which depends on an account-level service-linked role. Creating that role up front avoids first-use failures during runner scale-up.
 
 ## What It Manages
 
 - The EC2 Spot service-linked role.
-- The License Manager core service-linked role used by dedicated Mac hosts.
 - Standard account and region inputs for bootstrap consistency.
 
 ## Operational Notes
 
 - Apply this before enabling Spot-backed EC2 runner pools.
-- Apply this before creating the License Manager configuration and resource group for dedicated Mac hosts.
-- AWS service-linked roles are account scoped and may already exist; Terraform should own them only where this module is the bootstrap authority.
+- The EC2 Spot service-linked role is account scoped and may already exist; Terraform should own it only where this module is the bootstrap authority.
 - This does not decide whether a runner pool uses Spot; that is configured in the EC2 deployment specs.
 
 <!-- BEGIN_TF_DOCS -->
@@ -41,7 +39,6 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
-| [aws_iam_service_linked_role.license_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 | [aws_iam_service_linked_role.spot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_linked_role) | resource |
 | [aws_servicecatalogappregistry_application.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/servicecatalogappregistry_application) | resource |
 

--- a/modules/helpers/service_linked_roles/main.tf
+++ b/modules/helpers/service_linked_roles/main.tf
@@ -4,8 +4,10 @@ resource "aws_iam_service_linked_role" "spot" {
   tags_all         = local.all_security_tags
 }
 
-resource "aws_iam_service_linked_role" "license_manager" {
-  aws_service_name = "license-manager.amazonaws.com"
-  tags             = local.all_security_tags
-  tags_all         = local.all_security_tags
+removed {
+  from = aws_iam_service_linked_role.license_manager
+
+  lifecycle {
+    destroy = false
+  }
 }

--- a/modules/helpers/service_linked_roles/tests/behavior.tftest.hcl
+++ b/modules/helpers/service_linked_roles/tests/behavior.tftest.hcl
@@ -17,12 +17,9 @@ run "service_linked_role_contract" {
   assert {
     condition = (
       aws_iam_service_linked_role.spot.aws_service_name == "spot.amazonaws.com"
-      && aws_iam_service_linked_role.license_manager.aws_service_name == "license-manager.amazonaws.com"
       && aws_iam_service_linked_role.spot.tags.Product == "Forge"
       && aws_iam_service_linked_role.spot.tags.Env == "test"
-      && aws_iam_service_linked_role.license_manager.tags.Product == "Forge"
-      && aws_iam_service_linked_role.license_manager.tags.Env == "test"
     )
-    error_message = "Service-linked role helper must keep the Spot and License Manager service-linked roles with merged security tags."
+    error_message = "Service-linked role helper must keep the Spot service-linked role with merged security tags."
   }
 }

--- a/modules/helpers/service_linked_roles/tests/source_inventory.tftest.hcl
+++ b/modules/helpers/service_linked_roles/tests/source_inventory.tftest.hcl
@@ -8,8 +8,9 @@ run "helpers_service_linked_roles_source_inventory" {
   variables {
     module_path = "."
     expected_literals = [
-      "resource \"aws_iam_service_linked_role\" \"license_manager\"",
       "resource \"aws_iam_service_linked_role\" \"spot\"",
+      "from = aws_iam_service_linked_role.license_manager",
+      "destroy = false",
       "provider \"aws\"",
     ]
   }
@@ -20,7 +21,7 @@ run "helpers_service_linked_roles_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 3
-    error_message = "Source inventory must keep 3 module-specific Terraform blocks pinned."
+    condition     = output.expected_literal_count == 4
+    error_message = "Source inventory must keep 4 module-specific Terraform source contracts pinned."
   }
 }


### PR DESCRIPTION
## Description

- Stop managing the AWS License Manager service-linked role because License Manager creates it automatically when required.
- Preserve existing roles during upgrades by removing the Terraform state entry without destroying the AWS resource.
- Remove the dedicated Mac hosts ordering dependency and align the helper documentation and tests with the remaining EC2 Spot role.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu fmt -check -recursive modules/helpers/service_linked_roles`
- `tofu -chdir=modules/helpers/service_linked_roles init -backend=false -input=false`
- `tofu -chdir=modules/helpers/service_linked_roles validate -no-color`
- `tofu -chdir=modules/helpers/service_linked_roles test -no-color` (3 passed)
- `tflint --chdir=modules/helpers/service_linked_roles --disable-rule=terraform_required_providers --no-color`
- `terragrunt hcl format --check --file examples/deployments/helpers/terragrunt/_global_settings/dedicated_mac_hosts.hcl`
- Repository pre-commit suite (all hooks passed)
- `git diff --check`
