### PR TITLE
chore(arc): guard maintenance node scheduling

### DIFF
--- a/modules/infra/eks/karpenter.tf
+++ b/modules/infra/eks/karpenter.tf
@@ -47,6 +47,8 @@ metadata:
   name: karpenter
 EOF2
 
+# Keep tolerations key-scoped so maintenance=true:NoSchedule remains
+# unmatched while a node is prepared for drain.
 helm --kube-context ${self.triggers.kube_context} upgrade \
   --install karpenter oci://public.ecr.aws/karpenter/karpenter \
   --namespace karpenter \

--- a/modules/infra/eks/tests/source_inventory.tftest.hcl
+++ b/modules/infra/eks/tests/source_inventory.tftest.hcl
@@ -19,6 +19,8 @@ run "infra_eks_contract" {
       "resource \"null_resource\" \"patch_calico_installation\"",
       "resource \"null_resource\" \"wait_for_cluster\"",
       "resource \"null_resource\" \"karpenter\"",
+      "--set 'tolerations[0].key'=CriticalAddonsOnly",
+      "--set 'tolerations[1].key'=karpenter.sh/controller",
       "resource \"null_resource\" \"apply_ec2_node_class\"",
       "resource \"null_resource\" \"apply_node_pool\"",
       "data \"aws_eks_addon_version\" \"aws_ebs_csi_driver\"",

--- a/modules/platform/arc/README.md
+++ b/modules/platform/arc/README.md
@@ -22,6 +22,73 @@ In Forge, the Kubernetes lane turns GitHub Actions jobs into ephemeral pods. Thi
 - The controller and scale-set listeners expose `/metrics` on port `8080` with Prometheus discovery annotations.
 - Listener metrics retain repository, job, event, result, and workflow dimensions. The managed Prometheus chart and Splunk OTel Prometheus autodiscovery can scrape the same endpoints independently; do not add Prometheus remote write to the collector unless direct collector scraping is disabled.
 
+## Karpenter Node Maintenance
+
+`maintenance=true:NoSchedule` prevents new Forge pods from scheduling on a
+node. It does not evict pods that are already running, and an existing idle
+runner can still accept a job. Quiesce the affected scale sets before draining
+the node.
+
+First confirm that Karpenter owns the node. The output must include a NodePool
+name and the `karpenter.sh/termination` finalizer:
+
+```bash
+kubectl get node "$node" \
+  -o jsonpath='{.metadata.labels.karpenter\.sh/nodepool}{"\n"}{.metadata.finalizers}{"\n"}'
+```
+
+Taint the node:
+
+```bash
+kubectl taint node "$node" maintenance=true:NoSchedule --overwrite
+```
+
+Pause new job submissions or route them to another runner lane, then wait until
+the affected scale sets report `gha_assigned_jobs = 0` and
+`gha_running_jobs = 0`. Use the normal tenant deployment workflow to set both
+runner bounds to zero for every affected scale set. This is ARC's supported
+[jobs queue draining](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets#example-jobs-queue-draining)
+configuration:
+
+```hcl
+runner_size = {
+  max_runners = 0
+  min_runners = 0
+}
+```
+
+Record the original bounds before applying the change. Wait until the target
+node has no runner or job pods. Checking the pod list before queue-drain mode
+has an assignment race: an existing idle runner could accept a job after the
+check.
+
+Then inspect, drain, and delete the node:
+
+```bash
+kubectl get pods --all-namespaces \
+  --field-selector "spec.nodeName=$node" \
+  -o wide
+
+# Run only after active runner and job pods have completed.
+kubectl drain "$node" \
+  --ignore-daemonsets \
+  --delete-emptydir-data
+
+kubectl delete node "$node" --wait=false
+kubectl wait --for=delete "node/$node" --timeout=10m
+```
+
+Karpenter's termination finalizer terminates the backing instance before it
+allows the Node object to disappear. If the NodePool label or finalizer is
+missing, stop: deleting a self-managed or ASG-backed Node object does not
+terminate its EC2 instance. Use the owning node-group workflow instead. Do not
+bypass PodDisruptionBudgets with `--disable-eviction` or unmanaged-pod checks
+with `--force` without investigating the blocker.
+
+After node deletion is confirmed, restore the original runner bounds through
+the normal tenant deployment workflow. Wait for the required runner capacity
+to become ready before resuming job submissions.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/platform/arc/README.md
+++ b/modules/platform/arc/README.md
@@ -22,20 +22,35 @@ In Forge, the Kubernetes lane turns GitHub Actions jobs into ephemeral pods. Thi
 - The controller and scale-set listeners expose `/metrics` on port `8080` with Prometheus discovery annotations.
 - Listener metrics retain repository, job, event, result, and workflow dimensions. The managed Prometheus chart and Splunk OTel Prometheus autodiscovery can scrape the same endpoints independently; do not add Prometheus remote write to the collector unless direct collector scraping is disabled.
 
-## Karpenter Node Maintenance
+## ARC Node Maintenance
 
 `maintenance=true:NoSchedule` prevents new Forge pods from scheduling on a
 node. It does not evict pods that are already running, and an existing idle
 runner can still accept a job. Quiesce the affected scale sets before draining
-the node.
+the node. This procedure applies to both Karpenter nodes and the fixed-capacity
+self-managed node group backed by an EC2 Auto Scaling group (ASG).
 
-First confirm that Karpenter owns the node. The output must include a NodePool
-name and the `karpenter.sh/termination` finalizer:
+First identify the owner. Configure the AWS CLI for the cluster account and
+Region, then inspect the Karpenter metadata and ASG membership:
 
 ```bash
+provider_id="$(kubectl get node "$node" -o jsonpath='{.spec.providerID}')"
+instance_id="${provider_id##*/}"
+asg_name="$(aws autoscaling describe-auto-scaling-instances \
+  --instance-ids "$instance_id" \
+  --query 'AutoScalingInstances[0].AutoScalingGroupName' \
+  --output text)"
+
 kubectl get node "$node" \
   -o jsonpath='{.metadata.labels.karpenter\.sh/nodepool}{"\n"}{.metadata.finalizers}{"\n"}'
+printf 'instance_id=%s\nasg_name=%s\n' "$instance_id" "$asg_name"
 ```
+
+A Karpenter node must have a NodePool label and the
+`karpenter.sh/termination` finalizer, with no ASG membership. An ASG-backed node
+must resolve to the expected cluster ASG and must not have Karpenter ownership
+metadata. Stop if the provider ID is empty, ownership is ambiguous, or the ASG
+name is `None` for a node believed to be ASG-backed.
 
 Taint the node:
 
@@ -62,7 +77,7 @@ node has no runner or job pods. Checking the pod list before queue-drain mode
 has an assignment race: an existing idle runner could accept a job after the
 check.
 
-Then inspect, drain, and delete the node:
+Then inspect and drain the node:
 
 ```bash
 kubectl get pods --all-namespaces \
@@ -73,21 +88,114 @@ kubectl get pods --all-namespaces \
 kubectl drain "$node" \
   --ignore-daemonsets \
   --delete-emptydir-data
+```
 
+Do not bypass PodDisruptionBudgets with `--disable-eviction` or unmanaged-pod
+checks with `--force` without investigating the blocker. After drain succeeds,
+use exactly one of the following ownership-specific paths.
+
+### Delete a Karpenter Node
+
+Reconfirm the NodePool label and `karpenter.sh/termination` finalizer, then
+delete the Node object:
+
+```bash
 kubectl delete node "$node" --wait=false
 kubectl wait --for=delete "node/$node" --timeout=10m
 ```
 
 Karpenter's termination finalizer terminates the backing instance before it
-allows the Node object to disappear. If the NodePool label or finalizer is
-missing, stop: deleting a self-managed or ASG-backed Node object does not
-terminate its EC2 instance. Use the owning node-group workflow instead. Do not
-bypass PodDisruptionBudgets with `--disable-eviction` or unmanaged-pod checks
-with `--force` without investigating the blocker.
+allows the Node object to disappear. Stop if either ownership marker is
+missing; deleting a self-managed or ASG-backed Node object does not terminate
+its EC2 instance, and its kubelet can register again.
 
-After node deletion is confirmed, restore the original runner bounds through
-the normal tenant deployment workflow. Wait for the required runner capacity
-to become ready before resuming job submissions.
+### Replace an ASG-backed Node
+
+Reconfirm that the instance belongs to the expected cluster ASG. Inspect its
+cluster ownership tag, desired capacity, suspended processes, instance
+protection, and lifecycle hooks:
+
+```bash
+aws autoscaling describe-auto-scaling-groups \
+  --auto-scaling-group-names "$asg_name" \
+  --query 'AutoScalingGroups[0].{
+    Desired:DesiredCapacity,
+    Min:MinSize,
+    Max:MaxSize,
+    SuspendedProcesses:SuspendedProcesses[].ProcessName,
+    ClusterTags:Tags[?starts_with(Key, `kubernetes.io/cluster/`)].{Key:Key,Value:Value},
+    Instances:Instances[].{
+      Id:InstanceId,
+      State:LifecycleState,
+      Health:HealthStatus,
+      Protected:ProtectedFromScaleIn
+    }
+  }'
+
+aws autoscaling describe-lifecycle-hooks \
+  --auto-scaling-group-name "$asg_name"
+
+previous_instance_ids="$(aws autoscaling describe-auto-scaling-groups \
+  --auto-scaling-group-names "$asg_name" \
+  --query 'AutoScalingGroups[0].Instances[].InstanceId' \
+  --output text)"
+printf 'previous_instance_ids=%s\n' "$previous_instance_ids"
+```
+
+The output must contain the expected
+`kubernetes.io/cluster/<cluster-name>=owned` tag and must not list `Launch` or
+`Terminate` as suspended. Account for any lifecycle hooks before continuing.
+An explicit termination request bypasses `ProtectedFromScaleIn`; if it is
+`true`, reconfirm that this is the intended instance.
+
+Terminate the instance through Auto Scaling while preserving desired capacity.
+The [`--no-should-decrement-desired-capacity`](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/terminate-instance-in-auto-scaling-group.html)
+option causes the ASG to launch a replacement:
+
+```bash
+aws autoscaling terminate-instance-in-auto-scaling-group \
+  --instance-id "$instance_id" \
+  --no-should-decrement-desired-capacity
+
+aws ec2 wait instance-terminated --instance-ids "$instance_id"
+kubectl delete node "$node" --ignore-not-found --wait=false
+kubectl wait --for=delete "node/$node" --timeout=10m
+```
+
+Do not use `kubectl delete node` as the ASG termination mechanism. Do not use
+`--should-decrement-desired-capacity` for a replacement. A permanent capacity
+change is a separate operation through the owning capacity workflow and must
+not be combined with node maintenance. If the waiter times out, inspect the ASG
+scaling activity and lifecycle hooks instead of submitting another termination
+request.
+
+Repeat the ASG query until it again has its desired number of healthy
+`InService` instances. Compare the IDs with `previous_instance_ids` and stop
+if there is not exactly one new replacement ID:
+
+```bash
+aws autoscaling describe-auto-scaling-groups \
+  --auto-scaling-group-names "$asg_name" \
+  --query 'AutoScalingGroups[0].{Desired:DesiredCapacity,Instances:Instances[].{Id:InstanceId,State:LifecycleState,Health:HealthStatus}}'
+
+kubectl get nodes \
+  -o 'custom-columns=NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,PROVIDER_ID:.spec.providerID'
+```
+
+Set `replacement_node` to the Node whose provider ID ends with the new
+replacement instance ID, then wait for Kubernetes readiness:
+
+```bash
+kubectl wait \
+  --for=condition=Ready \
+  "node/$replacement_node" \
+  --timeout=10m
+```
+
+After Karpenter deletion is confirmed, or after the ASG replacement Node is
+`Ready`, restore the original runner bounds through the normal tenant
+deployment workflow. Wait for the required runner capacity to become ready
+before resuming job submissions.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/modules/platform/arc/scale_set/helm.tf
+++ b/modules/platform/arc/scale_set/helm.tf
@@ -15,6 +15,8 @@ resource "kubernetes_config_map_v1" "hook_extension" {
       spec:
         automountServiceAccountToken: true
         serviceAccountName: "${var.service_account}"
+        # Keep maintenance=true:NoSchedule unmatched while a node is prepared for drain.
+        tolerations: []
         securityContext:
           fsGroup: 123 # Group used by GitHub default agent image
         containers:

--- a/modules/platform/arc/scale_set/template_files/dind.yml.tftpl
+++ b/modules/platform/arc/scale_set/template_files/dind.yml.tftpl
@@ -257,7 +257,7 @@ template:
                 audience: sts.amazonaws.com
 
     tolerations:
-      # tenant tolerations
+      # Only tenant taints are tolerated; maintenance=true:NoSchedule remains unmatched.
       - key: "forge.local/scale_set_type"
         operator: "Equal"
         value: "dind"

--- a/modules/platform/arc/scale_set/template_files/k8s.yml.tftpl
+++ b/modules/platform/arc/scale_set/template_files/k8s.yml.tftpl
@@ -32,6 +32,8 @@ template:
       fsGroup: 123
     serviceAccountName: ${service_account}
     automountServiceAccountToken: true
+    # Keep maintenance=true:NoSchedule unmatched while a node is prepared for drain.
+    tolerations: []
     containers:
       - name: runner
         image: ${container_images.actions_runner}

--- a/modules/platform/arc/scale_set/template_files/metrics.yml.tftpl
+++ b/modules/platform/arc/scale_set/template_files/metrics.yml.tftpl
@@ -5,6 +5,8 @@ listenerTemplate:
       prometheus.io/path: "/metrics"
       prometheus.io/port: "8080"
   spec:
+    # Keep maintenance=true:NoSchedule unmatched while a node is prepared for drain.
+    tolerations: []
     containers:
       - name: listener
 

--- a/modules/platform/arc/scale_set/tests/behavior.tftest.hcl
+++ b/modules/platform/arc/scale_set/tests/behavior.tftest.hcl
@@ -80,10 +80,11 @@ run "scale_set_contract" {
       kubernetes_config_map_v1.hook_extension[0].metadata[0].name == "hook-extension-tenant-a-linux"
       && kubernetes_config_map_v1.hook_extension[0].metadata[0].namespace == "tenant-a"
       && strcontains(kubernetes_config_map_v1.hook_extension[0].data["container-podspec.yaml"], "serviceAccountName: \"runner\"")
+      && length(yamldecode(kubernetes_config_map_v1.hook_extension[0].data["container-podspec.yaml"]).spec.tolerations) == 0
       && kubernetes_service_account_v1.runner_sa[0].metadata[0].name == "runner"
       && kubernetes_service_account_v1.runner_sa[0].metadata[0].namespace == "tenant-a"
     )
-    error_message = "ARC scale set must keep hook extension and runner service account scoped to the tenant namespace."
+    error_message = "ARC scale set must keep hook extension and runner service account scoped to the tenant namespace without tolerating maintenance nodes."
   }
 
   assert {
@@ -99,8 +100,10 @@ run "scale_set_contract" {
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "prometheus.io/scrape: \"true\"")
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "gha_job_startup_duration_seconds")
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "job_workflow_target")
+      && length(yamldecode(helm_release.gha_runner_scale_set[0].values[0]).template.spec.tolerations) == 0
+      && length(yamldecode(helm_release.gha_runner_scale_set[0].values[0]).listenerTemplate.spec.tolerations) == 0
     )
-    error_message = "ARC scale set Helm release must render runner configuration and annotated high-cardinality listener metrics."
+    error_message = "ARC scale set Helm release must render runner configuration and annotated high-cardinality listener metrics without tolerating maintenance nodes."
   }
 
   assert {
@@ -137,8 +140,21 @@ run "scale_set_dind_contract" {
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "pod-identity-token-custom")
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "gha_completed_jobs_total")
       && strcontains(helm_release.gha_runner_scale_set[0].values[0], "job_workflow_name")
+      && length(yamldecode(helm_release.gha_runner_scale_set[0].values[0]).template.spec.tolerations) == 2
+      && toset([
+        for toleration in yamldecode(helm_release.gha_runner_scale_set[0].values[0]).template.spec.tolerations :
+        toleration.key
+        ]) == toset([
+        "forge.local/scale_set_type",
+        "forge.local/tenant",
+      ])
+      && alltrue([
+        for toleration in yamldecode(helm_release.gha_runner_scale_set[0].values[0]).template.spec.tolerations :
+        toleration.operator == "Equal" && toleration.effect == "NoSchedule"
+      ])
+      && length(yamldecode(helm_release.gha_runner_scale_set[0].values[0]).listenerTemplate.spec.tolerations) == 0
     )
-    error_message = "DinD scale sets must keep tenant isolation, Pod Identity wiring, GHES/DinD values, and high-cardinality listener metrics."
+    error_message = "DinD scale sets must keep exact tenant tolerations, Pod Identity wiring, GHES/DinD values, and high-cardinality listener metrics without tolerating maintenance nodes."
   }
 }
 

--- a/modules/platform/arc/scale_set_controller/template_files/values.yml.tftpl
+++ b/modules/platform/arc/scale_set_controller/template_files/values.yml.tftpl
@@ -71,6 +71,7 @@ resources: {}
 
 nodeSelector: {}
 
+# Keep maintenance=true:NoSchedule unmatched while a node is prepared for drain.
 tolerations: []
 
 affinity: {}

--- a/modules/platform/arc/scale_set_controller/tests/behavior.tftest.hcl
+++ b/modules/platform/arc/scale_set_controller/tests/behavior.tftest.hcl
@@ -48,8 +48,9 @@ run "scale_set_controller_contract" {
       && strcontains(helm_release.gha_runner_scale_set_controller[0].values[0], "controllerManagerAddr: \":8080\"")
       && strcontains(helm_release.gha_runner_scale_set_controller[0].values[0], "listenerEndpoint: \"/metrics\"")
       && strcontains(helm_release.gha_runner_scale_set_controller[0].values[0], "prometheus.io/scrape: \"true\"")
+      && length(yamldecode(helm_release.gha_runner_scale_set_controller[0].values[0]).tolerations) == 0
     )
-    error_message = "ARC controller Helm release must keep chart inputs, safety flags, timeout, lower-case log level values, and annotated Prometheus metrics endpoints."
+    error_message = "ARC controller Helm release must keep chart inputs, safety flags, timeout, lower-case log level values, annotated Prometheus metrics endpoints, and no maintenance-node tolerations."
   }
 }
 

--- a/modules/platform/arc/templates/node_pool.yaml.tpl
+++ b/modules/platform/arc/templates/node_pool.yaml.tpl
@@ -36,6 +36,8 @@
           group: karpenter.k8s.aws
           kind: EC2NodeClass
           name: karpenter-${tenant}
+        # Node-specific maintenance taints are applied by operators. Declaring
+        # one here would make every node in the tenant pool unschedulable.
         taints:
           - key: forge.local/scale_set_type
             value: dind

--- a/modules/platform/arc/tests/behavior.tftest.hcl
+++ b/modules/platform/arc/tests/behavior.tftest.hcl
@@ -168,8 +168,16 @@ run "arc_single_runner_contract" {
       null_resource.apply_ec2_node_class.triggers.migrate_arc_cluster == "false"
       && null_resource.apply_node_pool.triggers.migrate_arc_cluster == "false"
       && length(null_resource.apply_node_pool.triggers.manifest_hash) == 64
+      && length(yamldecode(local.node_pool_manifest).spec.template.spec.taints) == 2
+      && toset([
+        for taint in yamldecode(local.node_pool_manifest).spec.template.spec.taints :
+        taint.key
+        ]) == toset([
+        "forge.local/scale_set_type",
+        "forge.local/tenant",
+      ])
     )
-    error_message = "ARC root module must record non-migration Karpenter trigger values."
+    error_message = "ARC root module must record non-migration Karpenter trigger values and keep NodePool taints limited to tenant isolation."
   }
 }
 

--- a/tests/iac/maintenance_taint_contract_test.py
+++ b/tests/iac/maintenance_taint_contract_test.py
@@ -1,0 +1,32 @@
+"""Offline contracts for maintenance-node scheduling safeguards."""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.contract
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_karpenter_controller_tolerations_remain_key_scoped() -> None:
+    source = REPO_ROOT.joinpath(
+        'modules',
+        'infra',
+        'eks',
+        'karpenter.tf',
+    ).read_text(encoding='utf-8')
+
+    toleration_lines = [
+        line.strip()
+        for line in source.splitlines()
+        if 'tolerations[' in line
+    ]
+
+    assert toleration_lines == [
+        "--set 'tolerations[0].key'=CriticalAddonsOnly \\",
+        "--set 'tolerations[0].operator'=Exists \\",
+        "--set 'tolerations[1].key'=karpenter.sh/controller \\",
+        "--set 'tolerations[1].operator'=Exists \\",
+        "--set 'tolerations[1].effect'=NoSchedule \\",
+    ]


### PR DESCRIPTION
## Description

- Make empty toleration lists explicit for ARC controller, listener, Kubernetes-mode runner, and Kubernetes-mode job pods.
- Pin DinD and Karpenter controller tolerations to their existing key-scoped sets, and keep the tenant NodePool free of a pool-wide maintenance taint.
- Document the shared taint, ARC queue-drain, and Kubernetes drain sequence,
  followed by owner-specific deletion for Karpenter and ASG-backed nodes.
- Preserve ASG desired capacity during node replacement and remove the stale
  Kubernetes Node only after its EC2 instance terminates.

This hardens an existing safe behavior: `maintenance=true:NoSchedule` already blocks new Forge pods because no managed pod tolerates that taint. There is no intended runtime scheduling change. The new contracts prevent a future wildcard or maintenance toleration from silently bypassing the maintenance workflow.

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Refactor
- [x] Other: Contract hardening

## Testing

- `tofu fmt -check -recursive modules/platform/arc modules/infra/eks`
- `tofu validate` and `tofu test` for ARC scale set, ARC controller, ARC root, and EKS modules: 16 tests passed
- TFLint for ARC scale set, ARC controller, ARC root, and EKS modules
- `uv run --project .. --locked --only-group lambda-tests pytest -q iac`: 129 tests passed
- `pre-commit run --files ...`: all applicable hooks passed

No live cluster drain or node deletion was performed.
