### PR TITLE
fix(arc): suppress storage classes during migration

### DIFF
--- a/modules/platform/arc/storage_class.tf
+++ b/modules/platform/arc/storage_class.tf
@@ -1,5 +1,5 @@
 locals {
-  storage_classes = distinct([
+  storage_classes = var.migrate_arc_cluster ? [] : distinct([
     for runner in values(var.multi_runner_config) : {
       name = "${runner.runner_set_configs.namespace}-${runner.runner_config.volume_requests_storage_type}"
       type = runner.runner_config.volume_requests_storage_type

--- a/modules/platform/arc/tests/behavior.tftest.hcl
+++ b/modules/platform/arc/tests/behavior.tftest.hcl
@@ -194,9 +194,9 @@ run "arc_migration_contract" {
       output.runners_map.tenant_a.runner_role_arn == "arn:aws:iam::123456789012:role/tenant-a-arc-runner-role"
       && null_resource.apply_ec2_node_class.triggers.migrate_arc_cluster == "true"
       && null_resource.apply_node_pool.triggers.migrate_arc_cluster == "true"
-      && kubernetes_manifest.storage_class["tenant-a-gp3"].manifest.parameters.type == "gp3"
+      && length(kubernetes_manifest.storage_class) == 0
     )
-    error_message = "ARC migration mode must keep runner outputs and storage classes while flipping Karpenter migration triggers."
+    error_message = "ARC migration mode must keep runner outputs while suppressing storage classes and flipping Karpenter migration triggers."
   }
 }
 


### PR DESCRIPTION
## Summary

- Suppress tenant StorageClass resources while `migrate_arc_cluster` is enabled
- Align StorageClass lifecycle with the ARC controller, scale sets, and Karpenter resources
- Update the ARC migration behavior contract to require zero StorageClass instances

## Problem

During a blue/green tenant migration, ARC is disabled on the source cluster with `migrate_arc_cluster = true`. The StorageClass collection ignored that flag, allowing OpenTofu to attempt StorageClass creation while migration mode was active. If the cluster already contains that StorageClass, the apply fails because the resource already exists.

## Validation

- `tofu test` in `modules/platform/arc`: 5 passed, 0 failed
- full validation delegated to GitHub Actions