### PR TITLE
fix(karpenter): add EBS CSI startup taints

### DIFF
--- a/modules/infra/eks/templates/node_pool.yaml.tpl
+++ b/modules/infra/eks/templates/node_pool.yaml.tpl
@@ -5,6 +5,12 @@ metadata:
 spec:
   template:
     spec:
+      # The EBS CSI node plugin removes this taint after it is ready. Marking
+      # it as a startup taint prevents Karpenter from provisioning duplicate
+      # nodes while the plugin is still initializing.
+      startupTaints:
+        - key: ebs.csi.aws.com/agent-not-ready
+          effect: NoExecute
       requirements:
         - key: karpenter.k8s.aws/instance-family
           operator: In

--- a/modules/platform/arc/templates/node_pool.yaml.tpl
+++ b/modules/platform/arc/templates/node_pool.yaml.tpl
@@ -9,6 +9,12 @@
           forge.local/scale_set_type: dind
           forge.local/tenant: ${tenant}
       spec:
+        # The EBS CSI node plugin removes this taint after it is ready. Marking
+        # it as a startup taint prevents Karpenter from provisioning duplicate
+        # nodes while the plugin is still initializing.
+        startupTaints:
+          - key: ebs.csi.aws.com/agent-not-ready
+            effect: NoExecute
         requirements:
         ${replace(trimspace(yamlencode(requirements)), "\n", "\n        ")}
         nodeClassRef:

--- a/modules/platform/arc/tests/behavior.tftest.hcl
+++ b/modules/platform/arc/tests/behavior.tftest.hcl
@@ -171,6 +171,15 @@ run "arc_single_runner_contract" {
     )
     error_message = "ARC root module must record non-migration Karpenter trigger values."
   }
+
+  assert {
+    condition = (
+      strcontains(file("${path.module}/templates/node_pool.yaml.tpl"), "startupTaints:")
+      && strcontains(file("${path.module}/templates/node_pool.yaml.tpl"), "ebs.csi.aws.com/agent-not-ready")
+      && strcontains(file("${path.module}/templates/node_pool.yaml.tpl"), "effect: NoExecute")
+    )
+    error_message = "Each tenant Karpenter NodePool must declare the EBS CSI bootstrap taint as a startup taint."
+  }
 }
 
 run "arc_migration_contract" {


### PR DESCRIPTION
## Description

Adds the AWS EBS CSI startup taint to the shared EKS and per-tenant ARC Karpenter NodePools. Karpenter can therefore wait for EBS CSI initialization without provisioning duplicate nodes for the same pending runner workload.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- Pre-commit checks passed, including Terraform/Tofu validation and YAML validation.
- Both NodePool templates parse as valid YAML.
- ARC interface contract test passed.
- EKS source inventory test requires `tofu init` because the local module cache is stale.
- ARC behavior test is blocked by the existing Darwin ARM64 Kubernetes provider plugin handshake.
