### PR TITLE
fix(runners): preserve example pre-install userdata

### DIFF
--- a/examples/deployments/platform/terragrunt/environments/prod/regions/eu-west-1/vpcs/main/tenants/acme/runner_settings.hcl
+++ b/examples/deployments/platform/terragrunt/environments/prod/regions/eu-west-1/vpcs/main/tenants/acme/runner_settings.hcl
@@ -114,7 +114,8 @@ locals {
           detailed_monitoring_enabled = true
           ssm_enabled                 = true
           user_data = {
-            enabled = true
+            enabled     = true
+            pre_install = "# No pre-install steps."
           }
           instance_target_capacity_type = "on-demand"
           instance_types                = spec.instance_types

--- a/examples/templates/platform/tenant/runner_settings.hcl
+++ b/examples/templates/platform/tenant/runner_settings.hcl
@@ -114,7 +114,8 @@ locals {
           detailed_monitoring_enabled = true
           ssm_enabled                 = true
           user_data = {
-            enabled = true
+            enabled     = true
+            pre_install = "# No pre-install steps."
           }
           instance_target_capacity_type = "on-demand"
           instance_types                = spec.instance_types


### PR DESCRIPTION
## Description

Follow-up to #638 that preserves the EC2 example's previous launch-template user-data bytes.

The legacy EC2 path supplied `# No pre-install steps.` as `userdata_pre_install`. The nested `compute_provider.ec2.user_data` adapter otherwise falls back to an empty string. This sets the same value explicitly in both the platform template and checked-in deployment example.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: ___________

## Testing

- `pre-commit run terragrunt-hcl-fmt --files examples/templates/platform/tenant/runner_settings.hcl examples/deployments/platform/terragrunt/environments/prod/regions/eu-west-1/vpcs/main/tenants/acme/runner_settings.hcl`
- `RELEASE_VERSION_PATH=$PWD/examples/deployments/platform/release_versions.yml terragrunt hcl validate --working-dir examples/deployments/platform/terragrunt/environments`
- `python -m pytest -q tests/quality/examples_contract_test.py` (4 passed)
- Signed commit hooks passed.
