### PR TITLE
feat(ec2-deployment): use v2 runner state branch

### DIFF
--- a/modules/platform/ec2_deployment/main.tf
+++ b/modules/platform/ec2_deployment/main.tf
@@ -126,7 +126,7 @@ resource "aws_iam_policy" "runner_hooks_ssm_read" {
 
 module "runners" {
   #checkov:skip=CKV_TF_1:Module source uses Renovate-managed version tags; commit SHA pinning is an accepted policy tradeoff.
-  source = "git::https://github.com/github-aws-runners/terraform-aws-github-runner.git//modules/multi-runner?ref=v7.11.0"
+  source = "git::https://github.com/github-aws-runners/terraform-aws-github-runner.git//modules/multi-runner?ref=feat-move-v1-state-to-v2"
 
   aws_region = var.aws_region
 


### PR DESCRIPTION
## Description

Update the EC2 deployment runner module source to use the `feat-move-v1-state-to-v2` branch.

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other: __________

## Testing

- `tofu fmt -check modules/platform/ec2_deployment/main.tf`
- `git diff --check`
- `tofu validate` was attempted but is blocked by the existing invalid `terraform-aws-modules/lambda` ref `b842374...`; the requested runner module branch fetched successfully.
