### PR TITLE
fix(teleport): allow tenant pod exec

### DIFF
--- a/modules/integrations/teleport/tenant/main.tf
+++ b/modules/integrations/teleport/tenant/main.tf
@@ -23,8 +23,15 @@ resource "kubernetes_cluster_role_v1" "pods" {
 
   rule {
     api_groups = [""]
-    resources  = ["pods", "pods/log", "pods/exec"]
+    resources  = ["pods", "pods/log"]
     verbs      = ["get", "watch", "list"]
+  }
+
+  # Keep exec write access isolated from pod and pod-log read access.
+  rule {
+    api_groups = [""]
+    resources  = ["pods/exec"]
+    verbs      = ["get", "create"]
   }
 
 }

--- a/modules/integrations/teleport/tenant/tests/behavior.tftest.hcl
+++ b/modules/integrations/teleport/tenant/tests/behavior.tftest.hcl
@@ -23,12 +23,14 @@ run "teleport_tenant_rbac_contract" {
       kubernetes_cluster_role_v1.pods.metadata[0].name == "teleport-forge-tenant-pods"
       && contains(kubernetes_cluster_role_v1.pods.rule[0].resources, "pods")
       && contains(kubernetes_cluster_role_v1.pods.rule[0].resources, "pods/log")
-      && contains(kubernetes_cluster_role_v1.pods.rule[0].resources, "pods/exec")
       && contains(kubernetes_cluster_role_v1.pods.rule[0].verbs, "get")
       && contains(kubernetes_cluster_role_v1.pods.rule[0].verbs, "watch")
       && contains(kubernetes_cluster_role_v1.pods.rule[0].verbs, "list")
+      && contains(kubernetes_cluster_role_v1.pods.rule[1].resources, "pods/exec")
+      && contains(kubernetes_cluster_role_v1.pods.rule[1].verbs, "get")
+      && contains(kubernetes_cluster_role_v1.pods.rule[1].verbs, "create")
     )
-    error_message = "Teleport tenant RBAC must preserve pod, log, and exec read access."
+    error_message = "Teleport tenant RBAC must preserve pod and log read access and allow pod exec."
   }
 
   assert {


### PR DESCRIPTION
## Description

Allow the tenant Teleport group to exec into Kubernetes pods by granting `create` and `get` on the `pods/exec` subresource. Keep `pods` and `pods/log` permissions read-only to preserve least privilege.

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `terraform fmt -check`
- `git diff --check`
- Pre-commit checks passed during commit.
- `terraform test -filter=tests/behavior.tftest.hcl` passed once after provider initialization; a subsequent run was blocked by a local Kubernetes provider plugin handshake failure.
- Full module test: interface-contract and source-inventory tests passed; the behavior test encountered the same provider handshake failure.
