### PR TITLE
fix(splunk): isolate dispatcher Lambda packages

### DIFF
--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/lambda.tf
@@ -21,6 +21,7 @@ module "dispatcher" {
   source_path = [{
     path = "${path.module}/lambda"
   }]
+  hash_extra = "dispatcher"
 
   logging_log_group                 = aws_cloudwatch_log_group.dispatcher.name
   use_existing_cloudwatch_log_group = true
@@ -87,6 +88,7 @@ module "worker" {
   source_path = [{
     path = "${path.module}/lambda"
   }]
+  hash_extra = "worker"
 
   layers = [
     "arn:aws:lambda:${data.aws_region.current.region}:770693421928:layer:Klayers-p312-cryptography:26",

--- a/modules/integrations/splunk_stuck_workflow_job_dispatcher/tests/source_inventory.tftest.hcl
+++ b/modules/integrations/splunk_stuck_workflow_job_dispatcher/tests/source_inventory.tftest.hcl
@@ -10,6 +10,8 @@ run "integrations_splunk_stuck_workflow_job_dispatcher_contract" {
     expected_literals = [
       "module \"dispatcher\"",
       "module \"worker\"",
+      "hash_extra = \"dispatcher\"",
+      "hash_extra = \"worker\"",
       "resource \"random_password\" \"webhook_token\"",
       "resource \"aws_apigatewayv2_api\" \"splunk\"",
       "resource \"aws_apigatewayv2_integration\" \"dispatcher\"",


### PR DESCRIPTION
## Description

Prevent concurrent Lambda packaging from racing on the same temporary ZIP in `splunk_stuck_workflow_job_dispatcher`.

The dispatcher and worker modules build the same source directory. `terraform-aws-lambda` derives the artifact filename from the source hash, so parallel builds used the same `.zip.tmp` path.

This change assigns a distinct `hash_extra` value to each Lambda module and adds source-contract assertions to prevent regression.

## Testing

- `tofu test`: 2 passed, 0 failed
- Focused pre-commit hooks passed
- `tofu fmt -check` passed
- `git diff --check` passed