### PR TITLE
chore(helpers): remove License Manager state migration

### DIFF
--- a/modules/helpers/service_linked_roles/main.tf
+++ b/modules/helpers/service_linked_roles/main.tf
@@ -3,11 +3,3 @@ resource "aws_iam_service_linked_role" "spot" {
   tags             = local.all_security_tags
   tags_all         = local.all_security_tags
 }
-
-removed {
-  from = aws_iam_service_linked_role.license_manager
-
-  lifecycle {
-    destroy = false
-  }
-}

--- a/modules/helpers/service_linked_roles/tests/source_inventory.tftest.hcl
+++ b/modules/helpers/service_linked_roles/tests/source_inventory.tftest.hcl
@@ -9,8 +9,6 @@ run "helpers_service_linked_roles_source_inventory" {
     module_path = "."
     expected_literals = [
       "resource \"aws_iam_service_linked_role\" \"spot\"",
-      "from = aws_iam_service_linked_role.license_manager",
-      "destroy = false",
       "provider \"aws\"",
     ]
   }
@@ -21,7 +19,7 @@ run "helpers_service_linked_roles_source_inventory" {
   }
 
   assert {
-    condition     = output.expected_literal_count == 4
-    error_message = "Source inventory must keep 4 module-specific Terraform source contracts pinned."
+    condition     = output.expected_literal_count == 2
+    error_message = "Source inventory must keep 2 module-specific Terraform source contracts pinned."
   }
 }


### PR DESCRIPTION
## Description

This PR is stacked on #642.

- Remove the temporary License Manager state-migration block after the service-linked role has been detached from OpenTofu state.
- Restore the service-linked-role source inventory to its steady-state EC2 Spot-only contract.

**Merge gate:** Do not merge this PR until #642 has been merged and released, that migration release has been applied to every affected `service_linked_roles` state, and each state has been verified to no longer track `aws_iam_service_linked_role.license_manager` while the AWS-managed role remains intact. Consumers that skip the migration release could otherwise plan destruction of the role.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [x] Other: State migration cleanup

## Testing

- `tofu fmt -check -recursive modules/helpers/service_linked_roles`
- `tofu -chdir=modules/helpers/service_linked_roles init -backend=false -input=false`
- `tofu -chdir=modules/helpers/service_linked_roles validate -no-color`
- `tofu -chdir=modules/helpers/service_linked_roles test -no-color` (3 passed)
- `tflint --chdir=modules/helpers/service_linked_roles --disable-rule=terraform_required_providers --no-color`
- Repository pre-commit suite (all hooks passed)
- `git diff --check`
