### PR TITLE
feat(splunk-o11y): support cross-region ingest token

### DIFF
--- a/modules/integrations/splunk_o11y_aws_integration/README.md
+++ b/modules/integrations/splunk_o11y_aws_integration/README.md
@@ -10,12 +10,14 @@ Forge uses Splunk Observability for AWS metrics while Splunk Cloud handles logs.
 
 - A CloudFormation stack created from the configured template URL.
 - Secret lookups for Splunk access material.
+- Optional cross-region lookup of the Splunk ingest token, defaulting to the deployment region.
 - Region, ingest URL, and tagging inputs for the integration.
 - Application of the common Forge tags to the regional Splunk-managed CloudWatch Metric Stream.
 
 ## Operational Notes
 
 - This module depends on a valid Splunk-provided template URL.
+- Set `splunk_ingest_token_region` when the regional stack is deployed outside the region that stores the shared ingest token. Existing callers continue to read the token from `aws_region` by default.
 - CloudFormation failures should be debugged in both Terraform output and the CloudFormation events.
 - Use the common integration module for IAM role setup when needed.
 - Metric Stream tag management requires the AWS CLI and `cloudwatch:ListMetricStreams`, `cloudwatch:TagResource`, and `cloudwatch:UntagResource` permissions for the configured AWS profile.
@@ -58,6 +60,7 @@ No modules.
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | AWS profile to use. | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | Default AWS region. | `string` | n/a | yes |
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
+| <a name="input_splunk_ingest_token_region"></a> [splunk\_ingest\_token\_region](#input\_splunk\_ingest\_token\_region) | AWS region containing the Splunk ingest token secret. Defaults to aws\_region. | `string` | `null` | no |
 | <a name="input_splunk_ingest_url"></a> [splunk\_ingest\_url](#input\_splunk\_ingest\_url) | URL for Splunk Ingest. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to resources. | `map(string)` | n/a | yes |
 | <a name="input_template_url"></a> [template\_url](#input\_template\_url) | URL for the CloudFormation template. | `string` | n/a | yes |

--- a/modules/integrations/splunk_o11y_aws_integration/secrets.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/secrets.tf
@@ -1,4 +1,6 @@
 locals {
+  splunk_ingest_token_region = coalesce(var.splunk_ingest_token_region, var.aws_region)
+
   secrets = {
     splunk_o11y_ingest_token_aws_integration = {
       name = "/cicd/common/splunk_o11y_ingest_token_aws_integration"
@@ -9,9 +11,11 @@ locals {
 data "aws_secretsmanager_secret" "secrets" {
   for_each = local.secrets
   name     = each.value.name
+  region   = local.splunk_ingest_token_region
 }
 
 data "aws_secretsmanager_secret_version" "secrets" {
   for_each  = data.aws_secretsmanager_secret.secrets
   secret_id = each.value.id
+  region    = local.splunk_ingest_token_region
 }

--- a/modules/integrations/splunk_o11y_aws_integration/tests/behavior.tftest.hcl
+++ b/modules/integrations/splunk_o11y_aws_integration/tests/behavior.tftest.hcl
@@ -87,3 +87,20 @@ run "splunk_o11y_cloudformation_stack_contract" {
     error_message = "Metric Stream tag management must replace on stack, template, script, or desired-tag changes."
   }
 }
+
+run "splunk_o11y_cross_region_secret_lookup" {
+  command = plan
+
+  variables {
+    aws_region                 = "us-west-2"
+    splunk_ingest_token_region = "us-east-1"
+  }
+
+  assert {
+    condition = (
+      data.aws_secretsmanager_secret.secrets["splunk_o11y_ingest_token_aws_integration"].region == "us-east-1"
+      && data.aws_secretsmanager_secret_version.secrets["splunk_o11y_ingest_token_aws_integration"].region == "us-east-1"
+    )
+    error_message = "The regional integration must be able to read the shared Splunk ingest token from a different AWS region."
+  }
+}

--- a/modules/integrations/splunk_o11y_aws_integration/tests/interface_contract.tftest.hcl
+++ b/modules/integrations/splunk_o11y_aws_integration/tests/interface_contract.tftest.hcl
@@ -12,6 +12,7 @@ run "integrations_splunk_o11y_aws_integration_interface_contract" {
       "aws_region",
       "default_tags",
       "splunk_ingest_url",
+      "splunk_ingest_token_region",
       "tags",
       "template_url",
     ]
@@ -27,6 +28,9 @@ run "integrations_splunk_o11y_aws_integration_interface_contract" {
       "description = \"A map of tags to apply to resources.\"",
       "variable \"splunk_ingest_url\"",
       "description = \"URL for Splunk Ingest.\"",
+      "variable \"splunk_ingest_token_region\"",
+      "description = \"AWS region containing the Splunk ingest token secret. Defaults to aws_region.\"",
+      "default     = null",
       "variable \"tags\"",
       "variable \"template_url\"",
       "description = \"URL for the CloudFormation template.\"",
@@ -60,9 +64,9 @@ run "integrations_splunk_o11y_aws_integration_interface_contract" {
 
   assert {
     condition = (
-      output.expected_input_variable_count == 6
+      output.expected_input_variable_count == 7
       && output.expected_output_value_count == 0
-      && output.expected_interface_literal_count == 13
+      && output.expected_interface_literal_count == 16
     )
     error_message = "Interface contract counts must remain pinned for inputs, outputs, and source literals."
   }

--- a/modules/integrations/splunk_o11y_aws_integration/tests/source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_o11y_aws_integration/tests/source_inventory.tftest.hcl
@@ -12,6 +12,7 @@ run "integrations_splunk_o11y_aws_integration_contract" {
       "resource \"terraform_data\" \"cloudwatch_metric_stream_tags\"",
       "data \"aws_secretsmanager_secret\" \"secrets\"",
       "data \"aws_secretsmanager_secret_version\" \"secrets\"",
+      "region   = local.splunk_ingest_token_region",
       "provider \"aws\"",
       "AWS_PROFILE",
       "working_dir = path.module",

--- a/modules/integrations/splunk_o11y_aws_integration/variables.tf
+++ b/modules/integrations/splunk_o11y_aws_integration/variables.tf
@@ -13,6 +13,12 @@ variable "splunk_ingest_url" {
   type        = string
 }
 
+variable "splunk_ingest_token_region" {
+  description = "AWS region containing the Splunk ingest token secret. Defaults to aws_region."
+  type        = string
+  default     = null
+}
+
 variable "template_url" {
   description = "URL for the CloudFormation template."
   type        = string


### PR DESCRIPTION
## Summary

- Add an optional `splunk_ingest_token_region` input to the regional Splunk O11y AWS integration module.
- Default the token lookup to `aws_region`, preserving all existing callers.
- Allow a regional bootstrap such as `us-west-2` to read the existing shared ingest token from `us-east-1`.
- Document and test the cross-region behavior.

## Why

The Splunk AWS integration needs regional CloudFormation prerequisites before the common integration enables a new region. The shared ingest token currently lives in one primary region. Reading it cross-region avoids duplicating the secret and avoids rotation drift.

## Validation

- `tofu fmt -check -recursive modules/integrations/splunk_o11y_aws_integration`
- `tofu -chdir=modules/integrations/splunk_o11y_aws_integration validate`
- `tofu -chdir=modules/integrations/splunk_o11y_aws_integration test` — 4 passed
- `git diff --check`

No infrastructure was applied.