### PR TITLE
fix(splunk): prevent CloudWatch props ACL recreation

### DIFF
--- a/modules/integrations/splunk_cloud_conf_shared/props_ec2.tf
+++ b/modules/integrations/splunk_cloud_conf_shared/props_ec2.tf
@@ -19,6 +19,8 @@ resource "splunk_configs_conf" "forgecicd_cloudwatchlogs_forgecicd" {
 
   lifecycle {
     ignore_changes = [
+      acl[0].app,
+      acl[0].sharing,
       variables["ADD_EXTRA_TIME_FIELDS"],
       variables["ANNOTATE_PUNCT"],
       variables["AUTO_KV_JSON"],

--- a/modules/integrations/splunk_cloud_conf_shared/tests/behavior.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/behavior.tftest.hcl
@@ -609,3 +609,64 @@ run "organizes_webhook_health_for_operator_triage" {
     error_message = "The dashboard must order queued-job summary cards, the actionable queue table, relay health, trends, and raw events from top to bottom."
   }
 }
+
+run "seed_cloudwatchlogs_forgecicd_acl" {
+  command = apply
+
+  variables {
+    aws_profile  = "test"
+    aws_region   = "us-east-1"
+    default_tags = { Product = "Forge" }
+    splunk_conf = {
+      splunk_cloud = "https://splunk.example.com"
+      index        = "forge-prod-index"
+      tenant_names = ["tenant-a"]
+      acl = {
+        app     = "baseline-app"
+        owner   = "baseline-owner"
+        sharing = "app"
+        read    = ["baseline-reader"]
+        write   = ["baseline-writer"]
+      }
+    }
+    stuck_workflow_job_dispatcher_name_prefix = "forge-dispatcher"
+  }
+}
+
+run "ignores_only_force_new_cloudwatchlogs_forgecicd_acl_drift" {
+  command = plan
+
+  plan_options {
+    refresh = false
+  }
+
+  variables {
+    aws_profile  = "test"
+    aws_region   = "us-east-1"
+    default_tags = { Product = "Forge" }
+    splunk_conf = {
+      splunk_cloud = "https://splunk.example.com"
+      index        = "forge-prod-index"
+      tenant_names = ["tenant-a"]
+      acl = {
+        app     = "changed-app"
+        owner   = "changed-owner"
+        sharing = "global"
+        read    = ["changed-reader"]
+        write   = ["changed-writer"]
+      }
+    }
+    stuck_workflow_job_dispatcher_name_prefix = "forge-dispatcher"
+  }
+
+  assert {
+    condition = (
+      splunk_configs_conf.forgecicd_cloudwatchlogs_forgecicd.acl[0].app == "baseline-app"
+      && splunk_configs_conf.forgecicd_cloudwatchlogs_forgecicd.acl[0].sharing == "app"
+      && splunk_configs_conf.forgecicd_cloudwatchlogs_forgecicd.acl[0].owner == "changed-owner"
+      && splunk_configs_conf.forgecicd_cloudwatchlogs_forgecicd.acl[0].read[0] == "changed-reader"
+      && splunk_configs_conf.forgecicd_cloudwatchlogs_forgecicd.acl[0].write[0] == "changed-writer"
+    )
+    error_message = "CloudWatch Logs props must ignore replacement-only ACL app/sharing drift while continuing to manage owner and read/write permissions."
+  }
+}

--- a/modules/integrations/splunk_cloud_conf_shared/tests/source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_cloud_conf_shared/tests/source_inventory.tftest.hcl
@@ -30,6 +30,8 @@ run "integrations_splunk_cloud_conf_shared_contract" {
       "resource \"splunk_configs_conf\" \"forgecicd_aws_billing_cur\"",
       "resource \"splunk_configs_conf\" \"forgecicd_cloudwatchlogs\"",
       "resource \"splunk_configs_conf\" \"forgecicd_cloudwatchlogs_forgecicd\"",
+      "acl[0].app",
+      "acl[0].sharing",
       "resource \"splunk_configs_conf\" \"forgecicd_metadata\"",
       "resource \"splunk_configs_conf\" \"forgecicd_kube_container_runner\"",
       "resource \"splunk_configs_conf\" \"forgecicd_kube_container_runner_logs\"",


### PR DESCRIPTION
## Description

Prevent the `props/aws:cloudwatchlogs:forgecicd` configuration from being recreated when Splunk normalizes its ACL namespace or sharing values.

The Splunk provider treats `acl.app` and `acl.sharing` as replacement-only fields. This change ignores drift only for those fields while continuing to manage the ACL owner, read permissions, write permissions, and stanza variables.

A state-transition regression test verifies that replacement-only ACL drift is retained while updateable ACL fields continue to follow configuration changes.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu -chdir=modules/integrations/splunk_cloud_conf_shared validate -no-color`
- `tflint --chdir=modules/integrations/splunk_cloud_conf_shared --disable-rule=terraform_required_providers --no-color`
- `tofu -chdir=modules/integrations/splunk_cloud_conf_shared test -no-color` — 13 passed
- `pre-commit run --files modules/integrations/splunk_cloud_conf_shared/props_ec2.tf modules/integrations/splunk_cloud_conf_shared/tests/behavior.tftest.hcl modules/integrations/splunk_cloud_conf_shared/tests/source_inventory.tftest.hcl`